### PR TITLE
boost: scope wrappers + drag-drop containers + unified list_box

### DIFF
--- a/.das_module
+++ b/.das_module
@@ -27,6 +27,8 @@ def initialize(project_path : string) {
     register_native_path("imgui", "imgui_id_builtin", "{project_path}/widgets/imgui_id_builtin.das")
     // §4.7 — style stack helpers (with_style call_macro + push_style_one overloads).
     register_native_path("imgui", "imgui_style_builtin", "{project_path}/widgets/imgui_style_builtin.das")
+    // §4.9 — stateless scope wrappers (with_indent, with_item_width, with_text_wrap_pos).
+    register_native_path("imgui", "imgui_scope_builtin", "{project_path}/widgets/imgui_scope_builtin.das")
     // §4.6 — layout helpers (split_h, split_v, dock_left).
     register_native_path("imgui", "imgui_layout_builtin", "{project_path}/widgets/imgui_layout_builtin.das")
     // Phase 7 — docking (dockspace, dock_window) + DockBuilder bindings cherry-picked from imgui_internal.h.

--- a/doc/source/tutorials/containers.rst
+++ b/doc/source/tutorials/containers.rst
@@ -24,7 +24,7 @@ This tutorial covers four representative containers: ``menu_bar`` +
 (``examples/features/containers_*.das``) cover the rest:
 ``child`` / ``group`` (window family), ``tree_node`` /
 ``collapsing_header`` (layout family), ``popup_modal`` /
-``tooltip`` / ``combo_select`` / ``list_box_select`` (overlay family).
+``tooltip`` / ``combo_select`` / ``list_box`` (overlay family).
 
 Source: ``examples/tutorial/containers.das``.
 
@@ -176,6 +176,34 @@ Path-qualified targets for every container leaf:
 Note that menu items receive ``imgui_click`` directly — they're click
 targets, not open/close targets.
 
+Context popups
+==============
+
+``popup_context_item`` is the right-click-context sibling of ``popup`` —
+ImGui drives open/close internally based on the previous item receiving
+a right-click; the wrapper just gates the body on Begin returning true:
+
+.. code-block:: das
+
+   require imgui/imgui_containers_builtin
+
+   button(TARGET_BTN, (text = "Right-click me"))
+   popup_context_item(TARGET_CTX, (str_id = "target_ctx",
+                                   flags = ImGuiPopupFlags.MouseButtonRight)) {
+       if (menu_item(ACTION_RENAME, (text = "Rename", shortcut = "F2"))) {
+           // ...
+       }
+       if (menu_item(ACTION_DELETE, (text = "Delete", shortcut = "Del"))) {
+           // ...
+       }
+   }
+
+The popup is keyed off the **previously submitted item** — submission
+order matters, and ``popup_context_item`` registers under its own path
+in the snapshot. Use ``imgui_click`` to drive menu items from outside.
+
+Feature demo: ``examples/features/popup_context_item.das``.
+
 Next steps
 ==========
 
@@ -196,7 +224,7 @@ HTTP server) versus what gets rebuilt.
    * ``examples/features/containers_layout.das`` — tab_bar plus
      tree_node, collapsing_header
    * ``examples/features/containers_overlay.das`` — popup_modal,
-     tooltip, combo_select, list_box_select
+     tooltip, combo_select, list_box
 
    Previous tutorial: :ref:`tutorial_state_telemetry`
 

--- a/doc/source/tutorials/drag_drop.rst
+++ b/doc/source/tutorials/drag_drop.rst
@@ -1,0 +1,132 @@
+.. _tutorial_drag_drop:
+
+#######################
+Drag and drop
+#######################
+
+ImGui's drag-drop API is two paired ``Begin*``/``End*`` calls: one
+attached to the previously submitted item that's being dragged, one
+attached to the previously submitted item that's receiving. Both
+``Begin*`` calls return ``false`` unless ImGui's internal drag state
+machine says "drag-active" or "hover-over-target with payload"; calling
+``End*`` when ``Begin*`` returned false is undefined behavior.
+
+The boost layer ships two ``[container]``s — ``drag_drop_source`` and
+``drag_drop_target`` — that gate their bodies on the corresponding
+``Begin*`` return. Payload set/accept stay raw calls inside the body
+because the data is caller-owned and crosses widget boundaries.
+
+Source: ``examples/features/drag_drop.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/drag_drop.apng
+   :alt: drag_drop recording
+
+.. literalinclude:: ../../../examples/features/drag_drop.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Same backend + boost layer as the other container tutorials, plus the
+``drag_drop_source`` / ``drag_drop_target`` macros from
+``imgui/imgui_containers_builtin`` (which is already required by the
+container family).
+
+Source side
+===========
+
+Attach a ``drag_drop_source`` immediately after the source widget. ImGui
+implicitly binds it to the previously submitted item:
+
+.. code-block:: das
+
+   button(SOURCE_BTN, (text = "SOURCE"))
+   drag_drop_source(SOURCE_DD, (flags = ImGuiDragDropFlags.None)) {
+       unsafe {
+           SetDragDropPayload("MY_INT", addr(PAYLOAD_VALUE),
+                              uint64(typeinfo sizeof(PAYLOAD_VALUE)),
+                              ImGuiCond.Once)
+       }
+       Text("Dragging: {PAYLOAD_VALUE}")
+   }
+
+The body runs **only while the drag is active** — after the user has
+pressed the mouse on ``SOURCE_BTN`` and dragged past ImGui's
+``io.MouseDragThreshold``. Inside the body:
+
+* ``SetDragDropPayload(type, data, size, cond)`` publishes the payload.
+  ``type`` is a short string (max 32 chars) that the target compares
+  against; ``data`` is a raw pointer with caller-controlled lifetime
+  (ImGui copies it into its internal buffer on each call, so a stack
+  pointer is fine inside the body).
+* Any rendering call (``Text``, ``Image``, etc.) draws the drag preview
+  tooltip that follows the cursor.
+
+Target side
+===========
+
+Attach a ``drag_drop_target`` immediately after the target widget:
+
+.. code-block:: das
+
+   button(TARGET_BTN, (text = "TARGET"))
+   drag_drop_target(TARGET_DD) {
+       let payload = AcceptDragDropPayload("MY_INT", ImGuiDragDropFlags.None)
+       if (payload != null) {
+           unsafe {
+               RECEIVED = (reinterpret<int? const>(payload.Data))[0]
+           }
+       }
+   }
+
+The body runs **only while a drag is hovering this widget**. Inside:
+
+* ``AcceptDragDropPayload(type, flags)`` returns a non-null
+  ``ImGuiPayload?`` on the frame the user releases over the target with
+  a payload whose type matches ``type``; otherwise it returns null
+  (including on every frame the drag is hovering but not yet dropped).
+* The returned payload's ``Data`` field is a ``void? const`` —
+  ``reinterpret<T? const>(payload.Data)[0]`` reads the typed value back.
+
+Driving from outside
+====================
+
+Playwright exposes a high-level ``drag_to`` that bridges source-bbox →
+target-bbox automatically:
+
+.. code-block:: das
+
+   require imgui/imgui_playwright
+   drag_to(app, "MAIN_WIN/SOURCE_BTN", "MAIN_WIN/TARGET_BTN", steps = 8)
+
+It reads both bboxes from a fresh snapshot, computes ``(dx, dy) =
+target_center - source_center``, and dispatches the L1 ``imgui_drag``
+coroutine — press at the source, ``steps`` interpolated moves, release
+at the target. ImGui's drag state machine activates around the second
+or third move (depending on ``io.MouseDragThreshold``) and resolves on
+release.
+
+The lower-level ``drag(app, target, dx, dy, steps)`` is available when
+you want absolute offsets — useful for testing drag-without-drop or
+drag-cancel paths.
+
+Next steps
+==========
+
+That's the last container tutorial. The next walkthrough switches
+focus to live-reload internals.
+
+.. seealso::
+
+   Full source: :download:`examples/features/drag_drop.das <../../../examples/features/drag_drop.das>`
+
+   Integration test: ``tests/integration/test_drag_drop.das``.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.
+
+   :ref:`Containers <tutorial_containers>` — the container family in general.

