### PR TITLE
fix: incorrect build with GCC

### DIFF
--- a/.das_module
+++ b/.das_module
@@ -4,8 +4,8 @@ require fio
 [export]
 def initialize(project_path : string) {
     if (das_is_dll_build()) {
-        register_dynamic_module("{project_path}/dasModuleImgui.mod", "Module_dasIMGUI")
-        register_dynamic_module("{project_path}/dasModuleImgui.mod", "Module_dasIMGUI_NODE_EDITOR")
-        register_dynamic_module("{project_path}/imguiApp.mod", "Module_imgui_app")
+        register_dynamic_module("{project_path}/dasModuleImgui.das_module", "Module_dasIMGUI")
+        register_dynamic_module("{project_path}/dasModuleImgui.das_module", "Module_dasIMGUI_NODE_EDITOR")
+        register_dynamic_module("{project_path}/imguiApp.das_module", "Module_imgui_app")
     }
 }


### PR DESCRIPTION
A few years back GCC introduced builtin support for Modula2, their files extension is .mod, same as our dynamic libraries. If compiled with gcc and linked against dynamic module compilation fails.

It affect only imgui_app, which was fixed here by linker flag.