### PR TITLE
imgui_demo(popups): explicit open/close popup boost API + Selectable sweep

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,95 @@
+name: Integration tests
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'daslib/**'
+      - 'examples/**'
+      - 'tests/integration/**'
+      - 'utils/**'
+      - 'widgets/**'
+      - '.das_module'
+      - '.das_package'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    paths:
+      - 'daslib/**'
+      - 'examples/**'
+      - 'tests/integration/**'
+      - 'utils/**'
+      - 'widgets/**'
+      - '.das_module'
+      - '.das_package'
+      - '.github/workflows/tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# dasImgui is daspkg-installed into daslang-src/modules/dasImgui/ (mirrors the
+# docs workflow). Tests are driven by dastest at daslang-src/dastest/dastest.das.
+# Each test in tests/integration/ spawns daslang-live as a subprocess via
+# imgui_playwright; daslang-live opens a GLFW/OpenGL window so we wrap the
+# dastest invocation in `xvfb-run -a` to give it a virtual display. The
+# subprocess inherits DISPLAY=:99 from the xvfb-run environment.
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout daslang"
+        uses: actions/checkout@v4
+        with:
+          repository: GaijinEntertainment/daScript
+          path: daslang-src
+          ref: master
+
+      - name: "Checkout dasImgui"
+        uses: actions/checkout@v4
+        with:
+          path: dasImgui
+
+      - name: "Install system dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libglfw3-dev \
+            libfreetype6-dev \
+            mesa-common-dev \
+            xorg-dev \
+            xvfb
+
+      - name: "Install CMake and Ninja"
+        uses: lukka/get-cmake@latest
+
+      - name: "Build daslang + daslang-live"
+        working-directory: daslang-src
+        run: |
+          set -eux
+          cmake --no-warn-unused-cli -B./build \
+            -DCMAKE_BUILD_TYPE:STRING=Release \
+            -DDAS_HV_DISABLED=OFF \
+            -DDAS_PUGIXML_DISABLED=OFF \
+            -DDAS_LLVM_DISABLED=ON \
+            -DDAS_GLFW_DISABLED=OFF \
+            -G Ninja
+          cmake --build ./build --target daslang
+          cmake --build ./build --target daslang-live
+
+      - name: "daspkg install dasImgui (global)"
+        run: |
+          set -eux
+          ${{ github.workspace }}/daslang-src/bin/daslang \
+            ${{ github.workspace }}/daslang-src/utils/daspkg/main.das -- \
+            install ${{ github.workspace }}/dasImgui --global
+
+      - name: "Run integration tests (xvfb-run)"
+        working-directory: ${{ github.workspace }}/daslang-src
+        run: |
+          set -eux
+          xvfb-run -a bin/daslang dastest/dastest.das -- \
+            --test modules/dasImgui/tests/integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,27 +1,16 @@
 name: Integration tests
 
+# Disabled (manual-only) — to re-enable, add the `push:` / `pull_request:`
+# blocks back. Currently parked because:
+#   - Linux GitHub-hosted runners need xvfb + Mesa SW rendering, and the
+#     dasImgui playwright readiness gate (poll /status until first frame
+#     renders) doesn't survive that path: daslang-live boots, prints the
+#     lifecycle banner, then hangs before the first frame.
+#   - windows-latest works for GLFW/GL but transitively builds OpenSSL (via
+#     dasHV's libhv), which is a 1+ hour build on the CI runner.
+# Revisit once we have headless integration tests (mock GL backend or a
+# native-headless renderer path that doesn't need a real window).
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'daslib/**'
-      - 'examples/**'
-      - 'tests/integration/**'
-      - 'utils/**'
-      - 'widgets/**'
-      - '.das_module'
-      - '.das_package'
-      - '.github/workflows/tests.yml'
-  pull_request:
-    paths:
-      - 'daslib/**'
-      - 'examples/**'
-      - 'tests/integration/**'
-      - 'utils/**'
-      - 'widgets/**'
-      - '.das_module'
-      - '.das_package'
-      - '.github/workflows/tests.yml'
   workflow_dispatch:
 
 concurrency:
@@ -34,13 +23,12 @@ permissions:
 # dasImgui is daspkg-installed into daslang-src/modules/dasImgui/ (mirrors the
 # docs workflow). Tests are driven by dastest at daslang-src/dastest/dastest.das.
 # Each test in tests/integration/ spawns daslang-live as a subprocess via
-# imgui_playwright; daslang-live opens a GLFW/OpenGL window. Runs on
-# windows-latest because the Linux GitHub-hosted runners require xvfb +
-# software-rendered Mesa and the dasImgui playwright readiness gate doesn't
-# survive that path. Windows runners ship a usable GL stack out of the box.
+# imgui_playwright; daslang-live opens a GLFW/OpenGL window so we wrap the
+# dastest invocation in `xvfb-run -a` to give it a virtual display. The
+# subprocess inherits DISPLAY=:99 from the xvfb-run environment.
 jobs:
   integration:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout daslang"
         uses: actions/checkout@v4
@@ -54,42 +42,52 @@ jobs:
         with:
           path: dasImgui
 
+      - name: "Install system dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libglfw3-dev \
+            libfreetype6-dev \
+            mesa-common-dev \
+            xorg-dev \
+            xvfb
+
       - name: "Install CMake and Ninja"
         uses: lukka/get-cmake@latest
 
       - name: "Build daslang + daslang-live + shared modules"
         working-directory: daslang-src