--- a/doc/source/tutorials/drag_drop.rst
+++ b/doc/source/tutorials/drag_drop.rst
@@ -22,8 +22,11 @@ Source: ``examples/features/drag_drop.das``.
 Walkthrough
 ************
 
-.. image:: ../_static/tutorials/drag_drop.apng
-   :alt: drag_drop recording
+.. note::
+
+   APNG recording forthcoming — run
+   ``tests/integration/record_drag_drop.das`` against a live
+   ``daslang-live`` instance to regenerate it.
 
 .. literalinclude:: ../../../examples/features/drag_drop.das
    :language: das

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -19,6 +19,7 @@ construction.
    with_id.rst
    state_telemetry.rst
    containers.rst
+   drag_drop.rst
    live_reload.rst
    driving_outside.rst
    visual_aids_tour.rst

--- a/doc/source/tutorials/layout.rst
+++ b/doc/source/tutorials/layout.rst
@@ -98,8 +98,44 @@ Every helper's state struct is targetable by name. Drag without a mouse:
 ``value`` is the same type the user would set by dragging — pixels for
 ``dock_*``, fraction for ``split_*``.
 
-Next steps
-==========
+Scope wrappers
+==============
+
+Three stateless block-arg wrappers in ``imgui/imgui_scope_builtin`` cover
+the leftover Push/Pop idioms ImGui uses for ad-hoc layout overrides. Each
+brackets the block with the corresponding ImGui Push/Pop pair and takes
+no state — they read like inline scopes:
+
+.. code-block:: das
+
+   require imgui/imgui_scope_builtin
+
+   // Indent / Unindent — nest content under a heading.
+   with_indent(0.0f) {       // 0.0f defers to style IndentSpacing
+       Text("Bullet child")
+   }
+   with_indent(40.0f) {      // explicit pixel offset
+       Text("Hard-indented")
+   }
+
+   // PushItemWidth / PopItemWidth — scope a widget-width override.
+   with_item_width(120.0f) {
+       slider_float(NARROW, (text = "narrow", bounds = (0.0f, 1.0f)))
+   }
+   with_item_width(-60.0f) { // negative = right-edge minus N
+       slider_float(STRETCH, (text = "stretch", bounds = (0.0f, 1.0f)))
+   }
+
+   // PushTextWrapPos / PopTextWrapPos — scope where long text wraps.
+   with_text_wrap_pos(0.0f) { TextUnformatted(LIPSUM) }   // window right edge
+   with_text_wrap_pos(200.0f) { TextUnformatted(LIPSUM) } // wrap at 200 px
+
+Feature demos: ``examples/features/with_indent.das``,
+``examples/features/with_item_width.das``,
+``examples/features/with_text_wrap_pos.das``.
+
+Standalone vs live
+==================
 
 Docking is next — full ImGui dockspaces and the dock helpers that ride on
 top of them.

--- a/examples/features/containers_overlay.das
+++ b/examples/features/containers_overlay.das
@@ -18,7 +18,7 @@ require imgui/imgui_containers_builtin
 
 // =============================================================================
 // FEATURE: containers_overlay — Phase 0b.3 popup / popup_modal / tooltip /
-//          item_tooltip / combo_select / list_box_select containers.
+//          item_tooltip / combo_select / list_box containers.
 // SHOWS:   imgui_open / imgui_close on popups, hover-driven tooltips, block-
 //          arg combo + list_box variants for procedural-item lists.
 // DRIVE:   curl -X POST -d '{"name":"imgui_open","args":{"target":"OVERLAY_WIN/OPTIONS_POPUP"}}' \
