### PR TITLE
doc/css: cover das domain in dark theme, dim return type & field labels

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -15,6 +15,7 @@
     --bg-2:      #15130f;
     --bg-3:      #1c1a14;
     --fg:        #e8e2d2;
+    --fg-soft:   #c1baa9;
     --fg-dim:    #9b9281;
     --fg-faint:  #5b5547;
     --rule:      #2a2620;
@@ -264,17 +265,37 @@ a:hover { color: var(--fg) !important; border-bottom-color: var(--fg) !important
     text-transform: uppercase;
 }
 
-/* Domain signatures (function/class/etc. directives) */
-.rst-content dl.py dt,
-.rst-content dl.c dt,
-.rst-content dl.cpp dt,
-.rst-content dl.rst dt {
+/* Domain signatures (function/class/etc. directives).
+ * Sphinx 4+ tags every directive signature dt with `sig sig-object DOMAIN`,
+ * so one selector covers py/c/cpp/rst plus the custom `das` domain. */
+.rst-content dt.sig-object {
     background: var(--bg-2) !important;
     border: 1px solid var(--rule) !important;
     border-radius: 4px;
-    color: var(--fg);
+    color: var(--fg) !important;
     font-family: var(--font-mono);
 }
+/* Signature inner spans — sphinx_rtd_theme paints them dark-blue/black on
+ * white by default, which is unreadable on the dark background. Map them
+ * onto the same palette the code-block highlighter uses. */
+.rst-content dt.sig-object .sig-name,
+.rst-content dt.sig-object .sig-name.descname           { color: var(--amber) !important; }
+.rst-content dt.sig-object .sig-prename,
+.rst-content dt.sig-object .sig-prename.descclassname   { color: var(--fg-dim) !important; }
+.rst-content dt.sig-object .sig-paren,
+.rst-content dt.sig-object .sig-param,
+.rst-content dt.sig-object .sig-param .n,
+.rst-content dt.sig-object .sig-param .pre,
+.rst-content dt.sig-object .sig-return,
+/* daslang return type renders as bare .pre direct-children of dt, outside
+ * any sig-return wrapper — dim those too. */
+.rst-content dt.sig-object > .pre                       { color: var(--fg-dim) !important; }
+
+/* Field lists (Arguments:, Returns:, etc.). The "Arguments:" label and the
+ * bold parameter names sit at full --fg by default, which reads as a wall
+ * of white in long type signatures — recess them one notch toward grey. */
+.rst-content dl.field-list > dt,
+.rst-content dl.field-list strong                        { color: var(--fg-soft) !important; }
 
 /* Footer */
 .rst-footer-buttons .btn {


### PR DESCRIPTION
## Summary

Mirror of daslang PR https://github.com/GaijinEntertainment/daScript/pull/2652. `doc/source/_static/custom.css` is byte-identical between the two repos; both shipped the same gap.

The Forge-redesign custom.css covered Sphinx domain signatures for `dl.py` / `dl.c` / `dl.cpp` / `dl.rst` only, so the custom `das` Sphinx domain fell through to sphinx_rtd_theme's white-on-white default — signature boxes on stdlib pages rendered as light-cyan blocks with dark-blue function names that were unreadable on the dark background.

Three changes in `custom.css`:

1. Replace the per-domain selector list with `dt.sig-object`. Every Sphinx 4+ directive signature carries `class="sig sig-object DOMAIN"`, so one selector covers py/c/cpp/rst plus the custom das domain — and any future domain we add.
2. Add inner-span rules so the function name picks up `--amber`, params + return type sit at `--fg-dim` instead of inheriting sphinx_rtd_theme's defaults. The daslang domain emits the return type as bare `<span class="pre">` direct-children of the `dt`, outside any `.sig-return` wrapper, so a `dt.sig-object > .pre` selector catches those specifically.
3. Add `--fg-soft: #c1baa9` token (halfway between `--fg` and `--fg-dim`) and apply it to `dl.field-list > dt` and `dl.field-list strong` so "Arguments:" / bold param names don't read as a wall of white in long type signatures.

## Test plan
- [x] Verified locally against daslang's docs build (file is byte-identical pre-fix; same rendering issue)
- [ ] CI Sphinx build clean
