### PR TITLE
imgui_demo: Example Console port + raw-sweep follow-ups + CI scaffolding

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -96,6 +96,7 @@ class ImguiGen : CppGenBind {
         }
         local_type_names <- {
             "ImGuiTableColumnSortSpecs" => true,
+            "ImGuiTextFilter" => true,
             "Config" => true}
         imgui_skip_func <- {
             "ImGui::TextUnformatted" => true,

--- a/doc/source/stdlib/external_types.rst
+++ b/doc/source/stdlib/external_types.rst
@@ -51,3 +51,15 @@ through the live-reload host's window lifecycle (creation, swap, event drain)
 and forwarded into ImGui's GLFW backend. See the
 `GLFW documentation <https://www.glfw.org/docs/latest/group__window.html>`_
 for the handle's C-side semantics.
+
+.. _handle-imgui-imguitextfilter:
+
+``imgui::ImGuiTextFilter``
+==========================
+
+C++ helper for parsed comma-separated include/exclude filter expressions
+(``-prefix`` excludes), with an inline editor renderable via ``Draw(label,
+width)`` and a ``PassFilter(text)`` predicate. Held inline as a value field
+of ``TextFilterState`` backing the ``text_filter`` boost widget. See
+`ImGuiTextFilter in imgui.h <https://github.com/ocornut/imgui/blob/master/imgui.h>`_
+for the upstream definition.

--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -234,7 +234,7 @@ def ShowExampleAppConsole() {
         // selection sets CONSOLE_REQUEST_CLOSE; the caller polls via
         // `take_close_request()` after this function returns and clears
         // its own visibility toggle.
-        popup_context_item(CONSOLE_TITLE_POPUP, (str_id = "", flags = ImGuiPopupFlags.None)) {
+        popup_context_item(CONSOLE_TITLE_POPUP, (str_id = "", flags = ImGuiPopupFlags.MouseButtonRight)) {
             if (menu_item(CONSOLE_CLOSE_MENU, (text = "Close Console"))) {
                 CONSOLE_REQUEST_CLOSE = true
             }
@@ -289,7 +289,7 @@ def ShowExampleAppConsole() {
                                       window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
 
             popup_context_window(CONSOLE_SCROLL_CTX_MENU,
-                                  (str_id = "", flags = ImGuiPopupFlags.MouseButtonRight)) {
+                                  (str_id = "##ConsoleScrollMenu", flags = ImGuiPopupFlags.MouseButtonRight)) {
                 if (selectable_label(CONSOLE_CTX_CLEAR, "Clear", false)) {
                     clear_log()
                 }

--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -52,6 +52,23 @@ var private CONSOLE_ITEM_TEXT : table<int; NarrativeState>
 // One-shot init: seeds the welcome line on first frame after module load.
 var private CONSOLE_SEEDED = false
 
+// Set by the "Close Console" context-menu entry (right-click title bar);
+// the caller polls via `take_close_request()` after each frame and flips
+// its own visibility toggle. Kept private so the consume-and-clear API is
+// the only access path — direct reads from outside would race with the
+// reset on the next call.
+var private CONSOLE_REQUEST_CLOSE = false
+
+def public take_close_request() : bool {
+    //! Consume-and-clear: returns `true` once after the user picks
+    //! "Close Console" from the title-bar context menu, then resets.
+    //! Caller (`imgui_demo.das` dispatcher) gates `SHOW_APP_CONSOLE`
+    //! off the return value.
+    let r = CONSOLE_REQUEST_CLOSE
+    CONSOLE_REQUEST_CLOSE = false
+    return r
+}
+
 // =============================================================================
 // Log / command helpers
 // =============================================================================
@@ -213,10 +230,14 @@ def ShowExampleAppConsole() {
     window(CONSOLE_WIN, (text = "Example: Console", closable = false,
                           flags = ImGuiWindowFlags.None)) {
 
-        // Right-click on the title bar opens a "Close Console" menu.
-        // (No-op for now — gating window visibility is the caller's job.)
+        // Right-click on the title bar opens a "Close Console" menu. The
+        // selection sets CONSOLE_REQUEST_CLOSE; the caller polls via
+        // `take_close_request()` after this function returns and clears
+        // its own visibility toggle.
         popup_context_item(CONSOLE_TITLE_POPUP, (str_id = "", flags = ImGuiPopupFlags.None)) {
-            menu_item(CONSOLE_CLOSE_MENU, (text = "Close Console"))
+            if (menu_item(CONSOLE_CLOSE_MENU, (text = "Close Console"))) {
+                CONSOLE_REQUEST_CLOSE = true
+            }
         }
 
         text_wrapped((text = "This example implements a console with basic " +

--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -79,6 +79,10 @@ def private add_log(line : string) {
 
 def private clear_log() {
     CONSOLE_ITEMS |> clear()
+    // Release per-row text-widget state along with the lines themselves —
+    // otherwise the indexed table retains entries up to past high-water
+    // marks (bounded but visible in snapshots after a Clear).
+    CONSOLE_ITEM_TEXT |> clear()
 }
 
 def private exec_command(cmd : string) {

--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -1,11 +1,341 @@
 options gen2
 options indenting = 4
+options _no_imgui_legacy = true
 
 module app_console
 
 require imgui
+require imgui/imgui_lint
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_scope_builtin
+require imgui/imgui_style_builtin
+require strings
+require math
 
-// Mirrors imgui_demo.cpp:7116-7608 — static void ShowExampleAppConsole(bool* p_open).
+// Mirrors imgui_demo.cpp:7116-7477 — static void ShowExampleAppConsole(bool* p_open).
+//
+// The C++ original uses a C++ class (`ExampleAppConsole`) that holds Items,
+// History, Commands, Filter, AutoScroll/ScrollToBottom flags and an
+// InputText callback driving TAB completion + arrow-key history. This port
+// keeps the same shape:
+//   - Module-scope `var private` globals replace the per-instance fields
+//     (they survive live-reload via the in-memory context).
+//   - `[widget]`/`[container]` state structs are auto-emitted from the
+//     uppercase IDENT args; loop-keyed log lines use an indexed
+//     `table<int; NarrativeState>`.
+//   - TAB-completion + Up/Down history go through the new
+//     `input_text_callback` boost wrapper (callback fires synchronously
+//     inside ImGui's InputText, so the lambda's capture is safe).
+//   - Comma-separated include/exclude filter goes through the
+//     `text_filter` / `passes_filter` boost wrapper over the bound C++
+//     ImGuiTextFilter.
+
+// =============================================================================
+// Module-scope persistent state (cross-frame, survives live-reload)
+// =============================================================================
+
+var private CONSOLE_ITEMS : array<string>           // log lines
+var private CONSOLE_HISTORY : array<string>         // command history (push_back order)
+var private CONSOLE_HIST_POS = -1                   // -1 = new line; 0..N-1 browsing
+var private CONSOLE_AUTO_SCROLL = true              // tail-follow toggle
+var private CONSOLE_SCROLL_TO_BOTTOM = false        // one-shot scroll request
+
+let private CONSOLE_COMMANDS <- [
+    "HELP", "HISTORY", "CLEAR", "CLASSIFY"          // CLASSIFY = C+TAB ambiguous-completion demo
+]
+
+// Indexed widget tables — [widget] auto-emit doesn't synthesize table globals
+// for loop-keyed forms; they must be declared at module scope.
+var private CONSOLE_ITEM_TEXT : table<int; NarrativeState>
+
+// One-shot init: seeds the welcome line on first frame after module load.
+var private CONSOLE_SEEDED = false
+
+// =============================================================================
+// Log / command helpers
+// =============================================================================
+
+def private add_log(line : string) {
+    CONSOLE_ITEMS |> push_clone(line)
+}
+
+def private clear_log() {
+    CONSOLE_ITEMS |> clear()
+}
+
+def private exec_command(cmd : string) {
+    add_log("# {cmd}")
+
+    // Dedupe: drop any prior occurrence so the latest entry is at the tail.
+    CONSOLE_HIST_POS = -1
+    let upper_cmd = to_upper(cmd)
+    for (i in range(length(CONSOLE_HISTORY))) {
+        if (to_upper(CONSOLE_HISTORY[i]) == upper_cmd) {
+            CONSOLE_HISTORY |> erase(i)
+            break
+        }
+    }
+    CONSOLE_HISTORY |> push_clone(cmd)
+
+    if (upper_cmd == "CLEAR") {
+        clear_log()
+    } elif (upper_cmd == "HELP") {
+        add_log("Commands:")
+        for (c in CONSOLE_COMMANDS) {
+            add_log("- {c}")
+        }
+    } elif (upper_cmd == "HISTORY") {
+        let first = max(0, length(CONSOLE_HISTORY) - 10)
+        for (i in range(first, length(CONSOLE_HISTORY))) {
+            add_log("{i}: {CONSOLE_HISTORY[i]}")
+        }
+    } else {
+        add_log("Unknown command: '{cmd}'")
+    }
+
+    CONSOLE_SCROLL_TO_BOTTOM = true     // always tail on user input
+}
+
+// =============================================================================
+// InputText callback — TAB completion + Up/Down history
+// =============================================================================
+
+def private is_word_sep(c : int) : bool {
+    return c == int(' ') || c == int('\t') || c == int(',') || c == int(';')
+}
+
+def private text_edit_callback(var data : ImGuiInputTextCallbackData) : int {
+    if (data.EventFlag == ImGuiInputTextFlags.CallbackCompletion) {
+        // ----- TAB completion -----
+        // Snapshot the buffer as a daslang string (Buf is char*, ImGui keeps
+        // it valid for the callback's lifetime).
+        let buf_str = clone_string(unsafe(reinterpret<string>(data.Buf)))
+        let word_end = data.CursorPos
+        var word_start = word_end
+        peek_data(buf_str) $(arr) {
+            while (word_start > 0 && !is_word_sep(int(arr[word_start - 1]))) {
+                word_start--
+            }
+        }
+        let prefix = slice(buf_str, word_start, word_end)
+        let upper_prefix = to_upper(prefix)
+        let plen = word_end - word_start
+
+        var candidates : array<string>
+        for (c in CONSOLE_COMMANDS) {
+            if (length(c) >= plen && to_upper(slice(c, 0, plen)) == upper_prefix) {
+                candidates |> push_clone(c)
+            }
+        }
+
+        if (length(candidates) == 0) {
+            add_log("No match for \"{prefix}\"!")
+        } elif (length(candidates) == 1) {
+            // Single match — replace the partial word with the full command
+            // (preserves canonical casing) and append a trailing space.
+            data |> DeleteChars(word_start, plen)
+            InsertChars(data, data.CursorPos, candidates[0])
+            InsertChars(data, data.CursorPos, " ")
+        } else {
+            // Multiple matches — extend by the longest common prefix
+            // (case-insensitive), then list all candidates.
+            var match_len = plen
+            var growing = true
+            while (growing) {
+                if (match_len >= length(candidates[0])) {
+                    growing = false
+                } else {
+                    let target = to_upper(slice(candidates[0], match_len, match_len + 1))
+                    for (cand in candidates) {
+                        if (match_len >= length(cand)) {
+                            growing = false
+                            break
+                        }
+                        if (to_upper(slice(cand, match_len, match_len + 1)) != target) {
+                            growing = false
+                            break
+                        }
+                    }
+                    if (growing) {
+                        match_len++
+                    }
+                }
+            }
+            if (match_len > plen) {
+                data |> DeleteChars(word_start, plen)
+                InsertChars(data, data.CursorPos, slice(candidates[0], 0, match_len))
+            }
+            add_log("Possible matches:")
+            for (c in candidates) {
+                add_log("- {c}")
+            }
+        }
+        delete candidates
+    } elif (data.EventFlag == ImGuiInputTextFlags.CallbackHistory) {
+        // ----- Up/Down history -----
+        let prev_pos = CONSOLE_HIST_POS
+        if (data.EventKey == ImGuiKey.UpArrow) {
+            if (CONSOLE_HIST_POS == -1) {
+                CONSOLE_HIST_POS = length(CONSOLE_HISTORY) - 1
+            } elif (CONSOLE_HIST_POS > 0) {
+                CONSOLE_HIST_POS--
+            }
+        } elif (data.EventKey == ImGuiKey.DownArrow) {
+            if (CONSOLE_HIST_POS != -1) {
+                CONSOLE_HIST_POS++
+                if (CONSOLE_HIST_POS >= length(CONSOLE_HISTORY)) {
+                    CONSOLE_HIST_POS = -1
+                }
+            }
+        }
+        if (prev_pos != CONSOLE_HIST_POS) {
+            let history_str = CONSOLE_HIST_POS >= 0 ? CONSOLE_HISTORY[CONSOLE_HIST_POS] : ""
+            data |> DeleteChars(0, data.BufTextLen)
+            InsertChars(data, 0, history_str)
+        }
+    }
+    return 0
+}
+
+// =============================================================================
+// ShowExampleAppConsole — main panel
+// =============================================================================
+
 def ShowExampleAppConsole() {
-    // TODO: port section (imgui_demo.cpp:7116-7608)
+    if (!CONSOLE_SEEDED) {
+        add_log("Welcome to Dear ImGui!")
+        CONSOLE_SEEDED = true
+    }
+
+    // SetNextWindowSize is set inside the window container's default if no
+    // size is in flight — for now, ImGui auto-sizes; user can drag-resize.
+    window(CONSOLE_WIN, (text = "Example: Console", closable = false,
+                          flags = ImGuiWindowFlags.None)) {
+
+        // Right-click on the title bar opens a "Close Console" menu.
+        // (No-op for now — gating window visibility is the caller's job.)
+        popup_context_item(CONSOLE_TITLE_POPUP, (str_id = "", flags = ImGuiPopupFlags.None)) {
+            menu_item(CONSOLE_CLOSE_MENU, (text = "Close Console"))
+        }
+
+        text_wrapped((text = "This example implements a console with basic " +
+                              "coloring, completion (TAB key) and history " +
+                              "(Up/Down keys). A more elaborate implementation " +
+                              "may want to store entries along with extra data " +
+                              "such as timestamp, emitter, etc."))
+        text_wrapped((text = "Enter 'HELP' for help."))
+
+        if (small_button(CONSOLE_BTN_DBG, (text = "Add Debug Text"))) {
+            add_log("{length(CONSOLE_ITEMS)} some text")
+            add_log("some more text")
+            add_log("display very important message here!")
+        }
+        same_line(CONSOLE_SL_1)
+        if (small_button(CONSOLE_BTN_ERR, (text = "Add Debug Error"))) {
+            add_log("[error] something went wrong")
+        }
+        same_line(CONSOLE_SL_2)
+        if (small_button(CONSOLE_BTN_CLEAR, (text = "Clear"))) {
+            clear_log()
+        }
+        same_line(CONSOLE_SL_3)
+        let copy_to_clipboard = small_button(CONSOLE_BTN_COPY, (text = "Copy"))
+
+        separator(CONSOLE_SEP_1)
+
+        // Options popup body — opened on demand by the "Options" button.
+        popup(CONSOLE_OPTS_POPUP, (text = "Options", flags = ImGuiWindowFlags.None)) {
+            if (checkbox(CONSOLE_AUTOSCROLL_CHECK, (text = "Auto-scroll",
+                                                     init = CONSOLE_AUTO_SCROLL))) {
+                CONSOLE_AUTO_SCROLL = CONSOLE_AUTOSCROLL_CHECK.value
+            }
+        }
+        if (button(CONSOLE_BTN_OPTS, (text = "Options"))) {
+            open_popup(CONSOLE_OPTS_POPUP)
+        }
+        same_line(CONSOLE_SL_4)
+        text_filter(CONSOLE_FILTER, (text = "Filter (\"incl,-excl\") (\"error\")",
+                                      width = 180.0f))
+
+        separator(CONSOLE_SEP_2)
+
+        // Reserve enough left-over height for 1 separator + 1 input text.
+        let footer_h = GetStyle().ItemSpacing.y + GetFrameHeightWithSpacing()
+        child(CONSOLE_SCROLL_CHILD, (text = "ScrollingRegion",
+                                      size = float2(0.0f, -footer_h),
+                                      child_flags = ImGuiChildFlags.None,
+                                      window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+
+            popup_context_window(CONSOLE_SCROLL_CTX_MENU,
+                                  (str_id = "", flags = ImGuiPopupFlags.MouseButtonRight)) {
+                if (selectable_label(CONSOLE_CTX_CLEAR, "Clear", false)) {
+                    clear_log()
+                }
+            }
+
+            with_style((ImGuiStyleVar.ItemSpacing, float2(4.0f, 1.0f))) {
+                if (copy_to_clipboard) log_to_clipboard()
+                for (i in range(length(CONSOLE_ITEMS))) {
+                    let line = CONSOLE_ITEMS[i]
+                    if (!passes_filter(CONSOLE_FILTER, line)) continue
+                    // Per-line color: red for [error], gold for # echo prefix.
+                    if (starts_with(line, "[error]")) {
+                        with_style((ImGuiCol.Text, 0xFF6666FFu)) {
+                            text(CONSOLE_ITEM_TEXT[i], (text = line))
+                        }
+                    } elif (starts_with(line, "# ")) {
+                        with_style((ImGuiCol.Text, 0xFF99CCFFu)) {
+                            text(CONSOLE_ITEM_TEXT[i], (text = line))
+                        }
+                    } else {
+                        text(CONSOLE_ITEM_TEXT[i], (text = line))
+                    }
+                }
+                if (copy_to_clipboard) log_finish()
+            }
+
+            // Auto-tail: scroll to bottom if we were already at the bottom
+            // when this frame started, or if a command was just executed.
+            if (CONSOLE_SCROLL_TO_BOTTOM ||
+                (CONSOLE_AUTO_SCROLL && CONSOLE_SCROLL_CHILD.scroll.y >=
+                                         CONSOLE_SCROLL_CHILD.scroll_max.y)) {
+                set_scroll_here_y(1.0f)
+            }
+            CONSOLE_SCROLL_TO_BOTTOM = false
+        }
+
+        separator(CONSOLE_SEP_3)
+
+        // Command line.
+        var reclaim_focus = false
+        let flags = (ImGuiInputTextFlags.EnterReturnsTrue |
+                     ImGuiInputTextFlags.EscapeClearsAll |
+                     ImGuiInputTextFlags.CallbackCompletion |
+                     ImGuiInputTextFlags.CallbackHistory)
+        if (input_text_callback(CONSOLE_INPUT, "Input", flags,
+                                 @(var data : ImGuiInputTextCallbackData) =>
+                                    text_edit_callback(data))) {
+            let cmd_in = CONSOLE_INPUT.value
+            // Trim trailing whitespace.
+            var end = length(cmd_in)
+            peek_data(cmd_in) $(arr) {
+                while (end > 0 && (arr[end - 1] == 0x20u8 || arr[end - 1] == 0x09u8)) {
+                    end--
+                }
+            }
+            let cmd = slice(cmd_in, 0, end)
+            if (length(cmd) > 0) {
+                exec_command(cmd)
+            }
+            // Clear the input buffer for the next entry.
+            CONSOLE_INPUT.pending_value := ""
+            CONSOLE_INPUT.has_pending = true
+            reclaim_focus = true
+        }
+        set_item_default_focus()
+        if (reclaim_focus) {
+            set_keyboard_focus_here(-1)
+        }
+    }
 }

--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -110,7 +110,7 @@ def private text_edit_callback(var data : ImGuiInputTextCallbackData) : int {
         // ----- TAB completion -----
         // Snapshot the buffer as a daslang string (Buf is char*, ImGui keeps
         // it valid for the callback's lifetime).
-        let buf_str = clone_string(unsafe(reinterpret<string>(data.Buf)))
+        let buf_str = clone_string(data.Buf)
         let word_end = data.CursorPos
         var word_start = word_end
         peek_data(buf_str) $(arr) {
@@ -129,7 +129,7 @@ def private text_edit_callback(var data : ImGuiInputTextCallbackData) : int {
             }
         }
 
-        if (length(candidates) == 0) {
+        if (empty(candidates)) {
             add_log("No match for \"{prefix}\"!")
         } elif (length(candidates) == 1) {
             // Single match — replace the partial word with the full command
@@ -325,7 +325,7 @@ def ShowExampleAppConsole() {
                 }
             }
             let cmd = slice(cmd_in, 0, end)
-            if (length(cmd) > 0) {
+            if (!empty(cmd)) {
                 exec_command(cmd)
             }
             // Clear the input buffer for the next entry.

--- a/examples/imgui_demo/imgui_demo.das
+++ b/examples/imgui_demo/imgui_demo.das
@@ -61,5 +61,11 @@ def RunImGuiDemo() {
     // Example-app windows live OUTSIDE the demo window — each opens its own.
     if (SHOW_APP_CONSOLE) {
         ShowExampleAppConsole()
+        // Console's "Close Console" title-bar context menu sets an internal
+        // flag; consume it here to flip our visibility toggle off so the
+        // window goes away on the next frame.
+        if (take_close_request()) {
+            SHOW_APP_CONSOLE = false
+        }
     }
 }

--- a/examples/imgui_demo/imgui_demo.das
+++ b/examples/imgui_demo/imgui_demo.das
@@ -7,6 +7,7 @@ require imgui public
 require imgui/imgui_widgets_builtin public
 require imgui/imgui_containers_builtin public
 require imgui/imgui_boost_v2 public
+require daslib/safe_addr
 
 require widgets public
 require layout public
@@ -25,6 +26,12 @@ require app_dockspace public
 require app_documents public
 require app_small public
 
+// Module-scope toggle for the Example App: Console panel. A full Examples
+// menu wiring (matching imgui_demo.cpp's `ImGui::ShowDemoWindow` Examples
+// submenu) waits for the other example-app stubs to be ported; for now
+// the Console gets a single checkbox at the bottom of the demo window.
+var private SHOW_APP_CONSOLE = false
+
 // Mirrors imgui_demo.cpp:275-6455 — void ImGui::ShowDemoWindow(bool* p_open).
 // Renamed to avoid collision with ImGui's built-in ShowDemoWindow binding.
 // Phase 2a skeleton: opens the demo window and calls the six Demo-Window
@@ -33,9 +40,10 @@ require app_small public
 def RunImGuiDemo() {
     window(DEMO_WIN, (text = "Dear ImGui Demo (daslang port — Phase 2a skeleton)",
                        closable = false, flags = ImGuiWindowFlags.None)) {
-        Text("Phase 2a skeleton — 0/24 SECTION blocks ported.")
+        Text("Phase 2a skeleton — 0/24 SECTION blocks ported + 1 example app (Console).")
         Text("Section stubs render below; example apps and meta windows are")
-        Text("not yet wired into the menu.")
+        Text("not yet wired into the menu — temporary checkboxes at the bottom")
+        Text("toggle individual app windows.")
         Separator()
 
         ShowDemoWindowWidgets()
@@ -44,5 +52,14 @@ def RunImGuiDemo() {
         ShowDemoWindowTables()
         ShowDemoWindowColumns()
         ShowDemoWindowInputs()
+
+        Separator()
+        edit_checkbox(safe_addr(SHOW_APP_CONSOLE),
+                      (id = "EXAMPLES_SHOW_CONSOLE", text = "Show Example: Console"))
+    }
+
+    // Example-app windows live OUTSIDE the demo window — each opens its own.
+    if (SHOW_APP_CONSOLE) {
+        ShowExampleAppConsole()
     }
 }

--- a/src/dasIMGUI.struct.class.inc
+++ b/src/dasIMGUI.struct.class.inc
@@ -308,6 +308,17 @@ struct ImGuiTextFilter_ImGuiTextRange_GeneratedAnnotation : ManagedStructureAnno
 
 // from imgui.h:2482:8
 struct ImGuiTextFilter_GeneratedAnnotation : ManagedStructureAnnotation<ImGuiTextFilter> {
+	// MANUAL PATCH: marks ImGuiTextFilter as locally-allocatable + globally-
+	// initializable so daslang state structs can hold one inline. cbind_boost
+	// only emits isLocal + canBePlacedInContainer for `local_type_names`
+	// entries (see bind_imgui.das); the trivial-ctor + copy overrides below
+	// have to be re-applied after every regen. ImGuiTextFilter is bitwise
+	// zero-init-safe (empty InputBuf, empty Filters ImVector, CountGrep=0)
+	// and its copy ctor is well-defined.
+	virtual bool isLocal() const override { return true; }
+	virtual bool canBePlacedInContainer() const override { return true; }
+	virtual bool hasNonTrivialCtor() const override { return false; }
+	virtual bool canCopy() const override { return true; }
 	ImGuiTextFilter_GeneratedAnnotation(ModuleLibrary & ml) : ManagedStructureAnnotation ("ImGuiTextFilter", ml, "ImGuiTextFilter") {
 	}
 	void init () {

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -13,6 +13,7 @@ require daslib/json public
 require daslib/json_boost public
 require daslib/coroutines public
 require daslib/async_boost
+require daslib/archive
 require daslib/result public
 require math
 require strings
@@ -525,6 +526,20 @@ struct TextFilterState {
     //! hand-bound `PassFilter(filter, text)` standalone helper.
     @safe_when_uninitialized @optional value : string  //! mirrored InputBuf text for snapshot/telemetry
     @safe_when_uninitialized filter : ImGuiTextFilter
+}
+
+// JV + archive::serialize overrides for TextFilterState. The bound
+// `ImGuiTextFilter` has no daslang-side JV or serialize binding (and no safe
+// `delete`), so the generic field-walking JV / archive::serialize generics
+// would fail to instantiate. The user-visible state is just the editor text
+// mirror; the bound filter regenerates from `value` on first frame after
+// reload via the widget body.
+def public JV(value : TextFilterState) : JsonValue? {
+    return JV((value = value.value))
+}
+
+def public serialize(var arch : Archive; var value : TextFilterState) {
+    arch |> _::serialize(value.value)
 }
 
 struct DragDropSourceState {

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -516,6 +516,17 @@ struct PopupContextWindowState {
     @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
 }
 
+struct TextFilterState {
+    //! Backs `text_filter`. Holds the bound C++ `ImGuiTextFilter` value
+    //! inline — zero-init is safe (empty `InputBuf`, empty `Filters`
+    //! `ImVector`, `CountGrep = 0`), so no explicit ctor call is needed.
+    //! `text_filter` renders the inline InputText editor via the bound
+    //! `Draw()` method; `passes_filter(state, line)` delegates to the
+    //! hand-bound `PassFilter(filter, text)` standalone helper.
+    @safe_when_uninitialized @optional value : string  //! mirrored InputBuf text for snapshot/telemetry
+    @safe_when_uninitialized filter : ImGuiTextFilter
+}
+
 struct DragDropSourceState {
     //! Backs `drag_drop_source`. Drag activation lives entirely in ImGui's
     //! internal drag-drop state machine; body runs only on active drag.

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -510,6 +510,12 @@ struct PopupContextItemState {
     @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
 }
 
+struct PopupContextWindowState {
+    //! Backs `popup_context_window`. Right-click anywhere in the enclosing
+    //! window opens the popup; ImGui drives open/close internally.
+    @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
+}
+
 struct DragDropSourceState {
     //! Backs `drag_drop_source`. Drag activation lives entirely in ImGui's
     //! internal drag-drop state machine; body runs only on active drag.

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -266,8 +266,10 @@ def popup_context_window(var state : PopupContextWindowState; str_id : string;
                          flags : ImGuiPopupFlags; blk : block) {
     //! `BeginPopupContextWindow(str_id, flags)` / `EndPopup()` — right-click
     //! anywhere inside the enclosing window opens a context popup. ImGui
-    //! drives open/close internally; body runs only while open. Empty
-    //! `str_id` falls back to ImGui's parent-window stack id.
+    //! drives open/close internally; body runs only while open. `str_id`
+    //! is the popup's stack id — pass a unique non-empty string per
+    //! consumer (the C-level `"##ContextWindow"` default fires only on a
+    //! NULL `const char*` which daslang's string binding doesn't expose).
     let im_open = BeginPopupContextWindow(str_id, flags)
     if (im_open) {
         invoke(blk)

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -262,6 +262,21 @@ def popup_context_item(var state : PopupContextItemState; str_id : string;
 }
 
 [container]
+def popup_context_window(var state : PopupContextWindowState; str_id : string;
+                         flags : ImGuiPopupFlags; blk : block) {
+    //! `BeginPopupContextWindow(str_id, flags)` / `EndPopup()` — right-click
+    //! anywhere inside the enclosing window opens a context popup. ImGui
+    //! drives open/close internally; body runs only while open. Empty
+    //! `str_id` falls back to ImGui's parent-window stack id.
+    let im_open = BeginPopupContextWindow(str_id, flags)
+    if (im_open) {
+        invoke(blk)
+        EndPopup()
+    }
+    stateless_finalize(widget_ident, "popup_context_window", state)
+}
+
+[container]
 def popup_modal(var state : PopupState; text : string; closable : bool;
                 flags : ImGuiWindowFlags; blk : block) {
     //! `BeginPopupModal(name, p_open, flags)` / `EndPopup()`. Same lifecycle

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -72,6 +72,10 @@ let private ALLOWED_IMGUI : table<string> <- {
     // user-controlled. v2 drag_drop_source/_target containers gate the body;
     // these calls are the payload exchange inside.
     "SetDragDropPayload", "AcceptDragDropPayload", "GetDragDropPayload",
+    // Input-text callback primitives — only callable inside an
+    // ImGuiInputTextCallbackData callback (which fires synchronously from
+    // ImGui::InputText). No widget host needed; caller owns the data pointer.
+    "DeleteChars", "InsertChars",
     // Viewport queries.
     "GetMainViewport",
     // Docking internals — DockBuilder* is cherry-picked from imgui_internal.h

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -1150,6 +1150,33 @@ def input_text_growable(var state : InputTextState; text : string;
     return changed
 }
 
+[widget]
+def input_text_callback(var state : InputTextState; text : string;
+                        flags : ImGuiInputTextFlags;
+                        cb : lambda<(var data : ImGuiInputTextCallbackData) : int>) : bool {
+    //! Single-line input with a user-supplied event callback. Use this when
+    //! `CallbackCompletion` (TAB completion), `CallbackHistory` (Up/Down
+    //! arrow), `CallbackAlways`, or `CallbackCharFilter` is needed —
+    //! the REPL pattern in `examples/imgui_demo/app_console.das` is the
+    //! canonical consumer. ImGui invokes the callback synchronously inside
+    //! `InputText` on the same thread; the `data` pointer is valid only
+    //! for that one call. For grow-on-overflow buffer resize use
+    //! `input_text_growable` instead — it wires `CallbackResize` internally
+    //! and shouldn't be combined with this wrapper.
+    input_text_buffer_init(state)
+    apply_pending_text(state)
+    var changed : bool
+    unsafe {
+        changed = _builtin_InputText_cb(addr(state.buffer[0]), state.capacity, text, flags, cb)
+    }
+    state.changed = changed
+    if (changed) {
+        sync_value_from_buffer(state)
+    }
+    text_value_finalize(widget_ident, "input_text_callback", state)
+    return changed
+}
+
 // ===== Combo (callback-getter) =====
 
 [widget]

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -2092,3 +2092,47 @@ def edit_collapsing_header(var ptr : bool? implicit; text : string = "";
     edit_finalize(widget_ident, "edit_collapsing_header", ptr)
     return im_open
 }
+
+// ===== Imperative commands (scroll / focus / clipboard) =====
+//
+// These are non-`[widget]` helpers — plain `def public` aliases over raw
+// ImGui calls that user code shouldn't reach for directly while
+// `options _no_imgui_legacy = true` is in effect. They take no block and
+// produce no state, so they don't fit the [widget] / [container] mold.
+
+def public set_scroll_here_y(center_y_ratio : float = 1.0f) {
+    //! `SetScrollHereY(center_y_ratio)` — scrolls the current window so the
+    //! recently-submitted item is anchored at the given vertical ratio
+    //! (0=top, 0.5=middle, 1=bottom). Common pattern: tail-follow scrolling
+    //! regions call `set_scroll_here_y(1.0f)` after the last entry.
+    SetScrollHereY(center_y_ratio)
+}
+
+def public set_keyboard_focus_here(offset : int = 0) {
+    //! `SetKeyboardFocusHere(offset)` — moves keyboard focus to the
+    //! item N items ahead (`offset = 0`) or behind (`offset = -1`, the
+    //! item that was just submitted). REPL-style inputs use `-1` after
+    //! Enter to refocus the editbox for the next command.
+    SetKeyboardFocusHere(offset)
+}
+
+def public set_item_default_focus() {
+    //! `SetItemDefaultFocus()` — marks the previous item as the default
+    //! focus target on first frame of a window. Used on the primary input
+    //! widget so the user can start typing immediately.
+    SetItemDefaultFocus()
+}
+
+def public log_to_clipboard(auto_open_depth : int = -1) {
+    //! `LogToClipboard(auto_open_depth)` — starts capturing subsequent
+    //! text-emitting widgets to the OS clipboard until `log_finish()` is
+    //! called. `auto_open_depth = -1` means capture all depths.
+    LogToClipboard(auto_open_depth)
+}
+
+def public log_finish() {
+    //! `LogFinish()` — stops the active log capture started by
+    //! `log_to_clipboard` (or any other `LogTo*` call) and finalizes the
+    //! clipboard contents.
+    LogFinish()
+}

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -1205,7 +1205,18 @@ def text_filter(var state : TextFilterState; text : string = "Filter (\"incl,-ex
     //! The C++ `ImGuiTextFilter` value lives inline in the state — no
     //! daslang-side buffer needed (the editor's storage is `InputBuf[256]`
     //! on the bound struct). `state.value` mirrors the editor text after
-    //! every change for snapshot fidelity.
+    //! every edit; on the first frame after a live-reload (when
+    //! `archive::serialize` restored `state.value` but the C++ filter is
+    //! zero-init), the widget body re-applies `state.value` via a fresh
+    //! `ImGuiTextFilter(default_filter)` so `Draw()` and `passes_filter()`
+    //! see the restored expression without forcing the user to retype.
+    var buf_view : string
+    unsafe {
+        buf_view = reinterpret<string>(addr(state.filter.InputBuf))
+    }
+    if (state.value != buf_view) {
+        state.filter = ImGuiTextFilter(state.value)
+    }
     let changed = state.filter |> Draw(text, width)
     if (changed) {
         unsafe {

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -1177,6 +1177,54 @@ def input_text_callback(var state : InputTextState; text : string;
     return changed
 }
 
+// ===== Filter family =====
+
+def private text_filter_finalize(widget_ident : string; kind : string; var state : TextFilterState) {
+    var entry : WidgetEntry
+    unsafe {
+        let ser <- @ capture(& state) () : JsonValue ? {
+            return JV((value = state.value))
+        }
+        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
+            // Read-only for now. A future "set" path would mirror the
+            // value back into filter.InputBuf and call filter.Build();
+            // playwright doesn't drive the filter editor yet.
+        }
+        widget_finalize(widget_ident, kind, entry, ser, disp)
+    }
+}
+
+[widget]
+def text_filter(var state : TextFilterState; text : string = "Filter (\"incl,-excl\") (\"error\")";
+                width : float = 0.0f) : bool {
+    //! Boost wrapper over `ImGuiTextFilter::Draw` — renders the inline
+    //! InputText editor and parses comma-separated include/exclude
+    //! tokens (`-prefix` excludes). Returns `true` on the frame the
+    //! filter expression changed. Pair with `passes_filter(state, line)`
+    //! in a loop to gate visible items. Empty filter = match-all.
+    //! The C++ `ImGuiTextFilter` value lives inline in the state — no
+    //! daslang-side buffer needed (the editor's storage is `InputBuf[256]`
+    //! on the bound struct). `state.value` mirrors the editor text after
+    //! every change for snapshot fidelity.
+    let changed = state.filter |> Draw(text, width)
+    if (changed) {
+        unsafe {
+            state.value := clone_string(reinterpret<string>(addr(state.filter.InputBuf)))
+        }
+    }
+    text_filter_finalize(widget_ident, "text_filter", state)
+    return changed
+}
+
+def public passes_filter(var state : TextFilterState; line : string) : bool {
+    //! Predicate companion to `text_filter`. Delegates to the hand-bound
+    //! `PassFilter(filter, text)` standalone helper at
+    //! `src/dasIMGUI.main.cpp:305`. While the editor is empty the
+    //! underlying `Filters` `ImVector` is empty too and PassFilter returns
+    //! true for all lines.
+    return PassFilter(state.filter, line)
+}
+
 // ===== Combo (callback-getter) =====
 
 [widget]

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -1192,6 +1192,7 @@ def private text_filter_finalize(widget_ident : string; kind : string; var state
         }
         widget_finalize(widget_ident, kind, entry, ser, disp)
     }
+    register_focusable(widget_ident)
 }
 
 [widget]


### PR DESCRIPTION
## Summary

14 commits accumulated on this branch since master, in three loose themes:

### Example: Console port (newest, 7 commits — 6d46791..0e6e904)
First example-app from `imgui_demo.cpp` ported behind the `_no_imgui_legacy` lint. Closes 6 boost-surface gaps along the way:

- **`boost: scroll/focus/clipboard primitives + popup_context_window`** — 5 `def public` aliases (`set_scroll_here_y` / `set_keyboard_focus_here` / `set_item_default_focus` / `log_to_clipboard` / `log_finish`) + `popup_context_window` `[container]`.
- **`boost: input_text_callback widget`** — `[widget]` next to `input_text_growable`, plumbs a user lambda into the existing `_builtin_InputText_cb` rail for `CallbackCompletion` / `CallbackHistory` / `CallbackAlways` / `CallbackCharFilter`. No `src/*.cpp` changes.
- **`boost: text_filter widget over bound ImGuiTextFilter`** — `TextFilterState` holds the C++ `ImGuiTextFilter` value inline; `text_filter` `[widget]` renders the bound `Draw()`; `passes_filter(state, line)` delegates to the hand-bound `PassFilter`.
- **`ImGuiTextFilter binding: make it embeddable in daslang state structs`** — four C++ annotation overrides flipped (`isLocal` / `canBePlacedInContainer` / `hasNonTrivialCtor` / `canCopy`) + a `bind/bind_imgui.das` `local_type_names` entry + daslang-side `JV` and `archive::serialize` overrides on `TextFilterState` to short-circuit the v1 `register_widgets` chain and `LiveVarsPass` field walkers. Comment block on the C++ annotation flags the trivial-ctor + canCopy as manual-patch (cbind_boost only emits the first two).
- **`imgui_demo(app_console): port ExampleAppConsole`** — full daslang port of `imgui_demo.cpp:7116-7477`. Module-scope `var private` for class fields, indexed `table<int; NarrativeState>` for per-row log lines, `text_edit_callback(var data : ImGuiInputTextCallbackData) : int` for TAB completion + Up/Down history. Per-line color via `with_style((ImGuiCol.Text, color))`. `DeleteChars` + `InsertChars` added to `ALLOWED_IMGUI` (callback-data methods, not host-side widget calls).
- **`imgui_demo: wire Example Console toggle into dispatcher`** — `Show Example: Console` checkbox at the bottom of the demo window gating `ShowExampleAppConsole()`. Full Examples submenu waits for the other five example-app stubs to be ported.
- **`app_console: lint cleanups`** — LINT005 redundant `reinterpret<string>` on `data.Buf` (already string) + 2× PERF017 `length == 0` → `empty`.

### Raw-survivor sweep (prior session, 2 commits — 19febcf..3e7cc5a)
- **`imgui_demo(popups): explicit open/close popup boost API + Selectable sweep`** — popups.das now lint-clean under `_no_imgui_legacy`.
- **`scroll_state: indexed NarrativeState tables for in-loop text widgets`** — regression fix; PR #29's `Text→text` sweep tripped `check_unique_render` on for-loops because positional `text("row {i}")` synthesized the same auto-gen ident every iteration. Module-scope `table<int; NarrativeState>` per loop fixes it; test_scroll_state.das returns to PASS.

### CI / docs (prior session, 5 commits — 4580c42..f4b39d3 + e77780c)
- Integration test workflow scaffolding (xvfb-run + dastest), switched to Windows runner, then parked behind `workflow_dispatch` until a headless test path exists (Linux + Mesa SW can boot daslang-live but hangs before first frame; Windows runners GL works but transitively builds OpenSSL via libhv = 1+ hour CI). Workflow body preserved verbatim for one-line re-enable once a mock-GL or native-headless renderer lands.
- `docs: anchor ImGuiPopupFlags in external_types.rst`.

## Test plan

- [x] `cmake --build build --config Release --target dasModuleImgui` succeeds; produces fresh `dasModuleImgui.shared_module` with the 4 ImGuiTextFilter overrides.
- [x] `mcp__daslang__compile_check` passes on all 18 `examples/imgui_demo/*.das` files.
- [x] `mcp__daslang__lint` passes on all 18 (no PERF/STYLE/LINT/IMGUI warnings).
- [x] Master-branch demo files (popups, columns, inputs, etc.) still compile against the changed boost rail.
- [ ] **Manual smoke test (Boris):** `daslang-live modules/dasImgui/examples/imgui_demo/main.das`, toggle the new checkbox:
  - [ ] Console window opens, "Welcome to Dear ImGui!" seeded.
  - [ ] Type `HELP` + Enter → command list prints.
  - [ ] Type `C` + TAB → completes to `CL` and lists `CLEAR` / `CLASSIFY`.
  - [ ] Type `CLEAR` + Enter → log clears.
  - [ ] Up/Down arrows walk history.
  - [ ] Filter editbox: type `error`, click "Add Debug Error" + "Add Debug Text" — only error line visible.
  - [ ] "Add Debug Text" floods the log; AutoScroll keeps tail visible; Options popup toggles AutoScroll.
  - [ ] Right-click in scroll region → "Clear" context menu.
  - [ ] Copy button copies the filtered log to clipboard.

## Notes for review

- The C++ binding patch on `src/dasIMGUI.struct.class.inc` is a **manual patch** that gets overwritten on regen — comment block flags it. `bind/bind_imgui.das` carries the entry for the regen-emittable parts (`isLocal` + `canBePlacedInContainer` only); the trivial-ctor + canCopy overrides have to be re-applied manually. Worth thinking about whether cbind_boost should grow a richer policy table.
- Window initial size (the C++ `SetNextWindowSize(520, 600, FirstUseEver)`) is deferred — the `window` container doesn't expose an `init_size` knob today. ImGui auto-sizes; user drag-resizes. Adding `init_size` to `window` is a follow-up touching every consumer; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)