### PR TITLE
ci: split docs build and deploy into separate jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,12 +34,16 @@ permissions:
 # `cmake --install` needed. Mirrors the supported end-user flow (daspkg install
 # dasImgui --global) without nesting the source under daslang/modules/ at
 # cmake-configure time (which would trip the root-cmake INCLUDE).
+#
+# Split into build + deploy jobs: attaching `environment: github-pages` to a
+# job triggers GitHub's deployment-branch protection check *before* any step
+# runs, which instant-fails non-master refs (PRs, workflow_dispatch from a
+# branch). build runs on every push/PR; deploy only runs on master and is the
+# only job with the environment attached, so the protection rule still gates
+# the actual publish while PRs get full CI signal on the rest of the pipeline.
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: "Checkout daslang"
         uses: actions/checkout@v4
@@ -115,8 +119,7 @@ jobs:
             -b html -d build/sphinx-cache \
             doc/source build/site
 
-      - name: "Stage site for deployment"
-        if: github.ref == 'refs/heads/master'
+      - name: "Stage site"
         working-directory: ${{ github.workspace }}/daslang-src/modules/dasImgui
         run: |
           set -eux
@@ -132,7 +135,14 @@ jobs:
         with:
           path: ${{ github.workspace }}/daslang-src/modules/dasImgui/_site
 
+  deploy:
+    if: github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: "Deploy to GitHub Pages"
-        if: github.ref == 'refs/heads/master'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

GitHub's deployment-branch protection on the `github-pages` environment is evaluated *before* any step in a job that declares `environment: github-pages`. The previous single-job workflow had that declaration at the job level, so every PR build (and `workflow_dispatch` from non-master refs) instant-failed — no runner ever assigned, no step ever ran, just `Branch "refs/pull/N/merge" is not allowed to deploy to github-pages due to environment protection rules.` Loosening the rule unblocked PR builds but traded away the actual gate that prevents non-master refs from publishing.

Split `build-and-deploy` into two jobs:

- **`build`** runs on every push / PR / dispatch. Does the daslang + dasImgui build, runs `imgui2rst`, runs the stub-gate, builds Sphinx HTML, stages `_site/`, and (only on master) uploads the github-pages artifact via `actions/upload-pages-artifact@v3`. PR runs exercise every step except the upload — real CI signal lands on PRs again.
- **`deploy`** runs only on master, with `environment: github-pages` attached. Its only step is `actions/deploy-pages@v4`, which picks up the artifact uploaded by `build` in the same workflow run.

Separating the environment attachment from the build steps is what keeps the env protection rule meaningful (it now only gates the actual publish, not the build) while letting PRs complete.

After this lands, the temporary "Deployment branches and tags = no rules" relaxation I made on the `github-pages` environment can be reverted to "Default branch only" — the workflow itself enforces master-only deploy via the `if:` on the deploy job.

## Test plan

- [ ] This PR's CI run completes successfully (build job runs to green, deploy job skipped)
- [ ] After merge, the master CI run executes both jobs: build green, deploy green, daslang.io's sibling site at `borisbat.github.io/dasImgui/` updates
- [ ] Restore the `github-pages` environment "default branch only" protection rule after this lands — workflow gating is now the load-bearing barrier

🤖 Generated with [Claude Code](https://claude.com/claude-code)