-        shell: pwsh
         run: |
-          cmake --no-warn-unused-cli -B./build `
-            -DCMAKE_BUILD_TYPE:STRING=Release `
-            -DDAS_HV_DISABLED=OFF `
-            -DDAS_PUGIXML_DISABLED=OFF `
-            -DDAS_LLVM_DISABLED=ON `
-            -DDAS_GLFW_DISABLED=OFF
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          set -eux
+          cmake --no-warn-unused-cli -B./build \
+            -DCMAKE_BUILD_TYPE:STRING=Release \
+            -DDAS_HV_DISABLED=OFF \
+            -DDAS_PUGIXML_DISABLED=OFF \
+            -DDAS_LLVM_DISABLED=ON \
+            -DDAS_GLFW_DISABLED=OFF \
+            -G Ninja
           # daslang + daslang-live binaries plus the shared-module artifacts
-          # daslang-live LoadLibraryEx's at runtime via `require <module>` lines
-          # in the test scripts. Matches the set daslang's extended_checks
-          # workflow builds for live tests.
-          cmake --build ./build --config Release --parallel --target `
-            daslang daslang-live `
-            dasModuleLiveHost dasModuleGlfw dasModuleHV `
+          # daslang-live dlopens at runtime via `require <module>` lines in
+          # the test scripts: dasModuleLiveHost (lifecycle API exported via
+          # dlsym RTLD_DEFAULT), dasModuleGlfw (window/GL context), dasModuleHV
+          # (HTTP /status, /command, /shutdown endpoints used by playwright),
+          # dasModulePUGIXML + dasModuleStbImage (rendering deps). Matches the
+          # set daslang's extended_checks workflow builds for live tests.
+          cmake --build ./build --parallel --target \
+            daslang daslang-live \
+            dasModuleLiveHost dasModuleGlfw dasModuleHV \
             dasModulePUGIXML dasModuleStbImage
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: "daspkg install dasImgui (global)"
-        shell: pwsh
         run: |
-          & "${{ github.workspace }}/daslang-src/bin/Release/daslang.exe" `
-            "${{ github.workspace }}/daslang-src/utils/daspkg/main.das" -- `
-            install "${{ github.workspace }}/dasImgui" --global
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          set -eux
+          ${{ github.workspace }}/daslang-src/bin/daslang \
+            ${{ github.workspace }}/daslang-src/utils/daspkg/main.das -- \
+            install ${{ github.workspace }}/dasImgui --global
 
-      - name: "Run integration tests"
+      - name: "Run integration tests (xvfb-run)"
         working-directory: ${{ github.workspace }}/daslang-src
-        shell: pwsh
         run: |
