### PR TITLE
imgui_lint: default-on + STYLE001 + TextUnformatted text family

### DIFF
--- a/.das_module
+++ b/.das_module
@@ -36,9 +36,11 @@ def initialize(project_path : string) {
     register_native_path("imgui", "imgui_scope_builtin", "{project_path}/widgets/imgui_scope_builtin.das")
     // §4.6 — layout helpers (split_h, split_v, dock_left).
     register_native_path("imgui", "imgui_layout_builtin", "{project_path}/widgets/imgui_layout_builtin.das")
-    // Opt-in lint pass (`options _no_imgui_legacy = true`) — forbids legacy
-    // imgui_boost::* and raw imgui::* (modulo curated allow-list) so consumer
-    // files don't bypass v2 wrappers. Off by default.
+    // Default-on lint pass — forbids legacy imgui_boost::* and raw imgui::*
+    // (modulo curated allow-list) so consumer files don't bypass v2 wrappers.
+    // Bundled into imgui_boost_v2 via `require imgui/imgui_lint public`, so
+    // every dasImgui consumer gets it transitively. Per-file opt-out:
+    // `options _allow_imgui_legacy = true`.
     register_native_path("imgui", "imgui_lint", "{project_path}/widgets/imgui_lint.das")
     // Phase 7 — docking (dockspace, dock_window) + DockBuilder bindings cherry-picked from imgui_internal.h.
     register_native_path("imgui", "imgui_docking_builtin", "{project_path}/widgets/imgui_docking_builtin.das")

--- a/examples/features/active_widget.das
+++ b/examples/features/active_widget.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/await_quiescent.das
+++ b/examples/features/await_quiescent.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/clip_rect.das
+++ b/examples/features/clip_rect.das
@@ -1,4 +1,8 @@
 options gen2
+// Demos the low-level ImDrawList API (GetWindowDrawList + AddCircleFilled).
+// No v2 wrappers exist for direct drawlist primitives; opt out of the
+// default-on lint so the demo compiles cleanly.
+options _allow_imgui_legacy = true
 
 require imgui
 require imgui_app

--- a/examples/features/columns_demo.das
+++ b/examples/features/columns_demo.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/containers_layout.das
+++ b/examples/features/containers_layout.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/containers_overlay.das
+++ b/examples/features/containers_overlay.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/containers_window.das
+++ b/examples/features/containers_window.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/dock_basic.das
+++ b/examples/features/dock_basic.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/drag_drop.das
+++ b/examples/features/drag_drop.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/focus_widget.das
+++ b/examples/features/focus_widget.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/foundation.das
+++ b/examples/features/foundation.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/glfw_synth_keys.das
+++ b/examples/features/glfw_synth_keys.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/glfw_synth_mouse.das
+++ b/examples/features/glfw_synth_mouse.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/hex_id_click.das
+++ b/examples/features/hex_id_click.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/id_override.das
+++ b/examples/features/id_override.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/imgui_synth_keys.das
+++ b/examples/features/imgui_synth_keys.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/imgui_synth_mouse.das
+++ b/examples/features/imgui_synth_mouse.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/indexed_dynamic.das
+++ b/examples/features/indexed_dynamic.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/inputs_choice.das
+++ b/examples/features/inputs_choice.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/inputs_color.das
+++ b/examples/features/inputs_color.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/inputs_drag.das
+++ b/examples/features/inputs_drag.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/inputs_indexed.das
+++ b/examples/features/inputs_indexed.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/inputs_numeric.das
+++ b/examples/features/inputs_numeric.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/inputs_slider.das
+++ b/examples/features/inputs_slider.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/inputs_text.das
+++ b/examples/features/inputs_text.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/io_mirror.das
+++ b/examples/features/io_mirror.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/io_synth_drag.das
+++ b/examples/features/io_synth_drag.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/io_synth_text.das
+++ b/examples/features/io_synth_text.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/layout_helpers.das
+++ b/examples/features/layout_helpers.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/list_box.das
+++ b/examples/features/list_box.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/narrative_bullet.das
+++ b/examples/features/narrative_bullet.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/narrative_text.das
+++ b/examples/features/narrative_text.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/output_text.das
+++ b/examples/features/output_text.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/plot_getter.das
+++ b/examples/features/plot_getter.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/plot_widgets.das
+++ b/examples/features/plot_widgets.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/popup_context_item.das
+++ b/examples/features/popup_context_item.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/scroll_state.das
+++ b/examples/features/scroll_state.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/snapshot_unrendered.das
+++ b/examples/features/snapshot_unrendered.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/style_override.das
+++ b/examples/features/style_override.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/transport_demo.das
+++ b/examples/features/transport_demo.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/triggers.das
+++ b/examples/features/triggers.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/widget_init_defaults.das
+++ b/examples/features/widget_init_defaults.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost
@@ -54,10 +52,10 @@ def show_defaults(var state : DefaultsState; text : string) : int {
     Text("count={state.count} ratio={state.ratio} caption={state.caption}")
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(& state) () : JsonValue? {
+        let ser <- @ capture(& state) () : JsonValue ? {
             return JV(state)
         }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue?) {
+        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
             if (action == "set") {
                 state.pending_bump = true
                 state.has_pending = true

--- a/examples/features/widget_no_ident.das
+++ b/examples/features/widget_no_ident.das
@@ -1,4 +1,9 @@
 options gen2
+// This demo deliberately exercises the Form 2 named-tuple-without-ident shape
+// that STYLE001 forbids on single-arg narrative widgets like `text`. Opt out
+// per-file so the educational `text((text=...))` line below renders instead
+// of becoming a hard build error.
+options _allow_imgui_legacy = true
 
 require imgui
 require imgui_app

--- a/examples/features/with_indent.das
+++ b/examples/features/with_indent.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/with_item_width.das
+++ b/examples/features/with_item_width.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/features/with_text_wrap_pos.das
+++ b/examples/features/with_text_wrap_pos.das
@@ -1,8 +1,6 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
-require imgui/imgui_lint
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost

--- a/examples/imgui_demo/about.das
+++ b/examples/imgui_demo/about.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module about
 
@@ -20,7 +21,7 @@ var ABOUT_SHOW_CONFIG_INFO = false
 def ShowAboutWindow() {
     window(ABOUT_WINDOW, (text = "About Dear ImGui", closable = false,
                           flags = ImGuiWindowFlags.AlwaysAutoResize)) {
-        text((text = "Dear ImGui {IMGUI_VERSION} ({IMGUI_VERSION_NUM})"))
+        text("Dear ImGui {IMGUI_VERSION} ({IMGUI_VERSION_NUM})")
         separator(ABOUT_SEP_1)
         text("By Omar Cornut and all Dear ImGui contributors.")
         text((text = "Dear ImGui is licensed under the MIT License, " +
@@ -46,14 +47,14 @@ def ShowAboutWindow() {
                     LogText("```\n")
                 }
 
-                text((text = "Dear ImGui {IMGUI_VERSION} ({IMGUI_VERSION_NUM})"))
+                text("Dear ImGui {IMGUI_VERSION} ({IMGUI_VERSION_NUM})")
                 separator(ABOUT_SEP_2)
                 text("define: __cplusplus elided (daslang port)")
                 text("(C++ build-define block elided; see imgui_demo.cpp:6494-6565)")
                 separator(ABOUT_SEP_3)
-                text((text = "io.BackendPlatformName: {io.BackendPlatformName}"))
-                text((text = "io.BackendRendererName: {io.BackendRendererName}"))
-                text((text = "io.ConfigFlags: {fmt_hex(uint(io.ConfigFlags))}"))
+                text("io.BackendPlatformName: {io.BackendPlatformName}")
+                text("io.BackendRendererName: {io.BackendRendererName}")
+                text("io.ConfigFlags: {fmt_hex(uint(io.ConfigFlags))}")
                 if (uint(io.ConfigFlags & ImGuiConfigFlags.NavEnableKeyboard) != 0u) {
                     text(" NavEnableKeyboard")
                 }
@@ -102,7 +103,7 @@ def ShowAboutWindow() {
                 if (io.ConfigInputTextCursorBlink) {
                     text("io.ConfigInputTextCursorBlink")
                 }
-                text((text = "io.BackendFlags: {fmt_hex(uint(io.BackendFlags))}"))
+                text("io.BackendFlags: {fmt_hex(uint(io.BackendFlags))}")
                 if (uint(io.BackendFlags & ImGuiBackendFlags.HasGamepad) != 0u) {
                     text(" HasGamepad")
                 }
@@ -122,16 +123,16 @@ def ShowAboutWindow() {
                     text(" RendererHasViewports")
                 }
                 separator(ABOUT_SEP_4)
-                text((text = "io.DisplaySize: {io.DisplaySize.x},{io.DisplaySize.y}"))
-                text((text = "io.DisplayFramebufferScale: {io.DisplayFramebufferScale.x},{io.DisplayFramebufferScale.y}"))
+                text("io.DisplaySize: {io.DisplaySize.x},{io.DisplaySize.y}")
+                text("io.DisplayFramebufferScale: {io.DisplayFramebufferScale.x},{io.DisplayFramebufferScale.y}")
                 separator(ABOUT_SEP_5)
-                text((text = "style.WindowPadding: {style.WindowPadding.x},{style.WindowPadding.y}"))
-                text((text = "style.WindowBorderSize: {style.WindowBorderSize}"))
-                text((text = "style.FramePadding: {style.FramePadding.x},{style.FramePadding.y}"))
-                text((text = "style.FrameRounding: {style.FrameRounding}"))
-                text((text = "style.FrameBorderSize: {style.FrameBorderSize}"))
-                text((text = "style.ItemSpacing: {style.ItemSpacing.x},{style.ItemSpacing.y}"))
-                text((text = "style.ItemInnerSpacing: {style.ItemInnerSpacing.x},{style.ItemInnerSpacing.y}"))
+                text("style.WindowPadding: {style.WindowPadding.x},{style.WindowPadding.y}")
+                text("style.WindowBorderSize: {style.WindowBorderSize}")
+                text("style.FramePadding: {style.FramePadding.x},{style.FramePadding.y}")
+                text("style.FrameRounding: {style.FrameRounding}")
+                text("style.FrameBorderSize: {style.FrameBorderSize}")
+                text("style.ItemSpacing: {style.ItemSpacing.x},{style.ItemSpacing.y}")
+                text("style.ItemInnerSpacing: {style.ItemInnerSpacing.x},{style.ItemInnerSpacing.y}")
 
                 if (copy_to_clipboard) {
                     LogText("\n```\n")

--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -1,11 +1,10 @@
 options gen2
 options indenting = 4
-options _no_imgui_legacy = true
+options _allow_imgui_legacy = true
 
 module app_console
 
 require imgui
-require imgui/imgui_lint
 require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 require imgui/imgui_scope_builtin
@@ -249,7 +248,7 @@ def ShowExampleAppConsole() {
                               "(Up/Down keys). A more elaborate implementation " +
                               "may want to store entries along with extra data " +
                               "such as timestamp, emitter, etc."))
-        text_wrapped((text = "Enter 'HELP' for help."))
+        text_wrapped("Enter 'HELP' for help.")
 
         if (small_button(CONSOLE_BTN_DBG, (text = "Add Debug Text"))) {
             add_log("{length(CONSOLE_ITEMS)} some text")

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module app_custom_rendering
 

--- a/examples/imgui_demo/app_dockspace.das
+++ b/examples/imgui_demo/app_dockspace.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module app_dockspace
 

--- a/examples/imgui_demo/app_documents.das
+++ b/examples/imgui_demo/app_documents.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module app_documents
 

--- a/examples/imgui_demo/app_log.das
+++ b/examples/imgui_demo/app_log.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module app_log
 

--- a/examples/imgui_demo/app_main_menu.das
+++ b/examples/imgui_demo/app_main_menu.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module app_main_menu
 

--- a/examples/imgui_demo/app_small.das
+++ b/examples/imgui_demo/app_small.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module app_small
 

--- a/examples/imgui_demo/columns.das
+++ b/examples/imgui_demo/columns.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module columns
 
@@ -75,8 +76,7 @@ def ShowDemoWindowColumns() {
         text_disabled("(?)")
         item_tooltip(COLUMNS_OUTER_HELP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Columns() is an old API! Prefer using the more flexible " +
+                text_unformatted((text = "Columns() is an old API! Prefer using the more flexible " +
                     "and powerful BeginTable() API!"))
             }
         }
@@ -128,9 +128,9 @@ def private BasicSection() {
                  flags = ImGuiSelectableFlags.SpanAllColumns))
             let hovered = IsItemHovered()
             NextColumn()
-            text((text = "{names[i]}")); NextColumn()
-            text((text = "{paths[i]}")); NextColumn()
-            text((text = "{hovered ? 1 : 0}")); NextColumn()
+            text("{names[i]}"); NextColumn()
+            text("{paths[i]}"); NextColumn()
+            text("{hovered ? 1 : 0}"); NextColumn()
         }
         columns_close()
         Separator()
@@ -169,10 +169,10 @@ def private BordersSection() {
                 "k", "l", "m", "n", "o", "p", "q", "r", "s", "t",
                 "u", "v", "w", "x", "y", "z", "0", "1", "2", "3")
             let glyph = alphabet[i % length(alphabet)]
-            text((text = "{glyph}{glyph}{glyph}"))
-            text((text = "Width {GetColumnWidth(-1)}"))
-            text((text = "Avail {GetContentRegionAvail().x}"))
-            text((text = "Offset {GetColumnOffset(-1)}"))
+            text("{glyph}{glyph}{glyph}")
+            text("Width {GetColumnWidth(-1)}")
+            text("Avail {GetContentRegionAvail().x}")
+            text("Offset {GetColumnOffset(-1)}")
             text("Long text that is likely to clip")
             // Per-cell button — indexed; full-width via Button raw call so we
             // can pass ImVec2(-FLT_MIN, 0). The boost button widget defaults
@@ -281,7 +281,7 @@ def private HorizontalScrollingSection() {
                 while (clipper |> Step()) {
                     for (i in range(clipper.DisplayStart, clipper.DisplayEnd)) {
                         for (j in range(10)) {
-                            text((text = "Line {i} Column {j}..."))
+                            text("Line {i} Column {j}...")
                             NextColumn()
                         }
                     }

--- a/examples/imgui_demo/imgui_demo.das
+++ b/examples/imgui_demo/imgui_demo.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module imgui_demo
 

--- a/examples/imgui_demo/inputs.das
+++ b/examples/imgui_demo/inputs.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module inputs
 
@@ -15,7 +16,7 @@ require daslib/enum_trait
 // Boost-surface notes for this port:
 //   - Almost all of this section is read-only state inspection of ImGuiIO
 //     (mouse pos / mouse delta / key-down flags / nav-active / etc.). Each
-//     readout becomes a single narrative `text((text = "..."))` line; the
+//     readout becomes a single narrative `text("...")` line; the
 //     C++ pattern of `Text() ... SameLine() Text()` inside a loop is
 //     collapsed into one concatenated string accumulated with `+=` so each
 //     per-frame line stays a single widget (no indexed-table boilerplate
@@ -88,19 +89,18 @@ def private InputsSubSection() {
         text_disabled("(?)")
         item_tooltip(INPUTS_HM_INPUTS) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "This is a simplified view. See more detailed input state:\n" +
+                text_unformatted((text = "This is a simplified view. See more detailed input state:\n" +
                     "- in 'Tools->Metrics/Debugger->Inputs'.\n" +
                     "- in 'Tools->Debug Log->IO'."))
             }
         }
 
         if (IsMousePosValid(null)) {
-            text((text = "Mouse pos: ({io.MousePos.x}, {io.MousePos.y})"))
+            text("Mouse pos: ({io.MousePos.x}, {io.MousePos.y})")
         } else {
             text("Mouse pos: <INVALID>")
         }
-        text((text = "Mouse delta: ({io.MouseDelta.x}, {io.MouseDelta.y})"))
+        text("Mouse delta: ({io.MouseDelta.x}, {io.MouseDelta.y})")
 
         // C++ does Text("Mouse down:") + per-button SameLine+Text loop.
         // We build the entire line in one string and render with one widget.
@@ -112,7 +112,7 @@ def private InputsSubSection() {
         }
         text((text = down_line))
 
-        text((text = "Mouse wheel: {io.MouseWheel}"))
+        text("Mouse wheel: {io.MouseWheel}")
 
         // Keys down: iterate every named ImGuiKey value, skip ones not pressed.
         var keys_line = "Keys down:"
@@ -164,8 +164,7 @@ def private OutputsSubSection() {
         text_disabled("(?)")
         item_tooltip(INPUTS_HM_OUTPUTS) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "The value of io.WantCaptureMouse and io.WantCaptureKeyboard " +
+                text_unformatted((text = "The value of io.WantCaptureMouse and io.WantCaptureKeyboard " +
                     "are normally set by Dear ImGui to instruct your application " +
                     "of how to route inputs. Typically, when a value is true, it " +
                     "means Dear ImGui wants the corresponding inputs and we " +
@@ -177,12 +176,12 @@ def private OutputsSubSection() {
             }
         }
 
-        text((text = "io.WantCaptureMouse: {io.WantCaptureMouse}"))
-        text((text = "io.WantCaptureMouseUnlessPopupClose: {io.WantCaptureMouseUnlessPopupClose}"))
-        text((text = "io.WantCaptureKeyboard: {io.WantCaptureKeyboard}"))
-        text((text = "io.WantTextInput: {io.WantTextInput}"))
-        text((text = "io.WantSetMousePos: {io.WantSetMousePos}"))
-        text((text = "io.NavActive: {io.NavActive}, io.NavVisible: {io.NavVisible}"))
+        text("io.WantCaptureMouse: {io.WantCaptureMouse}")
+        text("io.WantCaptureMouseUnlessPopupClose: {io.WantCaptureMouseUnlessPopupClose}")
+        text("io.WantCaptureKeyboard: {io.WantCaptureKeyboard}")
+        text("io.WantTextInput: {io.WantTextInput}")
+        text("io.WantSetMousePos: {io.WantSetMousePos}")
+        text("io.NavActive: {io.NavActive}, io.NavVisible: {io.NavVisible}")
 
         WantCaptureOverrideSubSection()
     }
@@ -195,8 +194,7 @@ def private WantCaptureOverrideSubSection() {
         text_disabled("(?)")
         item_tooltip(INPUTS_HM_CAPTURE) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Hovering the colored canvas will override io.WantCaptureXXX " +
+                text_unformatted((text = "Hovering the colored canvas will override io.WantCaptureXXX " +
                     "fields.\nNotice how normally (when set to none), the value " +
                     "of io.WantCaptureKeyboard would be false when hovering and " +
                     "true when clicking."))
@@ -255,7 +253,7 @@ def private MouseCursorsSubSection() {
         let cur_idx = int(current)
         let cur_name = ((cur_idx >= 0 && cur_idx < length(cursors))
                         ? cursors[cur_idx] : "?")
-        text((text = "Current mouse cursor = {cur_idx}: {cur_name}"))
+        text("Current mouse cursor = {cur_idx}: {cur_name}")
 
         // The C++ wraps a CheckboxFlags (read-only display of the
         // HasMouseCursors backend bit) in BeginDisabled/EndDisabled. Since
@@ -263,15 +261,14 @@ def private MouseCursorsSubSection() {
         // a bounce-buffer (matches the style_editor.das gap), display the
         // bit state as plain text.
         let has_mouse_cursors = (uint(io.BackendFlags & ImGuiBackendFlags.HasMouseCursors) != 0u)
-        text((text = "io.BackendFlags: HasMouseCursors = {has_mouse_cursors}"))
+        text("io.BackendFlags: HasMouseCursors = {has_mouse_cursors}")
 
         text("Hover to see mouse cursors:")
         same_line(INPUTS_SL_HOVER)
         text_disabled("(?)")
         item_tooltip(INPUTS_HM_HOVER_CURSORS) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Your application can render a different mouse cursor based " +
+                text_unformatted((text = "Your application can render a different mouse cursor based " +
                     "on what ImGui::GetMouseCursor() returns. If software cursor " +
                     "rendering (io.MouseDrawCursor) is set ImGui will draw the " +
                     "right cursor for you, otherwise your backend needs to " +
@@ -376,7 +373,7 @@ def private FocusFromCodeSubSection() {
         PopTabStop()
 
         if (has_focus != 0) {
-            text((text = "Item with focus: {has_focus}"))
+            text("Item with focus: {has_focus}")
         } else {
             text("Item with focus: <none>")
         }
@@ -426,10 +423,10 @@ def private DraggingSubSection() {
             let dr_def : bool = IsMouseDragging(btn, -1.0f)
             let dr_zero : bool = IsMouseDragging(btn, 0.0f)
             let dr_big : bool = IsMouseDragging(btn, 20.0f)
-            text((text = "IsMouseDragging({b}):"))
-            text((text = "  w/ default threshold: {dr_def},"))
-            text((text = "  w/ zero threshold: {dr_zero},"))
-            text((text = "  w/ large threshold: {dr_big},"))
+            text("IsMouseDragging({b}):")
+            text("  w/ default threshold: {dr_def},")
+            text("  w/ zero threshold: {dr_zero},")
+            text("  w/ large threshold: {dr_big},")
         }
 
         button(INPUTS_DRAG_ME, (text = "Drag Me"))
@@ -446,8 +443,8 @@ def private DraggingSubSection() {
         let value_with_lock = GetMouseDragDelta(ImGuiMouseButton.Left, -1.0f)
         let mouse_delta = io.MouseDelta
         text("GetMouseDragDelta(0):")
-        text((text = "  w/ default threshold: ({value_with_lock.x}, {value_with_lock.y})"))
-        text((text = "  w/ zero threshold: ({value_raw.x}, {value_raw.y})"))
-        text((text = "io.MouseDelta: ({mouse_delta.x}, {mouse_delta.y})"))
+        text("  w/ default threshold: ({value_with_lock.x}, {value_with_lock.y})")
+        text("  w/ zero threshold: ({value_raw.x}, {value_raw.y})")
+        text("io.MouseDelta: ({mouse_delta.x}, {mouse_delta.y})")
     }
 }

--- a/examples/imgui_demo/layout.das
+++ b/examples/imgui_demo/layout.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module layout
 
@@ -145,8 +146,7 @@ def private ChildWindowsSection() {
         text("(?)")
         item_tooltip(LAYOUT_CHILD_HM1) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Use child windows to begin into a self-contained " +
+                text_unformatted((text = "Use child windows to begin into a self-contained " +
                     "independent scrolling/clipping regions within a host window."))
             }
         }
@@ -166,7 +166,7 @@ def private ChildWindowsSection() {
                child_flags = ImGuiChildFlags.None,
                window_flags = unsafe(reinterpret<ImGuiWindowFlags>(win_flags_1)))) {
             for (i in range(100)) {
-                text((text = "{i}: scrollable region"))
+                text("{i}: scrollable region")
             }
         }
 
@@ -210,8 +210,7 @@ def private ChildWindowsSection() {
         separator_text("Manual-resize")
         text("(?)")
         item_tooltip(LAYOUT_CHILD_HM2) {
-            text_unformatted((text =
-                "Drag bottom border to resize. Double-click bottom border " +
+            text_unformatted((text = "Drag bottom border to resize. Double-click bottom border " +
                 "to auto-fit to vertical contents."))
         }
         with_style((ImGuiCol.ChildBg, GetStyleColorVec4(ImGuiCol.FrameBg))) {
@@ -222,7 +221,7 @@ def private ChildWindowsSection() {
                    child_flags = unsafe(reinterpret<ImGuiChildFlags>(flags3)),
                    window_flags = ImGuiWindowFlags.None)) {
                 for (n in range(10)) {
-                    text((text = "Line {fmt_4d(n)}"))
+                    text("Line {fmt_4d(n)}")
                 }
             }
         }
@@ -248,7 +247,7 @@ def private ChildWindowsSection() {
                child_flags = unsafe(reinterpret<ImGuiChildFlags>(flags4)),
                window_flags = ImGuiWindowFlags.None)) {
             for (n in range(LAYOUT_CHILD_DRAW_LINES)) {
-                text((text = "Line {fmt_4d(n)}"))
+                text("Line {fmt_4d(n)}")
             }
         }
 
@@ -279,8 +278,7 @@ def private ChildWindowsSection() {
         text("(?)")
         item_tooltip(LAYOUT_CHILD_HM3) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Style the child window like a framed item: use FrameBg, " +
+                text_unformatted((text = "Style the child window like a framed item: use FrameBg, " +
                     "FrameRounding, FrameBorderSize, FramePadding instead of " +
                     "ChildBg, ChildRounding, ChildBorderSize, WindowPadding."))
             }
@@ -297,7 +295,7 @@ def private ChildWindowsSection() {
                child_flags = unsafe(reinterpret<ImGuiChildFlags>(LAYOUT_CHILD_FLAGS)),
                window_flags = ImGuiWindowFlags.None)) {
             for (n in range(50)) {
-                text((text = "Some test {n}"))
+                text("Some test {n}")
             }
         }
         if (LAYOUT_CHILD_OVERRIDE_BG) {
@@ -306,7 +304,7 @@ def private ChildWindowsSection() {
         let child_is_hovered = IsItemHovered(ImGuiHoveredFlags.None)
         let r_min = GetItemRectMin()
         let r_max = GetItemRectMax()
-        text((text = "Hovered: {child_is_hovered}"))
+        text("Hovered: {child_is_hovered}")
         text((text = "Rect of child window is: ({r_min.x},{r_min.y}) " +
                      "({r_max.x},{r_max.y})"))
     }
@@ -370,8 +368,7 @@ def private WidgetsWidthSection() {
         SameLine()
         text_disabled("(?)")
         item_tooltip(LAYOUT_WW_HM3) {
-            text_unformatted((text =
-                "Half of available width.\n(~ right-cursor_pos)\n" +
+            text_unformatted((text = "Half of available width.\n(~ right-cursor_pos)\n" +
                 "(works within a column set)"))
         }
         with_item_width(GetContentRegionAvail().x * 0.5f) {
@@ -434,8 +431,7 @@ def private WidgetsWidthSection() {
 def private BasicHorizontalLayoutSection() {
     tree_node(LAYOUT_BHL_TN, (text = "Basic Horizontal Layout",
                                flags = ImGuiTreeNodeFlags.None)) {
-        text_wrapped((text =
-            "(Use ImGui::SameLine() to keep adding items to the right of the " +
+        text_wrapped((text = "(Use ImGui::SameLine() to keep adding items to the right of the " +
             "preceding item)"))
 
         // Two-item lines via SameLine.
@@ -549,8 +545,7 @@ def private GroupsSection() {
         text("(?)")
         item_tooltip(LAYOUT_GROUPS_HM) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "BeginGroup() basically locks the horizontal position for " +
+                text_unformatted((text = "BeginGroup() basically locks the horizontal position for " +
                     "new line. EndGroup() bundles the whole group so that you " +
                     "can use \"item\" functions such as IsItemHovered()/" +
                     "IsItemActive() or SameLine() etc. on the whole group."))
@@ -616,8 +611,7 @@ def private TextBaselineAlignmentSection() {
         text("(?)")
         item_tooltip(LAYOUT_TBA_HM1) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "This is testing the vertical alignment that gets applied " +
+                text_unformatted((text = "This is testing the vertical alignment that gets applied " +
                     "on text to keep it aligned with widgets. Lines only " +
                     "composed of text or \"small\" widgets use less vertical " +
                     "space than lines with framed widgets."))
@@ -636,8 +630,7 @@ def private TextBaselineAlignmentSection() {
             button(LAYOUT_TBA_BTN2, (text = "Some framed item")); SameLine()
             text("(?)")
             item_tooltip(LAYOUT_TBA_HM3) {
-                text_unformatted((text =
-                    "We call AlignTextToFramePadding() to vertically align " +
+                text_unformatted((text = "We call AlignTextToFramePadding() to vertically align " +
                     "the text baseline by +FramePadding.y"))
             }
 
@@ -732,8 +725,7 @@ def private ScrollingSection() {
         // ----- Vertical scrolling -----
         text("(?)")
         item_tooltip(LAYOUT_SCROLL_HM_V) {
-            text_unformatted((text =
-                "Use SetScrollHereY() or SetScrollFromPosY() to scroll to a " +
+            text_unformatted((text = "Use SetScrollHereY() or SetScrollFromPosY() to scroll to a " +
                 "given vertical position."))
         }
 
@@ -811,13 +803,13 @@ def private ScrollingSection() {
                                                 "Item {item}")
                                     SetScrollHereY(float(i) * 0.25f)
                                 } else {
-                                    text((text = "Item {item}"))
+                                    text("Item {item}")
                                 }
                             }
                         }
                         let sy = GetScrollY()
                         let smy = GetScrollMaxY()
-                        text((text = "{fmt_0f(sy)}/{fmt_0f(smy)}"))
+                        text("{fmt_0f(sy)}/{fmt_0f(smy)}")
                     }
                 }
             }
@@ -828,8 +820,7 @@ def private ScrollingSection() {
         text("(?)")
         item_tooltip(LAYOUT_SCROLL_HM_H) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Use SetScrollHereX() or SetScrollFromPosX() to scroll " +
+                text_unformatted((text = "Use SetScrollHereX() or SetScrollFromPosX() to scroll " +
                     "to a given horizontal position.\n\nBecause the clipping " +
                     "rectangle of most window hides half worth of " +
                     "WindowPadding on the left/right, using " +
@@ -861,7 +852,7 @@ def private ScrollingSection() {
                             SetScrollHereX(float(i) * 0.25f)
                             hit_track = true
                         } else {
-                            text((text = "Item {item}"))
+                            text("Item {item}")
                         }
                     }
                     // scroll_to_off/scroll_to_pos for horizontal omitted to
@@ -873,7 +864,7 @@ def private ScrollingSection() {
                 let names <- ["Left", "25%", "Center", "75%", "Right"]
                 let sx = GetScrollX()
                 let smx = GetScrollMaxX()
-                text((text = "{names[i]}\n{fmt_0f(sx)}/{fmt_0f(smx)}"))
+                text("{names[i]}\n{fmt_0f(sx)}/{fmt_0f(smx)}")
                 Spacing()
             }
         }
@@ -882,8 +873,7 @@ def private ScrollingSection() {
         text("(?)")
         item_tooltip(LAYOUT_SCROLL_HM_FB) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Horizontal scrolling for a window is enabled via the " +
+                text_unformatted((text = "Horizontal scrolling for a window is enabled via the " +
                     "ImGuiWindowFlags_HorizontalScrollbar flag.\n\nYou may " +
                     "want to also explicitly specify content width by using " +
                     "SetNextWindowContentWidth() before Begin()."))
@@ -938,7 +928,7 @@ def private ScrollingSection() {
         SameLine()
         // Compute and display scroll_x/scroll_max_x via the child's State.
         let fb_state & = LAYOUT_SCROLL_FB_CHILD
-        text((text = "{fmt_0f(fb_state.scroll.x)}/{fmt_0f(fb_state.scroll_max.x)}"))
+        text("{fmt_0f(fb_state.scroll.x)}/{fmt_0f(fb_state.scroll_max.x)}")
         if (scroll_x_delta != 0.0f) {
             // Re-enter the child by name to nudge its scroll position. This
             // is the standard ImGui trick — BeginChild outside the child body
@@ -975,8 +965,7 @@ def private HorizontalContentsSizeDemo() {
             text("(?)")
             item_tooltip(LAYOUT_HSZ_HM) {
                 with_text_wrap_pos(GetFontSize() * 35.0f) {
-                    text_unformatted((text =
-                        "Test how different widgets react and impact the work " +
+                    text_unformatted((text = "Test how different widgets react and impact the work " +
                         "rectangle growing when horizontal scrolling is " +
                         "enabled.\n\nUse 'Metrics->Tools->Show windows " +
                         "rectangles' to visualize rectangles."))
@@ -1029,8 +1018,7 @@ def private HorizontalContentsSizeDemo() {
                                flags = ImGuiTreeNodeFlags.None)) {}
         }
         if (LAYOUT_HSZ_SHOW_TEXT_WRAPPED) {
-            text_wrapped((text =
-                "This text should automatically wrap on the edge of the work " +
+            text_wrapped((text = "This text should automatically wrap on the edge of the work " +
                 "rectangle."))
         }
         if (LAYOUT_HSZ_SHOW_COLUMNS) {
@@ -1039,14 +1027,14 @@ def private HorizontalContentsSizeDemo() {
                            float2(0.0f, 0.0f), 0.0f)) {
                 for (_n in range(4)) {
                     TableNextColumn()
-                    text((text = "Width {fmt_2f(GetContentRegionAvail().x)}"))
+                    text("Width {fmt_2f(GetContentRegionAvail().x)}")
                 }
                 EndTable()
             }
             text("Columns:")
             Columns(4, "", true)
             for (_n in range(4)) {
-                text((text = "Width {fmt_2f(GetColumnWidth(-1))}"))
+                text("Width {fmt_2f(GetColumnWidth(-1))}")
                 NextColumn()
             }
             Columns(1, "", true)
@@ -1099,8 +1087,7 @@ def private TextClippingSection() {
         text("(?)")
         item_tooltip(LAYOUT_CLIP_HM) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "(Left) Using ImGui::PushClipRect():\nWill alter ImGui " +
+                text_unformatted((text = "(Left) Using ImGui::PushClipRect():\nWill alter ImGui " +
                     "hit-testing logic + ImDrawList rendering.\n(use this if " +
                     "you want your clipping rectangle to affect interactions)" +
                     "\n\n(Center) Using ImDrawList::PushClipRect():\nWill " +
@@ -1147,8 +1134,7 @@ def private OverlapModeSection() {
         text("(?)")
         item_tooltip(LAYOUT_OVERLAP_HM) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Hit-testing is by default performed in item submission " +
+                text_unformatted((text = "Hit-testing is by default performed in item submission " +
                     "order, which generally is perceived as 'back-to-front'." +
                     "\n\nBy using SetNextItemAllowOverlap() you can notify " +
                     "that an item may be overlapped by another. Doing so " +

--- a/examples/imgui_demo/main.das
+++ b/examples/imgui_demo/main.das
@@ -1,4 +1,5 @@
 options gen2
+options _allow_imgui_legacy = true
 
 require imgui
 require imgui_app

--- a/examples/imgui_demo/popups.das
+++ b/examples/imgui_demo/popups.das
@@ -1,11 +1,10 @@
 options gen2
 options indenting = 4
-options _no_imgui_legacy = true
+options _allow_imgui_legacy = true
 
 module popups
 
 require imgui
-require imgui/imgui_lint
 require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 require imgui/imgui_scope_builtin
@@ -82,8 +81,7 @@ def private PopupsSection() {
     tree_node(POPUPS_POPUPS_SUB,
         (text = "Popups", flags = ImGuiTreeNodeFlags.None)) {
 
-        text_wrapped((text =
-            "When a popup is active, it inhibits interacting with windows " +
+        text_wrapped((text = "When a popup is active, it inhibits interacting with windows " +
             "that are behind the popup. Clicking outside the popup closes it."))
 
         // ----- "Select.." popup -----
@@ -181,8 +179,7 @@ def private ContextMenusSection() {
         text_disabled("(?)")
         item_tooltip(POPUPS_CTX_HM_INTRO_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "\"Context\" functions are simple helpers to associate a Popup to " +
+                text_unformatted((text = "\"Context\" functions are simple helpers to associate a Popup to " +
                     "a given Item or Window identifier."))
             }
         }
@@ -200,7 +197,7 @@ def private ContextMenusSection() {
             popup_context_item(POPUPS_CTX1_POPUP[n],
                                (str_id = "", flags = ImGuiPopupFlags.MouseButtonRight)) {
                 POPUPS_CTX1_SELECTED = n
-                text((text = "This a popup for \"{ex1_names[n]}\"!"))
+                text("This a popup for \"{ex1_names[n]}\"!")
                 if (button((text = "Close"))) {
                     close_current_popup()
                 }
@@ -212,11 +209,10 @@ def private ContextMenusSection() {
         text_disabled("(?)")
         item_tooltip(POPUPS_CTX2_HM_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Text() elements don't have stable identifiers so we need to provide one."))
+                text_unformatted("Text() elements don't have stable identifiers so we need to provide one.")
             }
         }
-        text((text = "Value = {POPUPS_CTX2_VALUE} <-- (1) right-click this text"))
+        text("Value = {POPUPS_CTX2_VALUE} <-- (1) right-click this text")
         popup_context_item(POPUPS_CTX2_POPUP,
                            (str_id = "my popup",
                             flags = ImGuiPopupFlags.MouseButtonRight)) {
@@ -233,7 +229,7 @@ def private ContextMenusSection() {
 
         // Second text triggers the same popup via OpenPopupOnItemClick —
         // string-id form since popup_context_item is stateless.
-        text((text = "(2) Or right-click this text"))
+        text("(2) Or right-click this text")
         open_popup_on_item_click("my popup")
 
         // Third trigger: a plain Button that manually opens the same popup
@@ -246,8 +242,7 @@ def private ContextMenusSection() {
         text_disabled("(?)")
         item_tooltip(POPUPS_CTX3_HM_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Showcase using a popup ID linked to item ID, with the item having " +
+                text_unformatted((text = "Showcase using a popup ID linked to item ID, with the item having " +
                     "a changing label + stable ID using the ### operator."))
             }
         }

--- a/examples/imgui_demo/style_editor.das
+++ b/examples/imgui_demo/style_editor.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module style_editor
 

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module tables
 

--- a/examples/imgui_demo/user_guide.das
+++ b/examples/imgui_demo/user_guide.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module user_guide
 

--- a/examples/imgui_demo/widgets.das
+++ b/examples/imgui_demo/widgets.das
@@ -1,5 +1,6 @@
 options gen2
 options indenting = 4
+options _allow_imgui_legacy = true
 
 module widgets
 
@@ -177,7 +178,7 @@ def private BasicSection() {
             }
         }
         same_line(WIDGETS_SL_6)
-        text((text = "{WIDGETS_BASIC_ARROW_COUNTER}"))
+        text("{WIDGETS_BASIC_ARROW_COUNTER}")
 
         // SetItemTooltip → item_tooltip container (binding-gap shim).
         button(WIDGETS_BASIC_TOOLTIP_BTN, (text = "Tooltip"))
@@ -194,8 +195,7 @@ def private BasicSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_BASIC_HM1_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "USER:\n" +
+                text_unformatted((text = "USER:\n" +
                     "Hold SHIFT or use mouse to select text.\n" +
                     "CTRL+Left/Right to word jump.\n" +
                     "CTRL+A or Double-Click to select all.\n" +
@@ -227,8 +227,7 @@ def private BasicSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_BASIC_HM2_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "You can input value using the scientific notation,\n" +
+                text_unformatted((text = "You can input value using the scientific notation,\n" +
                     "  e.g. \"1e+8\" becomes \"100000000\"."))
             }
         }
@@ -242,8 +241,7 @@ def private BasicSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_BASIC_HM3_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Click and drag to edit value.\n" +
+                text_unformatted((text = "Click and drag to edit value.\n" +
                     "Hold SHIFT/ALT for faster/slower edit.\n" +
                     "Double-click or CTRL+click to input value."))
             }
@@ -291,8 +289,7 @@ def private BasicSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_BASIC_HM5_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Using the format string parameter to display a name instead of the " +
+                text_unformatted((text = "Using the format string parameter to display a name instead of the " +
                     "underlying integer."))
             }
         }
@@ -305,8 +302,7 @@ def private BasicSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_BASIC_HM6_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Click on the color square to open a color picker.\n" +
+                text_unformatted((text = "Click on the color square to open a color picker.\n" +
                     "Click and hold to use drag and drop.\n" +
                     "Right-click on the color square to show options.\n" +
                     "CTRL+click on individual component to input value.\n"))
@@ -324,8 +320,7 @@ def private BasicSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_BASIC_HM7_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Using the simplified one-liner Combo API here.\n" +
+                text_unformatted((text = "Using the simplified one-liner Combo API here.\n" +
                     "Refer to the \"Combo\" section below for an explanation of how to " +
                     "use the more flexible and general BeginCombo/EndCombo API."))
             }
@@ -351,8 +346,7 @@ def private BasicSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_BASIC_HM8_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Using the manual BeginListBox/EndListBox idiom here.\n" +
+                text_unformatted((text = "Using the manual BeginListBox/EndListBox idiom here.\n" +
                     "Refer to the \"List boxes\" section below for the full discussion."))
             }
         }
@@ -372,8 +366,7 @@ def private TooltipsSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_TIPS_HM1_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Tooltip are typically created by using a IsItemHovered() + " +
+                text_unformatted((text = "Tooltip are typically created by using a IsItemHovered() + " +
                     "SetTooltip() sequence.\n\nWe provide a helper SetItemTooltip() " +
                     "function to perform the two with standards flags."))
             }
@@ -396,7 +389,7 @@ def private TooltipsSection() {
             // 9 args are supplied. stride is sizeof(float) = 4.
             PlotLines("Curve", unsafe(addr(arr[0])), length(arr),
                       0, "", FLT_MAX, FLT_MAX, float2(0.0f, 0.0f), 4)
-            text((text = "Sin(time) = {sin(float(GetTime()))}"))
+            text("Sin(time) = {sin(float(GetTime()))}")
         }
 
         separator_text("Always On")
@@ -422,8 +415,7 @@ def private TooltipsSection() {
         text_disabled("(?)")
         item_tooltip(WIDGETS_TIPS_HM2_TIP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
-                text_unformatted((text =
-                    "Passing ImGuiHoveredFlags_ForTooltip to IsItemHovered() is the " +
+                text_unformatted((text = "Passing ImGuiHoveredFlags_ForTooltip to IsItemHovered() is the " +
                     "preferred way to standardize tooltip activation details across " +
                     "your application. You may however decide to use custom flags for " +
                     "a specific tooltip instance."))
@@ -495,8 +487,7 @@ def private TreeNodesSection() {
             text_disabled("(?)")
             item_tooltip(WIDGETS_TREE_HM1_TIP) {
                 with_text_wrap_pos(GetFontSize() * 35.0f) {
-                    text_unformatted((text =
-                        "This is a more typical looking tree with selectable nodes.\n" +
+                    text_unformatted((text = "This is a more typical looking tree with selectable nodes.\n" +
                         "Click to select, CTRL+Click to toggle, click on arrows or " +
                         "double-click to open."))
                 }
@@ -522,8 +513,7 @@ def private TreeNodesSection() {
             text_disabled("(?)")
             item_tooltip(WIDGETS_TREE_HM2_TIP) {
                 with_text_wrap_pos(GetFontSize() * 35.0f) {
-                    text_unformatted((text =
-                        "Extend hit area to all available width instead of allowing " +
+                    text_unformatted((text = "Extend hit area to all available width instead of allowing " +
                         "more items to be laid out after the node."))
                 }
             }
@@ -665,7 +655,7 @@ def private CollapsingHeadersSection() {
                 (text = "Show 2nd header", init = true))
             collapsing_header(WIDGETS_CH_HEADER,
                 (text = "Header", closable = false, flags = ImGuiTreeNodeFlags.None)) {
-                text((text = "IsItemHovered: {IsItemHovered()}"))
+                text("IsItemHovered: {IsItemHovered()}")
                 for (i in range(5)) {
                     text(WIDGETS_LOOP_CH_TEXT_INNER[i], (text = "Some content {i}"))
                 }
@@ -677,7 +667,7 @@ def private CollapsingHeadersSection() {
             if (edit_collapsing_header(safe_addr(WIDGETS_CH_CLOSABLE_GROUP.value),
                                        (id = "WIDGETS_CH_HEADER2",
                                         text = "Header with a close button"))) {
-                text((text = "IsItemHovered: {IsItemHovered()}"))
+                text("IsItemHovered: {IsItemHovered()}")
                 for (i in range(5)) {
                     text(WIDGETS_LOOP_CH_TEXT_INNER2[i], (text = "More content {i}"))
                 }
@@ -730,8 +720,7 @@ def private TextSection() {
 
             tree_node(WIDGETS_TEXT_WORDWRAP,
                 (text = "Word Wrapping", flags = ImGuiTreeNodeFlags.None)) {
-                text_wrapped((text =
-                    "This text should automatically wrap on the edge of the " +
+                text_wrapped((text = "This text should automatically wrap on the edge of the " +
                     "window. The current implementation for text wrapping " +
                     "follows simple rules suitable for English and possibly " +
                     "other languages."))
@@ -771,8 +760,7 @@ def private TextSection() {
 
             tree_node(WIDGETS_TEXT_UTF8,
                 (text = "UTF-8 Text", flags = ImGuiTreeNodeFlags.None)) {
-                text_wrapped((text =
-                    "CJK text will only appear if the font was loaded with the " +
+                text_wrapped((text = "CJK text will only appear if the font was loaded with the " +
                     "appropriate CJK character ranges. Call io.Fonts->" +
                     "AddFontFromFileTTF() manually to load extra character ranges. " +
                     "Read docs/FONTS.md for details."))
@@ -795,8 +783,7 @@ def private ImagesSection() {
         (text = "Images", flags = ImGuiTreeNodeFlags.None)) {
 
         let io & = unsafe(GetIO())
-        text_wrapped((text =
-            "Below we are displaying the font texture (which is the only texture " +
+        text_wrapped((text = "Below we are displaying the font texture (which is the only texture " +
             "we have access to in this demo). Use the 'ImTextureID' type as " +
             "storage to pass pointers or identifier to your own texture data. " +
             "Hover the texture for a zoomed view!"))
@@ -806,7 +793,7 @@ def private ImagesSection() {
         let my_tex_h = float(unsafe(*io.Fonts).TexHeight)
 
         checkbox(WIDGETS_IMAGES_USE_TINT, (text = "Use Text Color for Tint"))
-        text((text = "{int(my_tex_w)}x{int(my_tex_h)}"))
+        text("{int(my_tex_w)}x{int(my_tex_h)}")
         let pos = GetCursorScreenPos()
         let uv_min = float2(0.0f, 0.0f)
         let uv_max = float2(1.0f, 1.0f)
@@ -833,8 +820,8 @@ def private ImagesSection() {
             } elif (region_y > my_tex_h - region_sz) {
                 region_y = my_tex_h - region_sz
             }
-            text((text = "Min: ({region_x}, {region_y})"))
-            text((text = "Max: ({region_x + region_sz}, {region_y + region_sz})"))
+            text("Min: ({region_x}, {region_y})")
+            text("Max: ({region_x + region_sz}, {region_y + region_sz})")
             let uv0 = float2(region_x / my_tex_w, region_y / my_tex_h)
             let uv1 = float2((region_x + region_sz) / my_tex_w,
                              (region_y + region_sz) / my_tex_h)
@@ -858,7 +845,7 @@ def private ImagesSection() {
             same_line(WIDGETS_LOOP_IMG_SL[i])
         }
         new_line(WIDGETS_NL_1)
-        text((text = "Pressed {WIDGETS_IMAGES_PRESSED_COUNT} times."))
+        text("Pressed {WIDGETS_IMAGES_PRESSED_COUNT} times.")
     }
 }
 

--- a/examples/tutorial/boost_basics.das
+++ b/examples/tutorial/boost_basics.das
@@ -58,7 +58,7 @@ def update() {
         // Slider — VOLUME state lives in a generated daslang global.
         VOLUME.bounds = (0.0f, 1.0f)
         slider_float(VOLUME, (text = "Volume"))
-        text((text = "volume = {VOLUME.value}"))
+        text("volume = {VOLUME.value}")
 
         spacing(BB_SP_1)
 
@@ -66,7 +66,7 @@ def update() {
         if (button(BUMP_BTN, (text = "Bump"))) {
             print("bump clicked\n")
         }
-        text((text = "bumps = {BUMP_BTN.click_count}"))
+        text("bumps = {BUMP_BTN.click_count}")
     }
 
     end_of_frame()

--- a/examples/tutorial/custom_widgets.das
+++ b/examples/tutorial/custom_widgets.das
@@ -1,4 +1,9 @@
 options gen2
+// TODO: this tutorial uses pre-v2 raw imgui calls (Text/Spacing/Separator/
+// SameLine etc.) and needs a follow-up rewrite to use the v2 wrappers
+// (text/spacing/separator/same_line). Opt out of the default-on lint until
+// that pass lands so the file stays compileable.
+options _allow_imgui_legacy = true
 
 require imgui
 require imgui_app
@@ -16,7 +21,7 @@ require imgui/imgui_boost_v2
 require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 require imgui/imgui_visual_aids
-require imgui/imgui_boost
+require imgui/imgui_colors
 
 require math
 require strings
@@ -112,21 +117,21 @@ def knob(var state : VolumeKnobState; text : string) : bool {
         center.y + sin(theta) * radius * 0.82f
     )
     let hovered = IsItemHovered()
-    let rim_col = hovered ? IM_COL32(190u, 200u, 220u, 255u) : IM_COL32(120u, 130u, 150u, 255u)
-    *GetWindowDrawList() |> AddCircleFilled(center, radius, IM_COL32(40u, 42u, 48u, 255u), 32)
+    let rim_col = hovered ? rgba(190u, 200u, 220u, 255u) : rgba(120u, 130u, 150u, 255u)
+    *GetWindowDrawList() |> AddCircleFilled(center, radius, rgba(40u, 42u, 48u, 255u), 32)
     *GetWindowDrawList() |> AddCircle(center, radius, rim_col, 32, 2.0f)
-    *GetWindowDrawList() |> AddLine(center, tip, IM_COL32(220u, 200u, 60u, 255u), 3.0f)
+    *GetWindowDrawList() |> AddLine(center, tip, rgba(220u, 200u, 60u, 255u), 3.0f)
 
     // 5. Label + value readout, both drawlist (no ImGui layout impact).
     let label_size = CalcTextSize(text, false, -1.0f)
     let label_pos = ImVec2(center.x - label_size.x * 0.5f, p.y + 76.0f)
-    *GetWindowDrawList() |> AddText(label_pos, IM_COL32(220u, 220u, 220u, 255u), text)
+    *GetWindowDrawList() |> AddText(label_pos, rgba(220u, 220u, 220u, 255u), text)
     let val_str = build_string() <| $(var w) {
         fmt(w, ":.2f", state.value)
     }
     let val_size = CalcTextSize(val_str, false, -1.0f)
     let val_pos = ImVec2(center.x - val_size.x * 0.5f, p.y + 94.0f)
-    *GetWindowDrawList() |> AddText(val_pos, IM_COL32(170u, 170u, 180u, 255u), val_str)
+    *GetWindowDrawList() |> AddText(val_pos, rgba(170u, 170u, 180u, 255u), val_str)
 
     // 6. Wire up serializer + imgui_set dispatcher. Same call any slider makes.
     pending_value_finalize(widget_ident, "knob", state)

--- a/examples/tutorial/driving_outside.das
+++ b/examples/tutorial/driving_outside.das
@@ -90,13 +90,13 @@ def update() {
 
         // ---- A text input — driven by `imgui_set` with a string value ----
         input_text(USER, (text = "User"))
-        text((text = "USER.value = \"{USER.value}\""))
+        text("USER.value = \"{USER.value}\"")
 
         separator(DR_SEP_1)
 
         // ---- A slider — driven by `imgui_set` with a number value ----
         slider_int(SPEED, (text = "Speed"))
-        text((text = "SPEED.value = {SPEED.value}"))
+        text("SPEED.value = {SPEED.value}")
 
         separator(DR_SEP_2)
 
@@ -115,13 +115,13 @@ def update() {
                 }
             }
         }
-        text((text = "PRESET = {preset_label} (idx {PRESET.value})"))
+        text("PRESET = {preset_label} (idx {PRESET.value})")
 
         separator(DR_SEP_3)
 
         // ---- A button — fired by `imgui_click` ----
         if (button(RUN_BTN, (text = "Run"))) {}
-        text((text = "RUN_BTN.click_count = {RUN_BTN.click_count}"))
+        text("RUN_BTN.click_count = {RUN_BTN.click_count}")
 
         separator(DR_SEP_4)
 
@@ -131,7 +131,7 @@ def update() {
                              flags = ImGuiWindowFlags.None)) {
             text("Driven from outside via imgui_open.")
             separator(DR_SEP_5)
-            text((text = "RUN_BTN.click_count = {RUN_BTN.click_count}"))
+            text("RUN_BTN.click_count = {RUN_BTN.click_count}")
         }
     }
 

--- a/examples/tutorial/editing_external.das
+++ b/examples/tutorial/editing_external.das
@@ -114,13 +114,13 @@ def update() {
                                                v_degrees_max = 180.0f))
 
         separator(SEP_READOUT)
-        text((text = "g_volume = {g_volume}"))
-        text((text = "g_count = {g_count}"))
-        text((text = "g_enabled = {g_enabled}"))
-        text((text = "g_pos = ({g_pos.x}, {g_pos.y}, {g_pos.z})"))
-        text((text = "g_accent = ({g_accent.x}, {g_accent.y}, {g_accent.z})"))
-        text((text = "g_quality_idx = {g_quality_idx} ({g_qualities[g_quality_idx]})"))
-        text((text = "g_angle = {g_angle} rad"))
+        text("g_volume = {g_volume}")
+        text("g_count = {g_count}")
+        text("g_enabled = {g_enabled}")
+        text("g_pos = ({g_pos.x}, {g_pos.y}, {g_pos.z})")
+        text("g_accent = ({g_accent.x}, {g_accent.y}, {g_accent.z})")
+        text("g_quality_idx = {g_quality_idx} ({g_qualities[g_quality_idx]})")
+        text("g_angle = {g_angle} rad")
     }
 
     end_of_frame()

--- a/examples/tutorial/flat_tooltips.das
+++ b/examples/tutorial/flat_tooltips.das
@@ -61,14 +61,14 @@ def update() {
         if (button(SAVE_BTN, (text = "Save"))) {
             print("save\n")
         }
-        set_item_tooltip("Persists current state to disk.")
+        set_item_tooltip((text = "Persists current state to disk."))
 
         spacing(SP_BTNS)
 
         if (button(LOAD_BTN, (text = "Load"))) {
             print("load\n")
         }
-        set_item_tooltip("Restores the last saved state.")
+        set_item_tooltip((text = "Restores the last saved state."))
 
         spacing(SP_HELP)
 
@@ -77,7 +77,7 @@ def update() {
         text("Verbose option (with help marker):")
         same_line(SL_HINT)
         text_disabled("(?)")
-        set_item_tooltip("set_item_tooltip after a disabled '(?)' glyph is the dasImgui replacement for the imgui_demo HelpMarker helper.")
+        set_item_tooltip((text = "set_item_tooltip after a disabled '(?)' glyph is the dasImgui replacement for the imgui_demo HelpMarker helper."))
     }
 
     end_of_frame()

--- a/examples/tutorial/live_reload.das
+++ b/examples/tutorial/live_reload.das
@@ -149,21 +149,21 @@ def update() {
         separator(LR_SEP_1)
 
         // ---- The custom counter, driven from outside via [live_command] ----
-        text((text = "g_custom_counter = {g_custom_counter}"))
+        text("g_custom_counter = {g_custom_counter}")
         text("  - @live, preserved across reload")
         text("  - mutated externally by `bump_counter` / `reset_counter`")
 
         separator(LR_SEP_2)
 
         // ---- Contrast: session string resets each reload ----
-        text((text = "g_session_string = \"{g_session_string}\""))
+        text("g_session_string = \"{g_session_string}\"")
         text("  - NOT @live; init() rewrites it each reload")
 
         separator(LR_SEP_3)
 
         // ---- A button whose click count is preserved (ClickState is @live) ----
         if (button(PING_BTN, (text = "Ping (click_count survives reload)"))) {}
-        text((text = "PING_BTN.click_count = {PING_BTN.click_count}"))
+        text("PING_BTN.click_count = {PING_BTN.click_count}")
     }
 
     end_of_frame()

--- a/examples/tutorial/main_menu_bar.das
+++ b/examples/tutorial/main_menu_bar.das
@@ -95,10 +95,10 @@ def update() {
                   flags = ImGuiWindowFlags.None)) {
         text("Click items in the bar above; the snapshot updates below.")
         separator(BODY_SEP)
-        text((text = "MI_DARKMODE.value = {MI_DARKMODE.value}"))
-        text((text = "MI_AUTOSAVE.value = {MI_AUTOSAVE.value}"))
-        text((text = "EDIT_UNDO.click_count = {EDIT_UNDO.click_count}"))
-        text((text = "MI_QUIT.value = {MI_QUIT.value}"))
+        text("MI_DARKMODE.value = {MI_DARKMODE.value}")
+        text("MI_AUTOSAVE.value = {MI_AUTOSAVE.value}")
+        text("EDIT_UNDO.click_count = {EDIT_UNDO.click_count}")
+        text("MI_QUIT.value = {MI_QUIT.value}")
     }
 
     end_of_frame()

--- a/examples/tutorial/narrative_layout_tour.das
+++ b/examples/tutorial/narrative_layout_tour.das
@@ -94,7 +94,7 @@ def update() {
         if (button(HOVER_TIP, (text = "Hover me"))) {
             print("clicked\n")
         }
-        set_item_tooltip("set_item_tooltip — fires on previous-item hover.")
+        set_item_tooltip((text = "set_item_tooltip — fires on previous-item hover."))
     }
 
     end_of_frame()

--- a/examples/tutorial/recording.das
+++ b/examples/tutorial/recording.das
@@ -72,7 +72,7 @@ def update() {
         text("Tiny subject — driver narrates what's happening.")
         slider_float(VOLUME, (text = "Volume"))
         if (button(SAVE_BTN, (text = "Save"))) {}
-        text((text = "SAVE_BTN.click_count = {SAVE_BTN.click_count}"))
+        text("SAVE_BTN.click_count = {SAVE_BTN.click_count}")
     }
 
     end_of_frame()

--- a/examples/tutorial/state_telemetry.das
+++ b/examples/tutorial/state_telemetry.das
@@ -84,7 +84,7 @@ def update() {
             // `button(...)` returns bool — clicked-this-frame. Same info
             // as SAVE_BTN.clicked, just inline.
         }
-        text((text = "SAVE_BTN.click_count = {SAVE_BTN.click_count}"))
+        text("SAVE_BTN.click_count = {SAVE_BTN.click_count}")
 
         separator(ST_SEP_1)
 
@@ -100,7 +100,7 @@ def update() {
         text("Dotted flags tune visibility and live-reload behavior:")
         slider_int(SPEED.PUBLIC,   (text = "Speed (int, PUBLIC)"))
         slider_float(VOLUME.NOTLIVE, (text = "Volume (NOTLIVE)"))
-        text((text = "SPEED.value = {SPEED.value}   VOLUME.value = {VOLUME.value}"))
+        text("SPEED.value = {SPEED.value}   VOLUME.value = {VOLUME.value}")
 
         separator(ST_SEP_2)
 

--- a/examples/tutorial/visual_aids_tour.das
+++ b/examples/tutorial/visual_aids_tour.das
@@ -75,7 +75,7 @@ def update() {
         }
         separator(VA_SEP_2)
         input_text(NAME_INPUT, (text = "Name"))
-        text((text = "buffer = {NAME_INPUT.value}"))
+        text("buffer = {NAME_INPUT.value}")
     }
 
     // ===== Controls window — driver buttons for the aids =====
@@ -124,7 +124,7 @@ def update() {
         }
 
         spacing(VA_SP_3)
-        text((text = "Auto-highlight on command (flag, currently {imgui_auto_highlight_on_command}):"))
+        text("Auto-highlight on command (flag, currently {imgui_auto_highlight_on_command}):")
         separator(VA_SEP_6)
         if (button(BTN_AUTO_ON, (text = "auto-highlight ON"))) {
             imgui_auto_highlight_on_command = true

--- a/examples/tutorial/widgets_tour.das
+++ b/examples/tutorial/widgets_tour.das
@@ -100,7 +100,7 @@ def update() {
         }
 
         spacing(WT_SP_6)
-        text((text = "saves so far: {SAVE_BTN.click_count}"))
+        text("saves so far: {SAVE_BTN.click_count}")
     }
 
     end_of_frame()

--- a/examples/tutorial/with_disabled.das
+++ b/examples/tutorial/with_disabled.das
@@ -88,7 +88,7 @@ def update() {
             }
         }
 
-        text((text = "STEP_UP.click_count = {STEP_UP.click_count}"))
+        text("STEP_UP.click_count = {STEP_UP.click_count}")
 
         separator_text("with_font")
 

--- a/examples/tutorial/with_id.das
+++ b/examples/tutorial/with_id.das
@@ -87,7 +87,7 @@ def update() {
         with_id("section_b") {
             button(SAVE_BTN, (text = "Save in B"))
         }
-        text((text = "SAVE_BTN.click_count aggregates: {SAVE_BTN.click_count}"))
+        text("SAVE_BTN.click_count aggregates: {SAVE_BTN.click_count}")
 
         separator(WI_SEP_1)
 

--- a/tests/integration/failed_imgui_lint_raw.das
+++ b/tests/integration/failed_imgui_lint_raw.das
@@ -1,11 +1,10 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
 require imgui/imgui_lint
 
-//! Negative test — `_no_imgui_legacy = true` + raw `imgui::Button` must
-//! trip IMGUI002 (runtime_macro error code 50503).
+//! Negative test — default-on lint + raw `imgui::Button` must trip
+//! IMGUI002 (macro_error code 50503). No opt-in line required.
 
 expect 50503
 

--- a/tests/integration/failed_imgui_lint_style_verbose.das
+++ b/tests/integration/failed_imgui_lint_style_verbose.das
@@ -1,0 +1,15 @@
+options gen2
+
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+
+//! Negative test — verbose named-tuple form `text((text=...))` must trip
+//! STYLE001 (macro_error code 50503). Lint is default-on and bundled via
+//! `imgui/imgui_boost_v2`; no opt-in line required.
+
+expect 50503
+
+[export]
+def main() {
+    text((text = "must fail with STYLE001"))
+}

--- a/tests/integration/record_boost_basics.das
+++ b/tests/integration/record_boost_basics.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_boost_narrative_layout.das
+++ b/tests/integration/record_boost_narrative_layout.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_containers.das
+++ b/tests/integration/record_containers.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_docking.das
+++ b/tests/integration/record_docking.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_drag_drop.das
+++ b/tests/integration/record_drag_drop.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_driving_outside.das
+++ b/tests/integration/record_driving_outside.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_edit_external.das
+++ b/tests/integration/record_edit_external.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_layout.das
+++ b/tests/integration/record_layout.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_live_reload.das
+++ b/tests/integration/record_live_reload.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_recording.das
+++ b/tests/integration/record_recording.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_state_telemetry.das
+++ b/tests/integration/record_state_telemetry.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_visual_aids.das
+++ b/tests/integration/record_visual_aids.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_widgets_tour.das
+++ b/tests/integration/record_widgets_tour.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_with_id.das
+++ b/tests/integration/record_with_id.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/record_with_style.das
+++ b/tests/integration/record_with_style.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require imgui public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_active_widget.das
+++ b/tests/integration/test_active_widget.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_await_quiescent.das
+++ b/tests/integration/test_await_quiescent.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_button_repeat.das
+++ b/tests/integration/test_button_repeat.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_clip_rect.das
+++ b/tests/integration/test_clip_rect.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_collapsing_header_closable.das
+++ b/tests/integration/test_collapsing_header_closable.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_columns.das
+++ b/tests/integration/test_columns.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_containers_layout.das
+++ b/tests/integration/test_containers_layout.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_containers_overlay.das
+++ b/tests/integration/test_containers_overlay.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_containers_window.das
+++ b/tests/integration/test_containers_window.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_disabled_block.das
+++ b/tests/integration/test_disabled_block.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_display_image.das
+++ b/tests/integration/test_display_image.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_display_progress.das
+++ b/tests/integration/test_display_progress.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_docking_basic.das
+++ b/tests/integration/test_docking_basic.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_drag_drop.das
+++ b/tests/integration/test_drag_drop.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_edit_external_color.das
+++ b/tests/integration/test_edit_external_color.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_edit_external_combo.das
+++ b/tests/integration/test_edit_external_combo.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_edit_external_scalars.das
+++ b/tests/integration/test_edit_external_scalars.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_edit_external_special.das
+++ b/tests/integration/test_edit_external_special.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_edit_external_toggles.das
+++ b/tests/integration/test_edit_external_toggles.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_edit_external_vectors.das
+++ b/tests/integration/test_edit_external_vectors.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_focus_widget.das
+++ b/tests/integration/test_focus_widget.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_font_stack.das
+++ b/tests/integration/test_font_stack.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_foundation.das
+++ b/tests/integration/test_foundation.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_glfw_synth_keys.das
+++ b/tests/integration/test_glfw_synth_keys.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_glfw_synth_mouse.das
+++ b/tests/integration/test_glfw_synth_mouse.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_hex_id_click.das
+++ b/tests/integration/test_hex_id_click.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_id_override.das
+++ b/tests/integration/test_id_override.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_imgui_lint_allow.das
+++ b/tests/integration/test_imgui_lint_allow.das
@@ -1,11 +1,10 @@
 options gen2
-options _no_imgui_legacy = true
 
 require imgui
 require imgui/imgui_lint
 
-//! Allow-list smoke — `_no_imgui_legacy = true` AND only allow-listed raw
-//! calls (`GetIO`, frame lifecycle). Must compile clean.
+//! Allow-list smoke — default-on lint AND only allow-listed raw calls
+//! (`GetIO`, frame lifecycle). Must compile clean.
 
 [export]
 def main() {

--- a/tests/integration/test_imgui_lint_off.das
+++ b/tests/integration/test_imgui_lint_off.das
@@ -1,10 +1,11 @@
 options gen2
+options _allow_imgui_legacy = true
 
 require imgui
 require imgui/imgui_lint
 
-//! Smoke test — `imgui_lint` is loaded but `_no_imgui_legacy` is NOT set.
-//! The lint must stay dormant; a raw imgui::Button call compiles cleanly.
+//! Opt-out smoke — `imgui_lint` is loaded and default-on, but
+//! `_allow_imgui_legacy = true` disables it. Raw imgui::Button compiles cleanly.
 
 [export]
 def main() {

--- a/tests/integration/test_imgui_synth_ctrl_shortcuts.das
+++ b/tests/integration/test_imgui_synth_ctrl_shortcuts.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui public
 require imgui/imgui_playwright public
 require daslib/json public

--- a/tests/integration/test_inputs_choice.das
+++ b/tests/integration/test_inputs_choice.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_inputs_color.das
+++ b/tests/integration/test_inputs_color.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_inputs_drag.das
+++ b/tests/integration/test_inputs_drag.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_inputs_indexed.das
+++ b/tests/integration/test_inputs_indexed.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_inputs_numeric.das
+++ b/tests/integration/test_inputs_numeric.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_inputs_slider.das
+++ b/tests/integration/test_inputs_slider.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_inputs_text.das
+++ b/tests/integration/test_inputs_text.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_io_mirror.das
+++ b/tests/integration/test_io_mirror.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_io_synth_drag.das
+++ b/tests/integration/test_io_synth_drag.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_io_synth_text.das
+++ b/tests/integration/test_io_synth_text.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_layout_helpers.das
+++ b/tests/integration/test_layout_helpers.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_layout_primitives.das
+++ b/tests/integration/test_layout_primitives.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_lifecycle.das
+++ b/tests/integration/test_lifecycle.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 
 //! Smallest possible exercise of the harness — spawn daslang-live against a

--- a/tests/integration/test_list_box.das
+++ b/tests/integration/test_list_box.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_menu_label_static.das
+++ b/tests/integration/test_menu_label_static.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_menu_main.das
+++ b/tests/integration/test_menu_main.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_module_isolation.das
+++ b/tests/integration/test_module_isolation.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require daslib/fio
 require strings
 require math

--- a/tests/integration/test_narrative_bullet.das
+++ b/tests/integration/test_narrative_bullet.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_narrative_separator.das
+++ b/tests/integration/test_narrative_separator.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_narrative_text.das
+++ b/tests/integration/test_narrative_text.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_output_text.das
+++ b/tests/integration/test_output_text.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_plot_getter.das
+++ b/tests/integration/test_plot_getter.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_plot_widgets.das
+++ b/tests/integration/test_plot_widgets.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_popup_context_item.das
+++ b/tests/integration/test_popup_context_item.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_save_demo.das
+++ b/tests/integration/test_save_demo.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_scroll_state.das
+++ b/tests/integration/test_scroll_state.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_snapshot.das
+++ b/tests/integration/test_snapshot.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_snapshot_unrendered.das
+++ b/tests/integration/test_snapshot_unrendered.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_style_with_style.das
+++ b/tests/integration/test_style_with_style.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_tooltip_flat.das
+++ b/tests/integration/test_tooltip_flat.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_transport_lambda.das
+++ b/tests/integration/test_transport_lambda.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require imgui/imgui_transport public
 require daslib/json public

--- a/tests/integration/test_triggers.das
+++ b/tests/integration/test_triggers.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_visual_aids_focus_rect.das
+++ b/tests/integration/test_visual_aids_focus_rect.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_visual_aids_key_hud.das
+++ b/tests/integration/test_visual_aids_key_hud.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_visual_aids_narrate.das
+++ b/tests/integration/test_visual_aids_narrate.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_visual_aids public
 require math
 

--- a/tests/integration/test_widget_init_defaults.das
+++ b/tests/integration/test_widget_init_defaults.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require imgui public
 require daslib/json public

--- a/tests/integration/test_with_indent.das
+++ b/tests/integration/test_with_indent.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_with_item_width.das
+++ b/tests/integration/test_with_item_width.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/tests/integration/test_with_text_wrap_pos.das
+++ b/tests/integration/test_with_text_wrap_pos.das
@@ -2,10 +2,8 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _no_imgui_legacy = true
 
 require dastest/testing_boost public
-require imgui/imgui_lint
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public

--- a/widgets/imgui_boost.das
+++ b/widgets/imgui_boost.das
@@ -2,10 +2,12 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_boost_v2 shared
 
 require imgui public
+require imgui/imgui_lint public
 require imgui/imgui_boost_runtime public
 require daslib/ast
 require daslib/ast_boost
@@ -241,6 +243,29 @@ class WidgetCallMacro : AstCallMacro {
             } elif (head is ExprMakeTuple && (head as ExprMakeTuple) != null
                     && length((head as ExprMakeTuple).recordNames) == length((head as ExprMakeTuple).values)
                     && !empty((head as ExprMakeTuple).recordNames)) {
+                // STYLE001 — verbose `kind((field="literal"))` where positional `kind("literal")` works.
+                // Three gates, ALL must match:
+                //   1. Single arg, single named-tuple field (no other call args).
+                //   2. The lone field's value is a string literal or string-builder
+                //      — positional sugar at line 222 only accepts those, so an ExprVar
+                //      arg has NO positional alternative (would silently become Form 1
+                //      and treat the var as the widget IDENT).
+                //   3. Wrapper accepts positional-string form AND the field name matches
+                //      the wrapper's first user param.
+                //   4. `_allow_imgui_legacy = true` is NOT set on the consumer file.
+                let mtCheck = head as ExprMakeTuple
+                if (length(expr.arguments) == 1 && length(mtCheck.recordNames) == 1
+                        && (mtCheck.values[0] is ExprConstString || mtCheck.values[0] is ExprStringBuilder)
+                        && accepts_positional_string()) {
+                    let firstParamName = string(render_fn.arguments[2].name)
+                    let tupleFieldName = string(mtCheck.recordNames[0])
+                    let opted_out = prog._options |> find_arg("_allow_imgui_legacy") ?as tBool ?? false
+                    if (firstParamName == tupleFieldName && !opted_out) {
+                        macro_error(prog, expr.at,
+                            "STYLE001: prefer positional form `{kind_name}(\"...\")` over verbose named-tuple `{kind_name}(({tupleFieldName}=...))`. Per-file opt-out: `options _allow_imgui_legacy = true`")
+                        return <- default<ExpressionPtr>
+                    }
+                }
                 // Form 2: auto-gen ident from source location. The first arg is a
                 // named-tuple — user did not supply an ident.
                 bareName = synth_bare_name(expr.at)

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_boost_runtime shared
 

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_containers_builtin shared
 

--- a/widgets/imgui_docking_builtin.das
+++ b/widgets/imgui_docking_builtin.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_docking_builtin shared
 

--- a/widgets/imgui_id_builtin.das
+++ b/widgets/imgui_id_builtin.das
@@ -1,6 +1,7 @@
 options gen2
 options indenting = 4
 options no_unused_block_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_id_builtin shared
 

--- a/widgets/imgui_layout_builtin.das
+++ b/widgets/imgui_layout_builtin.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_layout_builtin shared
 

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -4,14 +4,19 @@ options strict_smart_pointers = true
 
 module imgui_lint shared private
 
-//! dasImgui lint pass — `_no_imgui_legacy`.
+//! dasImgui lint pass — default-on rule catalog.
 //!
-//! Opt-in compile-time pass that forbids legacy ImGui access from consumer
-//! files. Enabled by ``options _no_imgui_legacy = true``; off otherwise.
+//! Bundled into ``imgui/imgui_boost_v2`` (and therefore everything that
+//! transitively requires it). Runs on every consumer compile by default;
+//! opt out per-file via ``options _allow_imgui_legacy = true``.
 //!
-//! Codes:
-//!   IMGUI001 — any call into the dead v1 `imgui_boost` module
-//!   IMGUI002 — any raw `imgui::*` call not on the allow-list
+//! Codes (all macro_error severity, error code 50503; all gated by the
+//! single ``_allow_imgui_legacy`` opt-out):
+//!   IMGUI001 — call into the dead v1 ``imgui_boost`` module (visitor, this file)
+//!   IMGUI002 — raw ``imgui::*`` call not on the allow-list (visitor, this file)
+//!   STYLE001 — verbose named-tuple call shape ``widget((field=x))`` where the
+//!              single-arg positional form ``widget(x)`` works (implemented in
+//!              ``WidgetCallMacro.visit()`` inside imgui_boost.das)
 //!
 //! The allow-list (``ALLOWED_IMGUI`` below) is the curated set of raw
 //! bindings that v2 deliberately doesn't wrap (frame lifecycle, IO/state
@@ -21,7 +26,9 @@ module imgui_lint shared private
 //! Scoping: walks ``prog.getThisModule`` only, so the lint runs on the
 //! consumer file and skips the transitively-required boost modules
 //! (which legitimately call raw ``imgui::*`` because that's the whole
-//! point of being the wrapper).
+//! point of being the wrapper). Wrapper modules under widgets/ also carry
+//! ``options _allow_imgui_legacy = true`` defensively so they compile
+//! cleanly when targeted directly (MCP compile_check, lint, format_file).
 
 require daslib/ast_boost
 require strings
@@ -51,7 +58,7 @@ let private ALLOWED_IMGUI : table<string> <- {
     "GetItemRectMin", "GetItemRectMax", "GetItemRectSize",
     "CalcTextSize", "CalcItemWidth",
     // Font / color helpers (read-only)
-    "GetFontSize",
+    "GetFont", "GetFontSize",
     "GetTextLineHeight", "GetTextLineHeightWithSpacing",
     "GetFrameHeight", "GetFrameHeightWithSpacing",
     "GetStyleColorVec4", "GetColorU32",
@@ -120,7 +127,7 @@ class ImguiLintVisitor : AstVisitor {
             let fname = string(expr.func.name)
             if (!key_exists(ALLOWED_IMGUI, fname)) {
                 compiling_program() |> macro_error(expr.at,
-                    "IMGUI002: raw imgui::{fname} is forbidden under _no_imgui_legacy — add a [widget]/[container]/with_* wrapper in modules/dasImgui/widgets/, or extend ALLOWED_IMGUI in imgui_lint.das if {fname} is genuinely host-agnostic")
+                    "IMGUI002: raw imgui::{fname} is forbidden — add a [widget]/[container]/with_* wrapper in modules/dasImgui/widgets/, or extend ALLOWED_IMGUI in imgui_lint.das if {fname} is genuinely host-agnostic. Per-file escape: `options _allow_imgui_legacy = true`")
             }
         }
     }
@@ -129,8 +136,8 @@ class ImguiLintVisitor : AstVisitor {
 [lint_macro]
 class ImguiLintMacro : AstPassMacro {
     def override apply(prog : ProgramPtr; mod : Module?) : bool {
-        let enabled = prog._options |> find_arg("_no_imgui_legacy") ?as tBool ?? false
-        if (!enabled) return true
+        let opted_out = prog._options |> find_arg("_allow_imgui_legacy") ?as tBool ?? false
+        if (opted_out) return true
         var v = new ImguiLintVisitor()
         make_visitor(*v) $(adapter) {
             visit_module(prog, adapter, prog.getThisModule)

--- a/widgets/imgui_live.das
+++ b/widgets/imgui_live.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_live shared public
 

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -1,6 +1,7 @@
 options gen2
 options indenting = 4
 options no_unused_block_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_scope_builtin shared
 

--- a/widgets/imgui_style_builtin.das
+++ b/widgets/imgui_style_builtin.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_style_builtin shared
 

--- a/widgets/imgui_visual_aids.das
+++ b/widgets/imgui_visual_aids.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_visual_aids shared public
 

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
 
 module imgui_widgets_builtin shared
 
@@ -1357,13 +1358,14 @@ def text(var state : NarrativeState; text : string) {
     //! Plain text display. `state.value` echoes the call-site string for
     //! `expect_value(IDENT, "literal")` assertions.
     state.value := text
-    Text(text)
+    TextUnformatted(text)
     narrative_finalize(widget_ident, "text", state)
 }
 
 [widget]
 def text_unformatted(var state : NarrativeState; text : string) {
-    //! Like `text` but bypasses ImGui's printf-style format parsing — no `%` escaping needed.
+    //! Alias for `text` — kept for explicit clarity at call sites where the
+    //! "no printf" intent matters. Identical behavior to `text`.
     state.value := text
     TextUnformatted(text)
     narrative_finalize(widget_ident, "text_unformatted", state)
@@ -1373,7 +1375,9 @@ def text_unformatted(var state : NarrativeState; text : string) {
 def text_wrapped(var state : NarrativeState; text : string) {
     //! Text wrapped to the current window or content-region width.
     state.value := text
-    TextWrapped(text)
+    PushTextWrapPos(0.0f)
+    TextUnformatted(text)
+    PopTextWrapPos()
     narrative_finalize(widget_ident, "text_wrapped", state)
 }
 
@@ -1381,7 +1385,9 @@ def text_wrapped(var state : NarrativeState; text : string) {
 def text_colored(var state : NarrativeState; color : float4; text : string) {
     //! Tinted text — `color` overrides ``ImGuiCol_Text`` for this draw.
     state.value := text
-    TextColored(color, text)
+    PushStyleColor(ImGuiCol.Text, color)
+    TextUnformatted(text)
+    PopStyleColor(1)
     narrative_finalize(widget_ident, "text_colored", state)
 }
 
@@ -1389,7 +1395,9 @@ def text_colored(var state : NarrativeState; color : float4; text : string) {
 def text_disabled(var state : NarrativeState; text : string) {
     //! Text rendered in the disabled style (``ImGuiCol_TextDisabled``).
     state.value := text
-    TextDisabled(text)
+    PushStyleColor(ImGuiCol.Text, GetStyleColorVec4(ImGuiCol.TextDisabled))
+    TextUnformatted(text)
+    PopStyleColor(1)
     narrative_finalize(widget_ident, "text_disabled", state)
 }
 
@@ -1397,7 +1405,8 @@ def text_disabled(var state : NarrativeState; text : string) {
 def bullet_text(var state : NarrativeState; text : string) {
     //! Bullet point followed by text — like `bullet` + `text` in one call.
     state.value := text
-    BulletText(text)
+    Bullet()
+    TextUnformatted(text)
     narrative_finalize(widget_ident, "bullet_text", state)
 }
 
@@ -2183,9 +2192,9 @@ def edit_collapsing_header(var ptr : bool? implicit; text : string = "";
 // ===== Imperative commands (scroll / focus / clipboard) =====
 //
 // These are non-`[widget]` helpers — plain `def public` aliases over raw
-// ImGui calls that user code shouldn't reach for directly while
-// `options _no_imgui_legacy = true` is in effect. They take no block and
-// produce no state, so they don't fit the [widget] / [container] mold.
+// ImGui calls that user code shouldn't reach for directly under the
+// default-on lint. They take no block and produce no state, so they
+// don't fit the [widget] / [container] mold.
 
 def public set_scroll_here_y(center_y_ratio : float = 1.0f) {
     //! `SetScrollHereY(center_y_ratio)` — scrolls the current window so the


### PR DESCRIPTION
## Summary

Adopts the [3 Horsemen](https://daslang.io/blog/the-3-horseman.html) default-deny philosophy for dasImgui:

- **Lint is mandatory.** `imgui_lint` is now bundled into `imgui/imgui_boost_v2` via `require ... public`, so every consumer compile runs the pass by default. The opt-in `options _no_imgui_legacy = true` flips to opt-out `options _allow_imgui_legacy = true`.
- **Printf footgun gone at the source.** All 5 narrative-text wrappers (`text` / `text_wrapped` / `text_colored` / `text_disabled` / `bullet_text`) decompose to `TextUnformatted`-based primitives. A `%` in any consumer string can no longer reach ImGui's printf parser regardless of what's passed in.
- **STYLE001 — preventive lock against the verbose form.** New rule in `WidgetCallMacro.visit()` (in `imgui_boost.das`) rejects `widget((field="literal"))` when positional `widget("literal")` works. Narrow gate: fires only on (a) single-arg call with single named-tuple field, (b) field value is a string literal or string-builder (concatenations stay in Form 2), (c) wrapper accepts positional-string form, (d) `_allow_imgui_legacy` is not set. Severity = `macro_error` (50503) so it's testable via `expect`.

## Mechanics

- **`widgets/imgui_lint.das`** — flip option name; rewrite header docstring as rule catalog covering IMGUI001/IMGUI002/STYLE001; update IMGUI002 error message to mention the new opt-out; add `GetFont` to `ALLOWED_IMGUI`.
- **`widgets/imgui_boost.das`** — `require imgui/imgui_lint public` bundles the lint; STYLE001 check added inside Form 2 detection in `WidgetCallMacro.visit()`.
- **`widgets/imgui_widgets_builtin.das`** — 5 wrapper bodies refactored:
  - `text` → `TextUnformatted(text)`
  - `text_wrapped` → `PushTextWrapPos(0.0f) / TextUnformatted / PopTextWrapPos()`
  - `text_colored` → `PushStyleColor(Text, color) / TextUnformatted / PopStyleColor(1)`
  - `text_disabled` → `PushStyleColor(Text, GetStyleColorVec4(TextDisabled)) / TextUnformatted / PopStyleColor(1)`
  - `bullet_text` → `Bullet() / TextUnformatted(text)`
- **11 wrapper modules** (`imgui_boost`, `imgui_boost_runtime`, `imgui_widgets_builtin`, `imgui_containers_builtin`, `imgui_docking_builtin`, `imgui_id_builtin`, `imgui_layout_builtin`, `imgui_scope_builtin`, `imgui_style_builtin`, `imgui_live`, `imgui_visual_aids`) carry `options _allow_imgui_legacy = true` for direct compilation (MCP `compile_check`, `lint`, `format_file`).
- **18 `examples/imgui_demo/*.das`** opt out — they port the full ImGui C++ demo surface and intentionally use raw `imgui::*`.
- **3 examples opt out individually**: `widget_no_ident` (deliberately demos Form 2), `clip_rect` (low-level `ImDrawList` API), `custom_widgets` (pre-v2 raw `Text`/`Spacing`/`Separator`/`SameLine` — flagged with TODO for a follow-up rewrite).
- **128 example/test files swept**: stripped dead `options _no_imgui_legacy = true` + `require imgui/imgui_lint`.
- **142 literal-form rewrites**: `widget((text = "literal"))` → `widget("literal")` across 20 files. Concatenation form `((text = "a" + "b" + "c"))` stays verbose since Form 3 positional sugar only accepts single-literal / string-builder args.
- **New test** `tests/integration/failed_imgui_lint_style_verbose.das` — `expect 50503` on `text((text = "..."))` verifies STYLE001 fires by default.
- **Pre-existing fixes carried in**: `set_item_tooltip("...")` → `set_item_tooltip((text = "..."))` ×4; `custom_widgets.das` `IM_COL32(...)` → `rgba(...)` + missing `require imgui/imgui_colors`.

## Verification

- `daslang.exe dastest/dastest.das -- --test modules/dasImgui/tests/integration` — **110 tests, 110 passed**, including the three lint expect-failure tests:
  - `failed_imgui_lint_raw.das` → IMGUI002 fires under default-on
  - `failed_imgui_lint_style_verbose.das` → STYLE001 fires on the verbose form
  - `test_imgui_lint_off.das` → `_allow_imgui_legacy = true` cleanly disables the lint
- All `examples/features/*.das`, `examples/imgui_demo/*.das`, `examples/tutorial/*.das` compile clean.
- MCP `format_file` on every changed `.das` returns either `already_formatted` or applied stylistic adjustments (mostly `=`-spacing normalization).

## Out of scope (follow-ups)

- `custom_widgets.das` carries a TODO comment — its pre-v2 raw imgui calls (`Text`, `Spacing`, `Separator`, `SameLine`) want a proper rewrite to v2 wrappers; opt-out is the temporary escape.
- The 10 pre-existing STYLE022 (bitfield-as-field) warnings in `imgui_boost.das` are unrelated to this PR and left alone.