@@ -114,7 +114,7 @@ def update() {
         Spacing()
 
         // ----- Block-arg combo + list_box -----
-        Text("combo_select / list_box_select — body emits Selectables")
+        Text("combo_select / list_box — body emits Selectables")
         Separator()
         var palette_label = "(none)"
         if (PALETTE_COMBO.value >= 0 && PALETTE_COMBO.value < length(PALETTE_NAMES)) {
@@ -134,8 +134,8 @@ def update() {
         }
         Text("palette = {palette_label} (idx {PALETTE_COMBO.value})")
 
-        list_box_select(TASK_LIST, (text = "tasks",
-                                    size = float2(220.0f, 110.0f))) {
+        list_box(TASK_LIST, (text = "tasks",
+                             size = float2(220.0f, 110.0f))) {
             for (i in range(length(TASK_NAMES))) {
                 let is_sel = (i == TASK_LIST.value)
                 if (Selectable(TASK_NAMES[i], is_sel,

--- a/examples/features/drag_drop.das
+++ b/examples/features/drag_drop.das
@@ -1,0 +1,115 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+
+// =============================================================================
+// FEATURE: drag_drop — [container]s drag_drop_source + drag_drop_target.
+//          Both gate their body on ImGui's internal drag-drop state machine.
+//          Bodies call raw SetDragDropPayload / AcceptDragDropPayload —
+//          payload data is caller-owned and crosses widget boundaries.
+// SHOWS:   drag SOURCE_BTN onto TARGET_BTN; TARGET_BTN's body accepts the
+//          "MY_INT" payload and writes it into RECEIVED. DROP_COUNT
+//          increments on each successful release-over-target.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/drag_drop.das
+// LIVE:       daslang-live modules/dasImgui/examples/features/drag_drop.das
+// =============================================================================
+
+var PAYLOAD_VALUE : int = 42
+var RECEIVED : int = 0
+var DROP_COUNT : int = 0
+
+[export]
+def init() {
+    live_create_window("drag_drop — source + target", 720, 480)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    NewFrame()
+
+    SetNextWindowSize(ImVec2(660.0, 420.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "drag_drop", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        Text("Drag the SOURCE button onto the TARGET button.")
+        Separator()
+
+        // Source: a normal button. Body runs only on active drag.
+        button(SOURCE_BTN, (text = "SOURCE"))
+        drag_drop_source(SOURCE_DD, (flags = ImGuiDragDropFlags.None)) {
+            unsafe {
+                SetDragDropPayload("MY_INT", addr(PAYLOAD_VALUE),
+                                   uint64(typeinfo sizeof(PAYLOAD_VALUE)),
+                                   ImGuiCond.Once)
+            }
+            Text("Dragging int: {PAYLOAD_VALUE}")
+        }
+
+        // SameLine(offset_from_start_x = 0 → "next to previous", spacing = 40 px gap).
+        SameLine(0.0f, 40.0f)
+
+        // Target: a normal button. Body runs only when payload-bearing drag hovers.
+        button(TARGET_BTN, (text = "TARGET"))
+        drag_drop_target(TARGET_DD) {
+            let payload = AcceptDragDropPayload("MY_INT", ImGuiDragDropFlags.None)
+            if (payload != null) {
+                unsafe {
+                    RECEIVED = (reinterpret<int? const>(payload.Data))[0]
+                }
+                DROP_COUNT++
+            }
+        }
+
+        Separator()
+        Text("Source payload value: {PAYLOAD_VALUE}")
+        Text("Target received value: {RECEIVED}")
+        Text("Drops accepted: {DROP_COUNT}")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/inputs_choice.das
+++ b/examples/features/inputs_choice.das
@@ -17,10 +17,11 @@ require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 
 // =============================================================================
-// FEATURE: inputs_choice — Phase 0b.2 Combo + ListBox (deprecated single-call
-//          forms). Both widgets take `items : array<string>` directly — daslang
-//          marshals it C-side without a shim.
-// SHOWS:   combo / list_box
+// FEATURE: inputs_choice — combo (items-array, single-call) + list_box
+//          (Begin/End + Selectable, unified block-arg form). list_box was
+//          unified onto BeginListBox/EndListBox in the boost scope-wrappers
+//          pass; body emits per-item Selectables, click writes state.value.
+// SHOWS:   combo (items-array sugar) / list_box (block-arg + Selectable)
 // DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/FRUIT","value":2}}' \
 //               localhost:9090/command
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/SHIRT_SIZE","value":1}}' \
@@ -29,10 +30,11 @@ require imgui/imgui_containers_builtin
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_choice.das
 //
 // NOT YET COVERED HERE:
-//   - BeginCombo/EndCombo (block-arg manual loop) → 0b.3 containers
-//   - BeginListBox/EndListBox (block-arg)         → 0b.3 containers
+//   - BeginCombo/EndCombo (block-arg manual loop) → combo_select container
 //   - _builtin_Combo (callback-getter)            → 0b.4 ABI shim
 // =============================================================================
+
+let SHIRT_NAMES : array<string> <- ["XS", "S", "M", "L", "XL", "XXL"]
 
 [export]
 def init() {
@@ -72,8 +74,16 @@ def update() {
         Separator()
 
         list_box(SHIRT_SIZE, (text = "Shirt size",
-                              items <- ["XS", "S", "M", "L", "XL", "XXL"],
-                              height_in_items = 4))
+                              size = float2(0.0f, 0.0f))) {
+            for (i in range(length(SHIRT_NAMES))) {
+                let is_sel = (i == SHIRT_SIZE.value)
+                if (Selectable(SHIRT_NAMES[i], is_sel,
+                               ImGuiSelectableFlags.None,
+                               float2(0.0f, 0.0f))) {
+                    SHIRT_SIZE.value = i
+                }
+            }
+        }
         Text("shirt size index = {SHIRT_SIZE.value}")
 
         Spacing()

--- a/examples/features/list_box.das
+++ b/examples/features/list_box.das
@@ -1,0 +1,105 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+
+// =============================================================================
+// FEATURE: list_box — unified [container] for BeginListBox/EndListBox. The
+//          legacy items-array `[widget] def list_box` was dropped; the modern
+//          form is block-arg + user-emitted Selectable rows. Click writes
+//          state.value; imgui_set steers it from the test harness.
+// SHOWS:   list_box scope with Selectable-driven selection state, custom
+//          row rendering (icons in front of names), and dynamic content
+//          (filterable item list).
+// DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/LANG","value":3}}' \
+//               localhost:9090/command
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/list_box.das
+// LIVE:       daslang-live modules/dasImgui/examples/features/list_box.das
+// =============================================================================
+
+let LANG_NAMES : array<string> <- ["daslang", "C++", "Rust", "Go", "Python", "Lua"]
+let LANG_ICONS : array<string> <- ["[D]", "[C]", "[R]", "[G]", "[P]", "[L]"]
+
+[export]
+def init() {
+    live_create_window("list_box — unified scope form", 720, 540)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    NewFrame()
+
+    SetNextWindowSize(ImVec2(660.0, 480.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "list_box", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        Text("Body emits Selectable rows; click writes LANG.value.")
+        Separator()
+
+        list_box(LANG, (text = "Language", size = float2(-1.0f, 180.0f))) {
+            for (i in range(length(LANG_NAMES))) {
+                let is_sel = (i == LANG.value)
+                let row_text = "{LANG_ICONS[i]} {LANG_NAMES[i]}"
+                if (Selectable(row_text, is_sel,
+                               ImGuiSelectableFlags.None,
+                               float2(0.0f, 0.0f))) {
+                    LANG.value = i
+                }
+            }
+        }
+
+        Separator()
+        var picked = "(none)"
+        if (LANG.value >= 0 && LANG.value < length(LANG_NAMES)) {
+            picked = LANG_NAMES[LANG.value]
+        }
+        Text("Picked: {picked} (idx {LANG.value})")
+        Text("imgui_set value=N steers next-frame selection.")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/popup_context_item.das
+++ b/examples/features/popup_context_item.das
@@ -1,0 +1,99 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+
+// =============================================================================
+// FEATURE: popup_context_item — [container] for BeginPopupContextItem/EndPopup.
+//          Right-click context menu attached to the previously submitted item.
+//          ImGui drives open/close internally — no pending_open/close.
+// SHOWS:   right-click any TARGET_BTN row to open its action menu; selected
+//          action increments PICKED counter and updates LAST_ACTION text.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/popup_context_item.das
+// LIVE:       daslang-live modules/dasImgui/examples/features/popup_context_item.das
+// =============================================================================
+
+var LAST_ACTION : string = "(none yet)"
+
+[export]
+def init() {
+    live_create_window("popup_context_item — container", 640, 480)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    NewFrame()
+
+    SetNextWindowSize(ImVec2(580.0, 420.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "popup_context_item", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        Text("Right-click the button below to open its context menu.")
+
+        if (button(TARGET_BTN, (text = "Right-click me"))) {
+            LAST_ACTION = "(left-click ignored)"
+        }
+        popup_context_item(TARGET_CTX, (str_id = "target_ctx",
+                                        flags = ImGuiPopupFlags.MouseButtonRight)) {
+            if (menu_item(ACTION_RENAME, (text = "Rename", shortcut = "F2"))) {
+                LAST_ACTION = "Rename"
+            }
+            if (menu_item(ACTION_DELETE, (text = "Delete", shortcut = "Del"))) {
+                LAST_ACTION = "Delete"
+            }
+            Separator()
+            if (menu_item(ACTION_INFO, (text = "Info", shortcut = ""))) {
+                LAST_ACTION = "Info"
+            }
+        }
+
+        Separator()
+        Text("Last action: {LAST_ACTION}")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/with_indent.das
+++ b/examples/features/with_indent.das
@@ -1,0 +1,94 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_scope_builtin
+
+// =============================================================================
+// FEATURE: with_indent — stateless block-arg wrapper around Indent/Unindent.
+// SHOWS:   nested with_indent blocks; default amount (0.0f) defers to ImGui's
+//          style IndentSpacing, explicit amounts produce custom indents.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/with_indent.das
+// LIVE:       daslang-live modules/dasImgui/examples/features/with_indent.das
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("with_indent — scope wrapper", 640, 480)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    NewFrame()
+
+    SetNextWindowSize(ImVec2(580.0, 420.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "with_indent", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        Text("Default indent (0.0f uses style IndentSpacing):")
+        with_indent(0.0f) {
+            Text("Level 1")
+            with_indent(0.0f) {
+                Text("Level 2")
+                with_indent(0.0f) {
+                    Text("Level 3")
+                }
+            }
+        }
+
+        Separator()
+        Text("Custom amounts:")
+        with_indent(40.0f) {
+            Text("indent 40px")
+        }
+        with_indent(80.0f) {
+            Text("indent 80px")
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/with_item_width.das
+++ b/examples/features/with_item_width.das
@@ -1,0 +1,96 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_scope_builtin
+
+// =============================================================================
+// FEATURE: with_item_width — stateless block-arg wrapper around
+//          PushItemWidth/PopItemWidth. Scoped widget-width override that
+//          auto-restores on block exit.
+// SHOWS:   nested scopes; positive (absolute), negative (right-edge minus N),
+//          and default style width contrasted side-by-side.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/with_item_width.das
+// LIVE:       daslang-live modules/dasImgui/examples/features/with_item_width.das
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("with_item_width — scope wrapper", 720, 480)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    NewFrame()
+
+    SetNextWindowSize(ImVec2(660.0, 420.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "with_item_width", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        Text("Default width (ImGui style):")
+        slider_float(DEFAULT_W, (text = "default", bounds = (0.0f, 1.0f)))
+
+        Separator()
+        Text("Absolute 120 px:")
+        with_item_width(120.0f) {
+            slider_float(NARROW_W, (text = "120px", bounds = (0.0f, 1.0f)))
+        }
+
+        Text("Absolute 320 px:")
+        with_item_width(320.0f) {
+            slider_float(WIDE_W, (text = "320px", bounds = (0.0f, 1.0f)))
+        }
+
+        Separator()
+        Text("Right-edge minus 60 px (negative):")
+        with_item_width(-60.0f) {
+            slider_float(STRETCH_W, (text = "stretch", bounds = (0.0f, 1.0f)))
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/with_text_wrap_pos.das
+++ b/examples/features/with_text_wrap_pos.das
@@ -1,0 +1,96 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_scope_builtin
+
+// =============================================================================
+// FEATURE: with_text_wrap_pos — stateless block-arg wrapper around
+//          PushTextWrapPos/PopTextWrapPos. Scoped wrap-x override for long
+//          text passed to TextWrapped or TextUnformatted.
+// SHOWS:   default wrap (window right edge), narrow wrap (200 px), wider
+//          wrap (400 px).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/with_text_wrap_pos.das
+// LIVE:       daslang-live modules/dasImgui/examples/features/with_text_wrap_pos.das
+// =============================================================================
+
+let LIPSUM = ("Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+              + "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+
+[export]
+def init() {
+    live_create_window("with_text_wrap_pos — scope wrapper", 720, 540)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    NewFrame()
+
+    SetNextWindowSize(ImVec2(660.0, 480.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "with_text_wrap_pos", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        Text("Default wrap (0.0f → window right edge):")
+        with_text_wrap_pos(0.0f) {
+            TextUnformatted(LIPSUM)
+        }
+
+        Separator()
+        Text("Wrap at 200 px:")
+        with_text_wrap_pos(200.0f) {
+            TextUnformatted(LIPSUM)
+        }
+
+        Separator()
+        Text("Wrap at 400 px:")
+        with_text_wrap_pos(400.0f) {
+            TextUnformatted(LIPSUM)
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/tests/integration/record_drag_drop.das
+++ b/tests/integration/record_drag_drop.das
@@ -1,0 +1,103 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``drag_drop.apng`` against an **already-running**
+//! daslang-live. Mirrors record_widgets_tour.das / record_layout.das.
+//!
+//! Workflow (two shells):
+//!
+//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
+//!     cd modules/dasImgui/doc/source/_static/tutorials
+//!     ../../../../../../bin/Release/daslang-live.exe \
+//!         ../../../../examples/features/drag_drop.das
+//!
+//!     # window 2 — fire the driver, exits when done:
+//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_drag_drop.das
+
+let BASE_URL = "http://127.0.0.1:9090"
+let OUTPUT   = "drag_drop.apng"
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    let app = ImguiApp(
+        base_url = BASE_URL,
+        feature_path = "",
+        transport <- live_api_transport(BASE_URL)
+    )
+    print("[record] connecting to {BASE_URL}\n")
+    if (!wait_until_ready(app, 5.0f)) {
+        panic("daslang-live not responding on {BASE_URL} — is it running with drag_drop.das?")
+    }
+
+    let T_SOURCE = "MAIN_WIN/SOURCE_BTN"
+    let T_TARGET = "MAIN_WIN/TARGET_BTN"
+
+    var snap = wait_for_render(app, T_SOURCE, 10.0f)
+    if (snap == null) {
+        panic("{T_SOURCE} never rendered — wrong app running on {BASE_URL}?")
+    }
+    let p_source = widget_center(snap, T_SOURCE)
+    let p_target = widget_center(snap, T_TARGET)
+
+    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
+    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
+    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 30)))
+
+    // Stage 1 — intro narration on the SOURCE button.
+    post_command(app, "imgui_narrate", JV((
+        text = "drag_drop_source attaches to the previous item.",
+        target = T_SOURCE,
+        frames = 200
+    )))
+    move_to(app, p_source)
+    sleep(3500u)
+
+    // Stage 2 — narration on the TARGET button.
+    post_command(app, "imgui_narrate", JV((
+        text = "drag_drop_target accepts a typed payload.",
+        target = T_TARGET,
+        frames = 200
+    )))
+    move_to(app, p_target)
+    sleep(3500u)
+
+    // Stage 3 — perform the drag. drag_to handles the synth press → moves → release.
+    post_command(app, "imgui_narrate", JV((
+        text = "drag_to(source, target) bridges bboxes automatically.",
+        target = T_SOURCE,
+        frames = 200
+    )))
+    sleep(2500u)
+    drag_to(app, T_SOURCE, T_TARGET, 10, 0)
+    sleep(2500u)
+
+    let stopped = post_command(app, "record_stop", null)
+    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
+    print("[record] record_stop -> {stop_dump}\n")
+    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
+
+    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
+    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
+}

--- a/tests/integration/test_containers_overlay.das
+++ b/tests/integration/test_containers_overlay.das
@@ -9,7 +9,7 @@ require daslib/json public
 require daslib/json_boost public
 
 //! Integration smoke for Phase 0b.3 overlay containers — popup, popup_modal,
-//! tooltip, item_tooltip, combo_select, list_box_select. Verifies the
+//! tooltip, item_tooltip, combo_select, list_box. Verifies the
 //! pending-open / pending-close flow on popups and the block-arg combo /
 //! list_box paths.
 
@@ -27,15 +27,15 @@ def test_containers_overlay_smoke(t : T?) {
         t |> equal(combo_entry?["kind"] ?? "", "combo_select",
                    "combo_select registers under nested path")
         var listbox_entry = find_widget(snap0, "OVERLAY_WIN/TASK_LIST")
-        t |> equal(listbox_entry?["kind"] ?? "", "list_box_select",
-                   "list_box_select registers under nested path")
+        t |> equal(listbox_entry?["kind"] ?? "", "list_box",
+                   "list_box registers under nested path")
 
         // ----- imgui_set on combo_select index -----
         set_value(d, "OVERLAY_WIN/PALETTE_COMBO", JV(2))
         t |> success(wait_for_int_value(d, "OVERLAY_WIN/PALETTE_COMBO", "value", 2, 300),
                      "imgui_set steers PALETTE_COMBO to 2 (Forest)")
 
-        // ----- imgui_set on list_box_select index -----
+        // ----- imgui_set on list_box index -----
         set_value(d, "OVERLAY_WIN/TASK_LIST", JV(3))
         t |> success(wait_for_int_value(d, "OVERLAY_WIN/TASK_LIST", "value", 3, 300),
                      "imgui_set steers TASK_LIST to 3 (Package)")

--- a/tests/integration/test_drag_drop.das
+++ b/tests/integration/test_drag_drop.das
@@ -1,0 +1,43 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `drag_drop_source` + `drag_drop_target` containers.
+//! Both register in the snapshot (stateless_finalize runs every frame).
+//! Driving an actual drop is L1-fragile (depends on ImGui's drag threshold,
+//! synth-mouse timing, and frame interleaving), so the L1 gate here just
+//! checks `drag_to` returns ok — the visual demo proves the drop semantics.
+
+let DRAG_DROP_FEATURE = "modules/dasImgui/examples/features/drag_drop.das"
+
+[test]
+def test_drag_drop_smoke(t : T?) {
+    with_imgui_app(DRAG_DROP_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN/SOURCE_BTN", 15.0f)
+        t |> success(snap0 != null, "SOURCE_BTN registers")
+        if (snap0 == null) return
+
+        let target_entry = find_widget(snap0, "MAIN_WIN/TARGET_BTN")
+        t |> equal(target_entry?["kind"] ?? "", "button",
+                   "TARGET_BTN.kind == 'button'")
+        let src_dd = find_widget(snap0, "MAIN_WIN/SOURCE_DD")
+        t |> equal(src_dd?["kind"] ?? "", "drag_drop_source",
+                   "SOURCE_DD.kind == 'drag_drop_source'")
+        let tgt_dd = find_widget(snap0, "MAIN_WIN/TARGET_DD")
+        t |> equal(tgt_dd?["kind"] ?? "", "drag_drop_target",
+                   "TARGET_DD.kind == 'drag_drop_target'")
+
+        // Drive an L1 drag from SOURCE_BTN's bbox center to TARGET_BTN's
+        // bbox center. Server replies ok with the source target name.
+        let resp = drag_to(d, "MAIN_WIN/SOURCE_BTN", "MAIN_WIN/TARGET_BTN", 8, 0)
+        t |> success(resp != null, "drag_to returned a response")
+        t |> equal(resp?["ok"] ?? false, true,
+                   "drag_to response.ok == true")
+    }
+}

--- a/tests/integration/test_list_box.das
+++ b/tests/integration/test_list_box.das
@@ -1,0 +1,44 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration test for unified `list_box` [container] — BeginListBox/EndListBox
+//! with Selectable rows in the body. `imgui_set {"value": N}` steers next-frame
+//! selection via the dispatcher; user-side Selectable click writes state.value.
+
+let LIST_BOX_FEATURE = "modules/dasImgui/examples/features/list_box.das"
+
+[test]
+def test_list_box_set_steers_selection(t : T?) {
+    with_imgui_app(LIST_BOX_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN/LANG", 15.0f)
+        t |> success(snap0 != null, "LANG list_box registers")
+        if (snap0 == null) return
+
+        let lang_entry = find_widget(snap0, "MAIN_WIN/LANG")
+        t |> equal(lang_entry?["kind"] ?? "", "list_box",
+                   "LANG.kind == 'list_box'")
+
+        // imgui_set steers selection to "Rust" (index 2).
+        set_value(d, "MAIN_WIN/LANG", JV(2))
+        t |> success(wait_for_int_value(d, "MAIN_WIN/LANG", "value", 2, 300),
+                     "imgui_set steers LANG to index 2 (Rust)")
+
+        // Another step — Python (4).
+        set_value(d, "MAIN_WIN/LANG", JV(4))
+        t |> success(wait_for_int_value(d, "MAIN_WIN/LANG", "value", 4, 300),
+                     "imgui_set steers LANG to index 4 (Python)")
+
+        // Final snapshot envelope.
+        var snap_final = snapshot(d)
+        let lang_final = find_widget(snap_final, "MAIN_WIN/LANG")
+        t |> equal(lang_final?["payload"]?["value"] ?? -1, 4,
+                   "LANG.payload.value persists final imgui_set")
+    }
+}

--- a/tests/integration/test_popup_context_item.das
+++ b/tests/integration/test_popup_context_item.das
@@ -1,0 +1,33 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `popup_context_item` — right-click context menu
+//! attached to the previously submitted item. The popup itself drives
+//! open/close internally (no pending_open/close). This test verifies
+//! TARGET_BTN registers and the popup_context_item container is itself
+//! reachable in the snapshot path tree.
+
+let POPUP_CTX_FEATURE = "modules/dasImgui/examples/features/popup_context_item.das"
+
+[test]
+def test_popup_context_item_smoke(t : T?) {
+    with_imgui_app(POPUP_CTX_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN/TARGET_BTN", 15.0f)
+        t |> success(snap0 != null, "TARGET_BTN registers")
+        if (snap0 == null) return
+
+        // popup_context_item itself registers at MAIN_WIN/TARGET_CTX even
+        // when closed — the [container] wrapper calls stateless_finalize
+        // every frame regardless of Begin's return.
+        let ctx_entry = find_widget(snap0, "MAIN_WIN/TARGET_CTX")
+        t |> equal(ctx_entry?["kind"] ?? "", "popup_context_item",
+                   "TARGET_CTX.kind == 'popup_context_item'")
+    }
+}

--- a/tests/integration/test_with_indent.das
+++ b/tests/integration/test_with_indent.das
@@ -1,0 +1,26 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `with_indent` — stateless block-arg wrapper around
+//! Indent/Unindent. The wrapper itself doesn't register a widget; this test
+//! just verifies the demo runs and MAIN_WIN reaches the snapshot.
+
+let WITH_INDENT_FEATURE = "modules/dasImgui/examples/features/with_indent.das"
+
+[test]
+def test_with_indent_smoke(t : T?) {
+    with_imgui_app(WITH_INDENT_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN", 15.0f)
+        t |> success(snap0 != null, "MAIN_WIN registers (demo renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "MAIN_WIN")?["kind"] ?? "", "window",
+                   "MAIN_WIN.kind == 'window'")
+    }
+}

--- a/tests/integration/test_with_item_width.das
+++ b/tests/integration/test_with_item_width.das
@@ -1,0 +1,33 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke + width gate for `with_item_width`. The 120-px-wide
+//! slider inside the wrapper should render with bbox width ≈ 120 px.
+
+let WITH_ITEM_WIDTH_FEATURE = "modules/dasImgui/examples/features/with_item_width.das"
+
+[test]
+def test_with_item_width_smoke(t : T?) {
+    with_imgui_app(WITH_ITEM_WIDTH_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN/NARROW_W", 15.0f)
+        t |> success(snap0 != null, "NARROW_W slider registers")
+        if (snap0 == null) return
+
+        // Slider bbox is float4 (x0, y0, x1, y1) serialized as JV with x/y/z/w.
+        let bb = find_widget(snap0, "MAIN_WIN/NARROW_W")?["bbox"]
+        let x0 = bb?["x"] ?? 0.0f
+        let x1 = bb?["z"] ?? 0.0f
+        let width = x1 - x0
+        // ImGui adds ~label + framepadding; the slider's drawn rect lands close
+        // to 120 but not exact. Allow [60, 200].
+        t |> success(width > 60.0f && width < 200.0f,
+                     "NARROW_W width ({width}) within with_item_width(120) range")
+    }
+}

--- a/tests/integration/test_with_text_wrap_pos.das
+++ b/tests/integration/test_with_text_wrap_pos.das
@@ -1,0 +1,26 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `with_text_wrap_pos` — stateless block-arg wrapper
+//! around PushTextWrapPos/PopTextWrapPos. Text wrap is purely visual; this
+//! test just verifies the demo runs and MAIN_WIN reaches the snapshot.
+
+let WITH_TEXT_WRAP_POS_FEATURE = "modules/dasImgui/examples/features/with_text_wrap_pos.das"
+
+[test]
+def test_with_text_wrap_pos_smoke(t : T?) {
+    with_imgui_app(WITH_TEXT_WRAP_POS_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN", 15.0f)
+        t |> success(snap0 != null, "MAIN_WIN registers (demo renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "MAIN_WIN")?["kind"] ?? "", "window",
+                   "MAIN_WIN.kind == 'window'")
+    }
+}

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -456,6 +456,24 @@ struct TooltipState {
     @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
 }
 
+struct PopupContextItemState {
+    //! Backs `popup_context_item`. Right-click attaches to the previous item
+    //! and ImGui drives open/close internally; no pending flags needed.
+    @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
+}
+
+struct DragDropSourceState {
+    //! Backs `drag_drop_source`. Drag activation lives entirely in ImGui's
+    //! internal drag-drop state machine; body runs only on active drag.
+    @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
+}
+
+struct DragDropTargetState {
+    //! Backs `drag_drop_target`. Body runs only when a payload-bearing drag
+    //! is hovering this target — caller still calls AcceptDragDropPayload inside.
+    @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
+}
+
 struct TreeNodeState {
     //! Backs the `tree_node` container. ImGui owns the open/close state
     //! internally; we mirror what's observable so snapshots reflect truth,
@@ -722,7 +740,7 @@ def public register_focusable(widget_ident : string) {
 }
 
 def public pending_value_container_finalize(widget_ident : string; kind : string;
-                                             var state : auto) {
+                                            var state : auto) {
     //! Container-side install of the ``pending_value`` dispatcher (``imgui_set``); used by layout containers like ``split_h`` / ``dock_left``.
     var entry : WidgetEntry
     unsafe {

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -35,7 +35,7 @@ require math
 // dispatcher lambda is a no-op; the serializer still reflects state for
 // snapshot.
 //
-// `combo_select` / `list_box_select` reuse ComboState / ListBoxState (a
+// `combo_select` / `list_box` reuse ComboState / ListBoxState (a
 // `pending_value : int` shape) and inline their own dispatcher because the
 // shared `pending_value_finalize` helper is private to imgui_widgets_builtin.
 
@@ -230,6 +230,20 @@ def popup(var state : PopupState; text : string;
 }
 
 [container]
+def popup_context_item(var state : PopupContextItemState; str_id : string;
+                       flags : ImGuiPopupFlags; blk : block) {
+    //! `BeginPopupContextItem(str_id, flags)` / `EndPopup()` — right-click
+    //! context popup attached to the previously submitted item. ImGui drives
+    //! open/close internally on right-click; body runs only while open.
+    let im_open = BeginPopupContextItem(str_id, flags)
+    if (im_open) {
+        invoke(blk)
+        EndPopup()
+    }
+    stateless_finalize(widget_ident, "popup_context_item", state)
+}
+
+[container]
 def popup_modal(var state : PopupState; text : string; closable : bool;
                 flags : ImGuiWindowFlags; blk : block) {
     //! `BeginPopupModal(name, p_open, flags)` / `EndPopup()`. Same lifecycle
@@ -394,13 +408,13 @@ def collapsing_header(var state : CollapsingHeaderState; text : string;
 
 // ===== Choice block-arg family =====
 //
-// `combo_select` and `list_box_select` are the BeginCombo / BeginListBox
-// counterparts to the leaf `combo` / `list_box` widgets shipped in 0b.2-choice.
-// They reuse the same state structs (ComboState / ListBoxState) — `value : int`
-// is the user-driven selection index. Body code is responsible for emitting
-// Selectable items inside; the dispatcher's "set" action just writes
-// `state.value` for the next frame. Per-call args (preview_value, flags, size)
-// follow the named-tuple convention.
+// `combo_select` is the BeginCombo counterpart to the leaf `combo` widget.
+// `list_box` is unified on the BeginListBox/EndListBox form — the legacy
+// items-array `[widget] def list_box` was dropped (modern ImGui idiom is
+// Begin/End + Selectable). Both reuse selection state structs (ComboState /
+// ListBoxState) — `value : int` is the user-driven selection index. Body
+// code emits Selectable items; the dispatcher's "set" action writes
+// `state.value` for the next frame. Per-call args follow the named-tuple convention.
 
 [container]
 def combo_select(var state : ComboState; text : string; preview_value : string;
@@ -433,7 +447,7 @@ def combo_select(var state : ComboState; text : string; preview_value : string;
 }
 
 [container]
-def list_box_select(var state : ListBoxState; text : string; size : float2; blk : block) {
+def list_box(var state : ListBoxState; text : string; size : float2; blk : block) {
     //! `BeginListBox(label, size)` / `EndListBox()` — only-on-true. Body
     //! emits the per-item rows. `imgui_set {"value":N}` steers next-frame
     //! selection; bodies typically read `state.value` to tag the active row.
@@ -457,6 +471,42 @@ def list_box_select(var state : ListBoxState; text : string; size : float2; blk 
                 state.has_pending = true
             }
         }
-        container_finalize(widget_ident, "list_box_select", entry, ser, disp)
+        container_finalize(widget_ident, "list_box", entry, ser, disp)
     }
+}
+
+// ===== Drag-drop family =====
+//
+// Both bodies are gated on ImGui's internal drag-drop state machine:
+// `drag_drop_source` body runs only when the previous item has been picked
+// up for drag; `drag_drop_target` body runs only when a payload-bearing
+// drag is hovering. Payload set/accept are raw `SetDragDropPayload` /
+// `AcceptDragDropPayload` calls inside the body — no boost wrapper, since
+// the payload data is caller-owned and crosses widget boundaries.
+
+[container]
+def drag_drop_source(var state : DragDropSourceState; flags : ImGuiDragDropFlags;
+                     blk : block) {
+    //! `BeginDragDropSource(flags)` / `EndDragDropSource()` — only-on-true.
+    //! Body calls `SetDragDropPayload(type, data, sz, cond)` to publish the
+    //! payload and renders the drag preview (Text, Image, etc.).
+    let im_open = BeginDragDropSource(flags)
+    if (im_open) {
+        invoke(blk)
+        EndDragDropSource()
+    }
+    stateless_finalize(widget_ident, "drag_drop_source", state)
+}
+
+[container]
+def drag_drop_target(var state : DragDropTargetState; blk : block) {
+    //! `BeginDragDropTarget()` / `EndDragDropTarget()` — only-on-true.
+    //! Body calls `AcceptDragDropPayload(type, flags)` to receive the payload
+    //! when the drag releases over this target.
+    let im_open = BeginDragDropTarget()
+    if (im_open) {
+        invoke(blk)
+        EndDragDropTarget()
+    }
+    stateless_finalize(widget_ident, "drag_drop_target", state)
 }

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -367,6 +367,21 @@ def public drag(app : ImguiApp; target : string;
                               JV((target = target, dx = dx, dy = dy, steps = steps, button = button)))
 }
 
+def public drag_to(app : ImguiApp; source : string; target : string;
+                   steps : int = 6; button : int = 0) : JsonValue? {
+    //! Drag from ``source`` widget center to ``target`` widget center. Reads
+    //! both bboxes from a fresh snapshot, computes the delta, and dispatches
+    //! the L1 drag coroutine (press at source → interpolated moves → release).
+    var snap = snapshot(app)
+    let sb = snap?["globals"]?[source]?["bbox"]
+    let tb = snap?["globals"]?[target]?["bbox"]
+    let sx = ((sb?["x"] ?? 0.0f) + (sb?["z"] ?? 0.0f)) * 0.5f
+    let sy = ((sb?["y"] ?? 0.0f) + (sb?["w"] ?? 0.0f)) * 0.5f
+    let tx = ((tb?["x"] ?? 0.0f) + (tb?["z"] ?? 0.0f)) * 0.5f
+    let ty = ((tb?["y"] ?? 0.0f) + (tb?["w"] ?? 0.0f)) * 0.5f
+    return drag(app, source, tx - sx, ty - sy, steps, button)
+}
+
 def public focus(app : ImguiApp; target : string) : JsonValue? {
     //! Force keyboard focus to the next render of ``target`` (``imgui_focus`` verb); display-only widgets reply ``Result.err("not focusable")``.
     return send_imgui_command(app.transport, "imgui_focus", JV((target = target)))

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -1,0 +1,32 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+
+module imgui_scope_builtin shared
+
+require imgui public
+require imgui/imgui_boost_runtime public
+
+def public with_indent(amount : float; blk : block) {
+    //! Run ``blk`` with ``Indent(amount)`` applied; matching ``Unindent(amount)`` on return.
+    //! Pass ``0.0f`` to defer to ImGui's ``IndentSpacing`` style default.
+    Indent(amount)
+    invoke(blk)
+    Unindent(amount)
+}
+
+def public with_item_width(item_width : float; blk : block) {
+    //! Run ``blk`` with ``PushItemWidth(item_width)`` applied; matching ``PopItemWidth()`` on return.
+    //! Negative values are "right edge minus N pixels"; positive are absolute widget width.
+    PushItemWidth(item_width)
+    invoke(blk)
+    PopItemWidth()
+}
+
+def public with_text_wrap_pos(wrap_local_pos_x : float; blk : block) {
+    //! Run ``blk`` with ``PushTextWrapPos(wrap_local_pos_x)`` applied; matching ``PopTextWrapPos()`` on return.
+    //! Pass ``0.0f`` to wrap at the window's right edge; positive is an x-coord in window-local space.
+    PushTextWrapPos(wrap_local_pos_x)
+    invoke(blk)
+    PopTextWrapPos()
+}

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -842,22 +842,6 @@ def combo(var state : ComboState; text : string; items : array<string>;
 }
 
 [widget]
-def list_box(var state : ListBoxState; text : string; items : array<string>;
-             height_in_items : int = -1) : bool {
-    //! `imgui_set {"value": N}` selects the N-th item next frame.
-    //! `height_in_items = -1` lets ImGui pick a default; positive caps the visible rows.
-    if (state.has_pending) {
-        state.value = state.pending_value
-        state.has_pending = false
-    }
-    let changed = ListBox(text, unsafe(addr(state.value)),
-                          unsafe(addr(items[0])), length(items), height_in_items)
-    state.changed = changed
-    pending_value_finalize(widget_ident, "list_box", state)
-    return changed
-}
-
-[widget]
 def color_button(var state : ClickState; desc_id : string;
                  col : float4;
                  size : float2 = float2(0.0f, 0.0f);


### PR DESCRIPTION
## Summary

Phase 1 of the boost API closes seven scope-wrapper gaps surfaced when planning
the `imgui_demo.cpp` port (Phase 2). Three stateless block-arg helpers, three
new `[container]`s, list_box unification, and a high-level drag-drop synth
helper for playwright.

## Stateless block-arg wrappers

New module `widgets/imgui_scope_builtin.das`:

- `with_indent(amount, blk)` — `Indent` / `Unindent`
- `with_item_width(width, blk)` — `PushItemWidth` / `PopItemWidth`
- `with_text_wrap_pos(pos, blk)` — `PushTextWrapPos` / `PopTextWrapPos`

Plain `def` block-arg pattern (no `[container]` annotation) — they don't ID
anything, just bracket Push/Pop. Pattern matches existing `with_id` in
`imgui_id_builtin.das`.

## `[container]` wrappers

Added to `widgets/imgui_containers_builtin.das`:

- `popup_context_item` — `BeginPopupContextItem` / `EndPopup` (right-click context)
- `drag_drop_source` — `BeginDragDropSource` / `EndDragDropSource`
- `drag_drop_target` — `BeginDragDropTarget` / `EndDragDropTarget`

Each registers in the snapshot path tree via `stateless_finalize` and gates its
body on the corresponding `Begin*` return. Payload set/accept stay raw
`SetDragDropPayload` / `AcceptDragDropPayload` calls inside the body (data is
caller-owned and crosses widget boundaries — no boost wrapper appropriate).

## `list_box` unification (breaking)

- Drop legacy items-array `[widget] def list_box` (single-call form,
  `ImGui::ListBox(label, &current, items, count, height)`).
- Rename `[container] list_box_select` → `list_box` (Begin/End + caller-emitted
  Selectable rows). Selection state machinery preserved — `imgui_set
  {"value": N}` still steers selection.
- Migrate the two existing callers (`examples/features/inputs_choice.das`,
  `examples/features/containers_overlay.das`).
- Update `tests/integration/test_containers_overlay.das` kind assertion
  (`list_box_select` → `list_box`).

Naming asymmetry: `combo` ([widget], items-array) and `combo_select`
([container], block-arg) still coexist. Only `list_box` was unified — the
modern ImGui idiom is `Begin/End` + `Selectable` and the items-array form had
only one user. Open to unifying `combo` similarly in a follow-up if you want
symmetry.

## Playwright

`widgets/imgui_playwright.das`:

- `drag_to(app, source, target, steps, button)` — bbox-driven drag synth.
  Reads source/target bboxes from a snapshot, computes delta, dispatches the
  existing L1 `imgui_drag` coroutine (press → interpolated moves → release).

## Tutorials + docs

- `doc/source/tutorials/layout.rst` — new "Scope wrappers" section
- `doc/source/tutorials/containers.rst` — new "Context popups" section
- `doc/source/tutorials/drag_drop.rst` — **new** full tutorial
- `doc/source/tutorials/index.rst` — drag_drop.rst added to toctree

No new APNG recordings for the stateless wrappers in this PR — existing
`record_layout.das` / `record_containers.das` are tied to specific tutorial
demos. New `record_drag_drop.das` ships the driver for `drag_drop.rst`'s APNG.

## Feature demos

Six new files under `examples/features/`:

- `with_indent.das`, `with_item_width.das`, `with_text_wrap_pos.das`
- `popup_context_item.das`, `drag_drop.das`, `list_box.das`

## Test plan

- [x] Format + lint clean on all 21 touched .das files
- [x] Full integration suite: **85 tests passing, 0 failures (417s)**
- [x] Six new tests under `tests/integration/` (one per wrapper)
- [x] No regressions in `test_inputs_choice` or `test_containers_overlay`
- [ ] Sphinx doc rebuild — not run locally; CI on PR will rebuild

## Follow-ups (out of scope here)

- Phase 2: port `imgui_demo.cpp` using these wrappers.
- Optional: APNG recordings for the stateless wrappers (extend
  `record_layout.das` if you want them inline with the existing layout demo).
- Optional: unify `combo` the same way `list_box` was, for symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;