-          & "./bin/Release/daslang.exe" dastest/dastest.das -- `
+          set -eux
+          xvfb-run -a bin/daslang dastest/dastest.das -- \
             --test modules/dasImgui/tests/integration
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: "Install CMake and Ninja"
         uses: lukka/get-cmake@latest
 
-      - name: "Build daslang + daslang-live"
+      - name: "Build daslang + daslang-live + shared modules"
         working-directory: daslang-src
         run: |
           set -eux
@@ -77,8 +77,17 @@ jobs:
             -DDAS_LLVM_DISABLED=ON \
             -DDAS_GLFW_DISABLED=OFF \
             -G Ninja
-          cmake --build ./build --target daslang
-          cmake --build ./build --target daslang-live
+          # daslang + daslang-live binaries plus the shared-module artifacts
+          # daslang-live dlopens at runtime via `require <module>` lines in
+          # the test scripts: dasModuleLiveHost (lifecycle API exported via
+          # dlsym RTLD_DEFAULT), dasModuleGlfw (window/GL context), dasModuleHV
+          # (HTTP /status, /command, /shutdown endpoints used by playwright),
+          # dasModulePUGIXML + dasModuleStbImage (rendering deps). Matches the
+          # set daslang's extended_checks workflow builds for live tests.
+          cmake --build ./build --parallel --target \
+            daslang daslang-live \
+            dasModuleLiveHost dasModuleGlfw dasModuleHV \
+            dasModulePUGIXML dasModuleStbImage
 
       - name: "daspkg install dasImgui (global)"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,13 @@ permissions:
 # dasImgui is daspkg-installed into daslang-src/modules/dasImgui/ (mirrors the
 # docs workflow). Tests are driven by dastest at daslang-src/dastest/dastest.das.
 # Each test in tests/integration/ spawns daslang-live as a subprocess via
-# imgui_playwright; daslang-live opens a GLFW/OpenGL window so we wrap the
-# dastest invocation in `xvfb-run -a` to give it a virtual display. The
-# subprocess inherits DISPLAY=:99 from the xvfb-run environment.
+# imgui_playwright; daslang-live opens a GLFW/OpenGL window. Runs on
+# windows-latest because the Linux GitHub-hosted runners require xvfb +
+# software-rendered Mesa and the dasImgui playwright readiness gate doesn't
+# survive that path. Windows runners ship a usable GL stack out of the box.
 jobs:
   integration:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: "Checkout daslang"
         uses: actions/checkout@v4
@@ -53,52 +54,42 @@ jobs:
         with:
           path: dasImgui
 
-      - name: "Install system dependencies"
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libglfw3-dev \
-            libfreetype6-dev \
-            mesa-common-dev \
-            xorg-dev \
-            xvfb
-
       - name: "Install CMake and Ninja"
         uses: lukka/get-cmake@latest
 
       - name: "Build daslang + daslang-live + shared modules"
         working-directory: daslang-src
+        shell: pwsh
         run: |
-          set -eux
-          cmake --no-warn-unused-cli -B./build \
-            -DCMAKE_BUILD_TYPE:STRING=Release \
-            -DDAS_HV_DISABLED=OFF \
-            -DDAS_PUGIXML_DISABLED=OFF \
-            -DDAS_LLVM_DISABLED=ON \
-            -DDAS_GLFW_DISABLED=OFF \
-            -G Ninja
+          cmake --no-warn-unused-cli -B./build `
+            -DCMAKE_BUILD_TYPE:STRING=Release `
+            -DDAS_HV_DISABLED=OFF `
+            -DDAS_PUGIXML_DISABLED=OFF `
+            -DDAS_LLVM_DISABLED=ON `
+            -DDAS_GLFW_DISABLED=OFF
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # daslang + daslang-live binaries plus the shared-module artifacts
-          # daslang-live dlopens at runtime via `require <module>` lines in
-          # the test scripts: dasModuleLiveHost (lifecycle API exported via
-          # dlsym RTLD_DEFAULT), dasModuleGlfw (window/GL context), dasModuleHV
-          # (HTTP /status, /command, /shutdown endpoints used by playwright),
-          # dasModulePUGIXML + dasModuleStbImage (rendering deps). Matches the
-          # set daslang's extended_checks workflow builds for live tests.
-          cmake --build ./build --parallel --target \
-            daslang daslang-live \
-            dasModuleLiveHost dasModuleGlfw dasModuleHV \
+          # daslang-live LoadLibraryEx's at runtime via `require <module>` lines
+          # in the test scripts. Matches the set daslang's extended_checks
+          # workflow builds for live tests.
+          cmake --build ./build --config Release --parallel --target `
+            daslang daslang-live `
+            dasModuleLiveHost dasModuleGlfw dasModuleHV `
             dasModulePUGIXML dasModuleStbImage
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: "daspkg install dasImgui (global)"
+        shell: pwsh
         run: |
-          set -eux
-          ${{ github.workspace }}/daslang-src/bin/daslang \
-            ${{ github.workspace }}/daslang-src/utils/daspkg/main.das -- \
-            install ${{ github.workspace }}/dasImgui --global
+          & "${{ github.workspace }}/daslang-src/bin/Release/daslang.exe" `
+            "${{ github.workspace }}/daslang-src/utils/daspkg/main.das" -- `
+            install "${{ github.workspace }}/dasImgui" --global
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: "Run integration tests (xvfb-run)"
+      - name: "Run integration tests"
         working-directory: ${{ github.workspace }}/daslang-src
+        shell: pwsh
         run: |
-          set -eux
-          xvfb-run -a bin/daslang dastest/dastest.das -- \
+          & "./bin/Release/daslang.exe" dastest/dastest.das -- `
             --test modules/dasImgui/tests/integration
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/doc/source/stdlib/external_types.rst
+++ b/doc/source/stdlib/external_types.rst
@@ -27,15 +27,17 @@ for the full enumerator list.
 .. _enum-imgui-ImGuiTabBarFlags:
 .. _enum-imgui-ImGuiTabItemFlags:
 .. _enum-imgui-ImGuiTreeNodeFlags:
+.. _enum-imgui-ImGuiPopupFlags:
 
 ``imgui::ImGui*Flags``
 ======================
 
 Bitfield enums exposed by the ``imgui`` builtin module: ``ImGuiWindowFlags``,
 ``ImGuiChildFlags``, ``ImGuiTabBarFlags``, ``ImGuiTabItemFlags``,
-``ImGuiTreeNodeFlags``. Passed to the corresponding ``imgui::Begin*`` /
-``BeginTabBar`` / ``BeginTabItem`` / ``TreeNodeEx`` calls. Values map directly to
-upstream ``ImGui*Flags_*`` enumerants; see the
+``ImGuiTreeNodeFlags``, ``ImGuiPopupFlags``. Passed to the corresponding
+``imgui::Begin*`` / ``BeginTabBar`` / ``BeginTabItem`` / ``TreeNodeEx`` /
+``OpenPopup`` calls. Values map directly to upstream ``ImGui*Flags_*``
+enumerants; see the
 `Dear ImGui flag enums <https://github.com/ocornut/imgui/blob/master/imgui.h>`_
 for the full enumerator lists.
 

--- a/examples/features/containers_overlay.das
+++ b/examples/features/containers_overlay.das
@@ -36,6 +36,8 @@ require imgui/imgui_containers_builtin
 
 let PALETTE_NAMES : array<string> <- ["Sunset", "Ocean", "Forest", "Mono"]
 let TASK_NAMES : array<string> <- ["Compile", "Lint", "Test", "Package", "Deploy"]
+var PALETTE_ROW : table<int; ClickState>
+var TASK_ROW : table<int; ClickState>
 
 [export]
 def init() {
@@ -127,9 +129,7 @@ def update() {
                                      flags = ImGuiComboFlags.None)) {
             for (i in range(length(PALETTE_NAMES))) {
                 let is_sel = (i == PALETTE_COMBO.value)
-                if (Selectable(PALETTE_NAMES[i], is_sel,
-                               ImGuiSelectableFlags.None,
-                               float2(0.0f, 0.0f))) {
+                if (selectable_label(PALETTE_ROW[i], PALETTE_NAMES[i], is_sel)) {
                     PALETTE_COMBO.value = i
                 }
             }
@@ -140,9 +140,7 @@ def update() {
                              size = float2(220.0f, 110.0f))) {
             for (i in range(length(TASK_NAMES))) {
                 let is_sel = (i == TASK_LIST.value)
-                if (Selectable(TASK_NAMES[i], is_sel,
-                               ImGuiSelectableFlags.None,
-                               float2(0.0f, 0.0f))) {
+                if (selectable_label(TASK_ROW[i], TASK_NAMES[i], is_sel)) {
                     TASK_LIST.value = i
                 }
             }

--- a/examples/features/inputs_choice.das
+++ b/examples/features/inputs_choice.das
@@ -37,6 +37,7 @@ require imgui/imgui_containers_builtin
 // =============================================================================
 
 let SHIRT_NAMES : array<string> <- ["XS", "S", "M", "L", "XL", "XXL"]
+var SHIRT_ROW : table<int; ClickState>
 
 [export]
 def init() {
@@ -79,9 +80,7 @@ def update() {
                               size = float2(0.0f, 0.0f))) {
             for (i in range(length(SHIRT_NAMES))) {
                 let is_sel = (i == SHIRT_SIZE.value)
-                if (Selectable(SHIRT_NAMES[i], is_sel,
-                               ImGuiSelectableFlags.None,
-                               float2(0.0f, 0.0f))) {
+                if (selectable_label(SHIRT_ROW[i], SHIRT_NAMES[i], is_sel)) {
                     SHIRT_SIZE.value = i
                 }
             }

--- a/examples/features/list_box.das
+++ b/examples/features/list_box.das
@@ -34,6 +34,7 @@ require imgui/imgui_containers_builtin
 
 let LANG_NAMES : array<string> <- ["daslang", "C++", "Rust", "Go", "Python", "Lua"]
 let LANG_ICONS : array<string> <- ["[D]", "[C]", "[R]", "[G]", "[P]", "[L]"]
+var LANG_ROW : table<int; ClickState>
 
 [export]
 def init() {
@@ -62,9 +63,7 @@ def update() {
             for (i in range(length(LANG_NAMES))) {
                 let is_sel = (i == LANG.value)
                 let row_text = "{LANG_ICONS[i]} {LANG_NAMES[i]}"
-                if (Selectable(row_text, is_sel,
-                               ImGuiSelectableFlags.None,
-                               float2(0.0f, 0.0f))) {
+                if (selectable_label(LANG_ROW[i], row_text, is_sel)) {
                     LANG.value = i
                 }
             }

--- a/examples/features/scroll_state.das
+++ b/examples/features/scroll_state.das
@@ -18,6 +18,9 @@ require imgui/imgui_boost_v2
 require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 
+var SCROLLY_ROW : table<int; NarrativeState>
+var LOG_ROW : table<int; NarrativeState>
+
 // =============================================================================
 // FEATURE: scroll_state — Phase 1.2 scroll capture for window + child.
 // SHOWS:   WindowState and ChildState now carry `scroll` and `scroll_max`
@@ -55,7 +58,8 @@ def update() {
         text("Window scroll values appear in SCROLLY_WIN.payload.scroll")
         text("along with scroll_max. Forty rows below to make it scroll.")
         for (i in range(0, 40)) {
-            text("row {i}: lorem ipsum dolor sit amet consectetur adipiscing elit")
+            text(SCROLLY_ROW[i],
+                (text = "row {i}: lorem ipsum dolor sit amet consectetur adipiscing elit"))
         }
     }
 
@@ -68,7 +72,7 @@ def update() {
                            child_flags = ImGuiChildFlags.Border,
                            window_flags = ImGuiWindowFlags.None)) {
             for (i in range(0, 25)) {
-                text("log line {i}")
+                text(LOG_ROW[i], (text = "log line {i}"))
             }
         }
     }

--- a/examples/imgui_demo/popups.das
+++ b/examples/imgui_demo/popups.das
@@ -1,9 +1,11 @@
 options gen2
 options indenting = 4
+options _no_imgui_legacy = true
 
 module popups
 
 require imgui
+require imgui/imgui_lint
 require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 require imgui/imgui_scope_builtin
@@ -20,16 +22,16 @@ require app_main_menu
 //
 // Boost-surface conventions applied here:
 //   - `popup` / `popup_modal` / `popup_context_item` containers replace the
-//     raw Begin*/End* pairs. Opening a popup is still a raw `OpenPopup(name)`
-//     call from the trigger Button — ImGui owns popup visibility, not the
-//     state struct, so we mirror the C++ idiom 1:1.
+//     raw Begin*/End* pairs. Triggers go through `open_popup(STATE)` for
+//     stateful popups; `open_popup(str_id)` / `open_popup_on_item_click` for
+//     stateless `popup_context_item` cases.
 //   - `menu` / `menu_bar` containers wrap the dropdown bodies.
 //   - `tree_node` containers wrap each sub-section (no test-engine markers).
 //   - `with_style((ImGuiStyleVar.FramePadding, …))` scopes the (0,0) padding
 //     push around the "Don't ask me next time" checkbox.
-//   - Loop-driven selection rows use raw `Selectable(name)` (matching the
-//     `widgets.das` listbox precedent at line 336) — every row reads/writes
-//     a single shared `int` state, no per-row widget state needed.
+//   - Loop-driven selection rows use `selectable_label(STATE_TABLE[i], ...)`
+//     with module-scope indexed tables — per-row ClickState gives telemetry
+//     and path-based addressing.
 
 // =============================================================================
 // Module-scope state (plain non-widget vars + indexed widget tables).
@@ -42,6 +44,8 @@ let private FISH_NAMES <- ["Bream", "Haddock", "Mackerel", "Pollock", "Tilefish"
 // Loop indices for the Toggle/Sub-menu/Stacked popups — one toggle per fish.
 var private POPUPS_TOGGLE_ITEM : table<int; ToggleState>
 var private POPUPS_STACKED_TOGGLE_ITEM : table<int; ToggleState>
+// Selectable rows inside the "Select.." popup body — one ClickState per fish.
+var private POPUPS_FISH_ROW : table<int; ClickState>
 
 // "Context menus" sub-section
 var private POPUPS_CTX1_SELECTED = -1
@@ -49,6 +53,8 @@ var private POPUPS_CTX2_VALUE = 0.5f
 // Example 1: 5 rows, each row has its own popup_context_item (right-click
 // the row to open). Indexed state per row.
 var private POPUPS_CTX1_POPUP : table<int; PopupContextItemState>
+// Per-row selectable_label state for Example 1's index-selection grid.
+var private POPUPS_CTX1_ROW : table<int; ClickState>
 
 // "Modals" sub-section — Stacked combo & color editor
 var private POPUPS_STACKED_COMBO_ITEMS <- ["aaaa", "bbbb", "cccc", "dddd", "eeee"]
@@ -76,22 +82,22 @@ def private PopupsSection() {
     tree_node(POPUPS_POPUPS_SUB,
         (text = "Popups", flags = ImGuiTreeNodeFlags.None)) {
 
-        TextWrapped(
+        text_wrapped((text =
             "When a popup is active, it inhibits interacting with windows " +
-            "that are behind the popup. Clicking outside the popup closes it.")
+            "that are behind the popup. Clicking outside the popup closes it."))
 
         // ----- "Select.." popup -----
         if (button(POPUPS_SELECT_BTN, (text = "Select.."))) {
-            OpenPopup("my_select_popup", ImGuiPopupFlags.None)
+            open_popup(POPUPS_SELECT_POPUP)
         }
         same_line(POPUPS_SL_1)
         let fish_label = (POPUPS_SELECTED_FISH == -1) ? "<None>" : FISH_NAMES[POPUPS_SELECTED_FISH]
-        TextUnformatted(fish_label)
+        text_unformatted((text = fish_label))
         popup(POPUPS_SELECT_POPUP,
               (text = "my_select_popup", flags = ImGuiWindowFlags.None)) {
-            SeparatorText("Aquarium")
+            separator_text("Aquarium")
             for (i in range(length(FISH_NAMES))) {
-                if (Selectable(FISH_NAMES[i])) {
+                if (selectable_label(POPUPS_FISH_ROW[i], FISH_NAMES[i], false)) {
                     POPUPS_SELECTED_FISH = i
                 }
             }
@@ -99,7 +105,7 @@ def private PopupsSection() {
 
         // ----- "Toggle.." popup -----
         if (button(POPUPS_TOGGLE_BTN, (text = "Toggle.."))) {
-            OpenPopup("my_toggle_popup", ImGuiPopupFlags.None)
+            open_popup(POPUPS_TOGGLE_POPUP)
         }
         popup(POPUPS_TOGGLE_POPUP,
               (text = "my_toggle_popup", flags = ImGuiWindowFlags.None)) {
@@ -118,7 +124,7 @@ def private PopupsSection() {
 
             // Stacked popup nested inside the toggle popup.
             if (button(POPUPS_STACKED_BTN, (text = "Stacked Popup"))) {
-                OpenPopup("another popup", ImGuiPopupFlags.None)
+                open_popup(POPUPS_STACKED_POPUP)
             }
             popup(POPUPS_STACKED_POPUP,
                   (text = "another popup", flags = ImGuiWindowFlags.None)) {
@@ -145,7 +151,7 @@ def private PopupsSection() {
 
         // ----- "With a menu.." popup (has a MenuBar inside) -----
         if (button(POPUPS_MENUBAR_BTN, (text = "With a menu.."))) {
-            OpenPopup("my_file_popup", ImGuiPopupFlags.None)
+            open_popup(POPUPS_MENUBAR_POPUP)
         }
         popup(POPUPS_MENUBAR_POPUP,
               (text = "my_file_popup", flags = ImGuiWindowFlags.MenuBar)) {
@@ -184,7 +190,8 @@ def private ContextMenusSection() {
         // ----- Example 1 — popup attached to last-item ID (no str_id) -----
         let ex1_names = fixed_array("Label1", "Label2", "Label3", "Label4", "Label5")
         for (n in range(5)) {
-            if (Selectable(ex1_names[n], POPUPS_CTX1_SELECTED == n)) {
+            if (selectable_label(POPUPS_CTX1_ROW[n], ex1_names[n],
+                                 POPUPS_CTX1_SELECTED == n)) {
                 POPUPS_CTX1_SELECTED = n
             }
             // BeginPopupContextItem() with no str_id binds to the previous
@@ -193,9 +200,9 @@ def private ContextMenusSection() {
             popup_context_item(POPUPS_CTX1_POPUP[n],
                                (str_id = "", flags = ImGuiPopupFlags.MouseButtonRight)) {
                 POPUPS_CTX1_SELECTED = n
-                Text("This a popup for \"{ex1_names[n]}\"!")
-                if (Button("Close")) {
-                    CloseCurrentPopup()
+                text((text = "This a popup for \"{ex1_names[n]}\"!"))
+                if (button((text = "Close"))) {
+                    close_current_popup()
                 }
             }
             set_item_tooltip(POPUPS_CTX1_TIP, (text = "Right-click to open popup"))
@@ -209,28 +216,30 @@ def private ContextMenusSection() {
                     "Text() elements don't have stable identifiers so we need to provide one."))
             }
         }
-        Text("Value = {POPUPS_CTX2_VALUE} <-- (1) right-click this text")
+        text((text = "Value = {POPUPS_CTX2_VALUE} <-- (1) right-click this text"))
         popup_context_item(POPUPS_CTX2_POPUP,
                            (str_id = "my popup",
                             flags = ImGuiPopupFlags.MouseButtonRight)) {
-            if (Selectable("Set to zero")) {
+            if (selectable_label(POPUPS_CTX2_SEL_ZERO, "Set to zero", false)) {
                 POPUPS_CTX2_VALUE = 0.0f
             }
-            if (Selectable("Set to PI")) {
+            if (selectable_label(POPUPS_CTX2_SEL_PI, "Set to PI", false)) {
                 POPUPS_CTX2_VALUE = 3.1415f
             }
             SetNextItemWidth(-3.40282347e38f)
-            DragFloat("##Value", unsafe(addr(POPUPS_CTX2_VALUE)),
-                      0.1f, 0.0f, 0.0f, "%.3f", ImGuiSliderFlags.None)
+            edit_drag_float(unsafe(addr(POPUPS_CTX2_VALUE)),
+                (id = "POPUPS_CTX2_DRAG", text = "##Value", speed = 0.1f))
         }
 
-        // Second text triggers the same popup via OpenPopupOnItemClick.
-        Text("(2) Or right-click this text")
-        OpenPopupOnItemClick("my popup", ImGuiPopupFlags.MouseButtonRight)
+        // Second text triggers the same popup via OpenPopupOnItemClick —
+        // string-id form since popup_context_item is stateless.
+        text((text = "(2) Or right-click this text"))
+        open_popup_on_item_click("my popup")
 
-        // Third trigger: a plain Button that manually opens the same popup.
+        // Third trigger: a plain Button that manually opens the same popup
+        // via the stateless string-id form.
         if (button(POPUPS_CTX2_BTN, (text = "(3) Or click this button"))) {
-            OpenPopup("my popup", ImGuiPopupFlags.None)
+            open_popup("my popup")
         }
 
         // ----- Example 3 — last-item ID popup, dynamic label / stable ID -----
@@ -247,13 +256,14 @@ def private ContextMenusSection() {
         // The editable name lives in the input_text widget's `.value`; we
         // read it for the dynamic label (and the C++ static-char-buffer
         // round-trip falls away — v2 owns the buffer per-widget).
-        Button("Button: {POPUPS_CTX3_INPUT.value}###Button")
+        button(POPUPS_CTX3_BTN,
+               (text = "Button: {POPUPS_CTX3_INPUT.value}###Button"))
         popup_context_item(POPUPS_CTX3_POPUP,
                            (str_id = "", flags = ImGuiPopupFlags.MouseButtonRight)) {
             text("Edit name:")
             input_text(POPUPS_CTX3_INPUT, (text = "##edit", init = "Label1"))
-            if (Button("Close")) {
-                CloseCurrentPopup()
+            if (button((text = "Close"))) {
+                close_current_popup()
             }
         }
         same_line(POPUPS_CTX3_SL)
@@ -269,11 +279,11 @@ def private ModalsSection() {
     tree_node(POPUPS_MODALS_SUB,
         (text = "Modals", flags = ImGuiTreeNodeFlags.None)) {
 
-        TextWrapped("Modal windows are like popups but the user cannot close them by clicking outside.")
+        text_wrapped("Modal windows are like popups but the user cannot close them by clicking outside.")
 
         // ----- "Delete?" modal -----
         if (button(POPUPS_MODAL_DELETE_BTN, (text = "Delete.."))) {
-            OpenPopup("Delete?", ImGuiPopupFlags.None)
+            open_popup(POPUPS_MODAL_DELETE)
         }
         // Center this window when appearing — compute the viewport center
         // from Pos + Size * 0.5 (the C++ helper ImGuiViewport::GetCenter()
@@ -293,19 +303,21 @@ def private ModalsSection() {
             with_style((ImGuiStyleVar.FramePadding, float2(0.0f, 0.0f))) {
                 checkbox(POPUPS_MODAL_DONT_ASK, (text = "Don't ask me next time"))
             }
-            if (Button("OK", float2(120.0f, 0.0f))) {
-                CloseCurrentPopup()
+            if (button(POPUPS_MODAL_DELETE_OK,
+                       (text = "OK", size = float2(120.0f, 0.0f)))) {
+                close_current_popup(POPUPS_MODAL_DELETE)
             }
             SetItemDefaultFocus()
             same_line(POPUPS_MODAL_DELETE_SL)
-            if (Button("Cancel", float2(120.0f, 0.0f))) {
-                CloseCurrentPopup()
+            if (button(POPUPS_MODAL_DELETE_CANCEL,
+                       (text = "Cancel", size = float2(120.0f, 0.0f)))) {
+                close_current_popup(POPUPS_MODAL_DELETE)
             }
         }
 
         // ----- "Stacked 1" / "Stacked 2" modals -----
         if (button(POPUPS_MODAL_STACK1_BTN, (text = "Stacked modals.."))) {
-            OpenPopup("Stacked 1", ImGuiPopupFlags.None)
+            open_popup(POPUPS_MODAL_STACK1)
         }
         popup_modal(POPUPS_MODAL_STACK1,
                     (text = "Stacked 1", closable = false,
@@ -331,7 +343,7 @@ def private ModalsSection() {
                          init = float4(0.4f, 0.7f, 0.0f, 0.5f)))
 
             if (button(POPUPS_MODAL_STACK2_BTN, (text = "Add another modal.."))) {
-                OpenPopup("Stacked 2", ImGuiPopupFlags.None)
+                open_popup(POPUPS_MODAL_STACK2)
             }
             // Stacked 2 — closable=true to demonstrate ImGui's X-button. The
             // C++ passes &unused_open through to BeginPopupModal; v2 wires
@@ -340,13 +352,13 @@ def private ModalsSection() {
                         (text = "Stacked 2", closable = true,
                          flags = ImGuiWindowFlags.None)) {
                 text("Hello from Stacked The Second!")
-                if (Button("Close")) {
-                    CloseCurrentPopup()
+                if (button(POPUPS_MODAL_STACK2_CLOSE, (text = "Close"))) {
+                    close_current_popup(POPUPS_MODAL_STACK2)
                 }
             }
 
-            if (Button("Close")) {
-                CloseCurrentPopup()
+            if (button(POPUPS_MODAL_STACK1_CLOSE, (text = "Close"))) {
+                close_current_popup(POPUPS_MODAL_STACK1)
             }
         }
     }
@@ -360,7 +372,7 @@ def private MenusInRegularWindowSection() {
     tree_node(POPUPS_MENUS_IN_WIN_SUB,
         (text = "Menus inside a regular window", flags = ImGuiTreeNodeFlags.None)) {
 
-        TextWrapped("Below we are testing adding menu items to a regular window. It's rather unusual but should work!")
+        text_wrapped("Below we are testing adding menu items to a regular window. It's rather unusual but should work!")
         separator(POPUPS_MENUS_IN_WIN_SEP)
 
         menu_label(POPUPS_MENUS_IN_WIN_ITEM,

--- a/examples/tutorial/driving_outside.das
+++ b/examples/tutorial/driving_outside.das
@@ -18,6 +18,7 @@ require imgui/imgui_containers_builtin
 require imgui/imgui_visual_aids
 
 let PRESETS : array<string> <- ["Calm", "Mellow", "Active", "Frantic"]
+var PRESET_ROW : table<int; ClickState>
 
 // =============================================================================
 // TUTORIAL: driving_outside — every boost widget is also a JSON endpoint.
@@ -109,9 +110,7 @@ def update() {
                               flags = ImGuiComboFlags.None)) {
             for (i in range(length(PRESETS))) {
                 let is_sel = (i == PRESET.value)
-                if (Selectable(PRESETS[i], is_sel,
-                               ImGuiSelectableFlags.None,
-                               float2(0.0f, 0.0f))) {
+                if (selectable_label(PRESET_ROW[i], PRESETS[i], is_sel)) {
                     PRESET.value = i
                 }
             }

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -295,6 +295,49 @@ def popup_modal(var state : PopupState; text : string; closable : bool;
     open_close_finalize(widget_ident, "popup_modal", state)
 }
 
+// ===== Popup control (trigger paired with popup / popup_modal containers) =====
+
+def open_popup(var state : PopupState) : void {
+    //! Queue `OpenPopup(state.text)` for the next visit of the paired
+    //! `popup` / `popup_modal` container — the container reads
+    //! `pending_open` before `BeginPopup`, so the linkage button-click →
+    //! popup is observable as a state mutation (visible to live/mouse-cards).
+    state.pending_open = true
+}
+
+def open_popup(str_id : string;
+               flags : ImGuiPopupFlags = ImGuiPopupFlags.None) : void {
+    //! String-id form for stateless popups (paired with `popup_context_item`).
+    //! No telemetry — open-state lives in ImGui internals.
+    OpenPopup(str_id, flags)
+}
+
+def open_popup_on_item_click(str_id : string;
+                             flags : ImGuiPopupFlags = ImGuiPopupFlags.MouseButtonRight) : void {
+    //! Right-click on the previously-submitted item opens `str_id` popup.
+    //! Stateless trigger paired with `popup_context_item`.
+    OpenPopupOnItemClick(str_id, flags)
+}
+
+def close_current_popup(var state : PopupState) : void {
+    //! Close the active popup. Sets `pending_close` for state-transition
+    //! telemetry AND calls `CloseCurrentPopup()` directly so the close
+    //! takes effect on the current frame (matches raw-call semantics).
+    state.pending_close = true
+    CloseCurrentPopup()
+}
+
+def close_current_popup() : void {
+    //! No-state form for body-internal use where a `PopupState` ident isn't
+    //! in scope (e.g., inside `popup_context_item`, which is stateless).
+    CloseCurrentPopup()
+}
+
+def is_popup_open(state : PopupState) : bool {
+    //! True while the paired popup container is open this frame.
+    return state.open
+}
+
 // ===== Tab family =====
 
 [container]

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -72,11 +72,6 @@ let private ALLOWED_IMGUI : table<string> <- {
     // user-controlled. v2 drag_drop_source/_target containers gate the body;
     // these calls are the payload exchange inside.
     "SetDragDropPayload", "AcceptDragDropPayload", "GetDragDropPayload",
-    // Raw Selectable form (label, is_selected, flags, size) — used inside
-    // list_box bodies where the row-selection model is user-controlled.
-    // The v2 `selectable(STATE_IDENT, ...)` widget is for boolean-toggle
-    // selectables, not for radio-style index selection.
-    "Selectable",
     // Viewport queries.
     "GetMainViewport",
     // Docking internals — DockBuilder* is cherry-picked from imgui_internal.h

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -145,8 +145,9 @@ def private edit_finalize(widget_ident : string; kind : string; var ptr : auto(T
 // ===== Triggers (click family) =====
 
 [widget]
-def button(var state : ClickState; text : string) : bool {
-    let im_clicked = Button(text, ImVec2(0.0f, 0.0f))
+def button(var state : ClickState; text : string;
+           size : float2 = float2(0.0f, 0.0f)) : bool {
+    let im_clicked = Button(text, ImVec2(size.x, size.y))
     var clicked = im_clicked
     if (state.pending_click) {
         state.pending_click = false


### PR DESCRIPTION
## Summary

Tightens the `_no_imgui_legacy` lint by closing two soft spots PR #29 left:

- **`Selectable` was allow-listed**, but `selectable_label(IDENT, text, selected)` (commit 81b18d2) already covers the radio-style index-selection case with per-row ClickState. Removed from allow-list; swept 5 consumer sites.
- **`OpenPopup` / `CloseCurrentPopup` / `IsPopupOpen` had no boost wrapper** — the only options were "raw" or "allow-list", both invisible to live / mouse-cards / @live. PopupState already has `pending_open` / `pending_close` fields and the container consumes them before `BeginPopup`, so plain `def` functions that flip those fields give explicit boost API with zero extra plumbing.

Also: `button` widget gains a `size : float2 = float2(0,0)` default arg (covers `Button("OK", float2(120,0))` and friends in modals).

## New boost surface (`widgets/imgui_containers_builtin.das`)

```
def open_popup(var state : PopupState) : void
def open_popup(str_id : string; flags : ImGuiPopupFlags = ImGuiPopupFlags.None) : void
def open_popup_on_item_click(str_id : string; flags = ImGuiPopupFlags.MouseButtonRight) : void
def close_current_popup(var state : PopupState) : void
def close_current_popup() : void
def is_popup_open(state : PopupState) : bool
```

Plain `def` — not `[widget]` — because the popup container auto-emits the PopupState global; the control fns reference it through the regular function-arg mechanism. String-id overloads handle the stateless `popup_context_item` use case.

## Sweep

`examples/imgui_demo/popups.das` fully cleaned under `_no_imgui_legacy = true`:

| Raw call | Boost replacement |
|---|---|
| `OpenPopup("...", ...)` ×9 | `open_popup(STATE)` or `open_popup(str_id)` |
| `OpenPopupOnItemClick(...)` ×1 | `open_popup_on_item_click(str_id)` |
| `CloseCurrentPopup()` ×8 | `close_current_popup(STATE)` or `close_current_popup()` |
| `Selectable(...)` ×5 | `selectable_label(TABLE[i], ...)` + module-scope `table<int; ClickState>` |
| `Text` / `TextWrapped` / `TextUnformatted` / `SeparatorText` ×9 | text family (positional / named-tuple per shape) |
| `Button(...)` ×6 | `button` widget, two with new `size=` arg |
| `DragFloat(...)` ×1 | `edit_drag_float` against `unsafe(addr(VAR))` |

Regression sweep for the Selectable removal — four files that relied on the (now removed) allow-list entry, each gains a module-scope ClickState table + `selectable_label` call:
- `examples/features/list_box.das`
- `examples/features/inputs_choice.das`
- `examples/features/containers_overlay.das` (palette + tasks)
- `examples/tutorial/driving_outside.das`

## Out of scope (deferred)

Other 4 imgui_demo files (inputs / columns / layout) still have raw survivors. Each needs its own wrapper additions before a sweep:
- `inputs.das` — `with_tab_stop`, `color_button` widget, drawlist API, several allow-list extensions (IsMousePosValid, GetMouseCursor/SetMouseCursor, SetNextFrameWantCapture*)
- `columns.das` — dynamic-columns container, `list_clipper` scope wrapper
- `layout.das` — tables container surface, `CollapsingHeader` widget

Plus ~10 raw-call residuals on `widgets/tables/imgui_demo/style_editor`.

## Test plan

- [ ] `mcp compile_check` clean on `examples/imgui_demo/main.das` + the 4 affected helper files
- [ ] `mcp lint` clean on `widgets/imgui_containers_builtin.das`, `widgets/imgui_widgets_builtin.das`, `widgets/imgui_lint.das`, `examples/imgui_demo/popups.das`
- [ ] `mcp format_file` reports `already_formatted` on all 8 touched files
- [ ] Lint contract tests pass (`test_imgui_lint_off`, `test_imgui_lint_allow`)
- [ ] Interactive: `daslang.exe modules/dasImgui/examples/imgui_demo/main.das` → open the Popups section, exercise Select / Toggle / Stacked / Menu / Modals; right-click Example 1/2 rows; click "(3) Or click this button" and the OK/Cancel/Close buttons. Verify popup open/close behavior is unchanged from raw OpenPopup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)