### PR TITLE
lint: clean dasImgui tree against daslang utils/lint (post PR #33)

### DIFF
--- a/examples/features/indexed_dynamic.das
+++ b/examples/features/indexed_dynamic.das
@@ -59,9 +59,7 @@ def find_max_key(t : table<int; SliderStateFloat>) : int {
 
 [export]
 def update() {
-    if (!live_begin_frame()) {
-        return
-    }
+    return if (!live_begin_frame())
     begin_frame()
 
     ImGui_ImplOpenGL3_NewFrame()

--- a/examples/features/inputs_indexed.das
+++ b/examples/features/inputs_indexed.das
@@ -58,9 +58,7 @@ def init() {
 
 [export]
 def update() {
-    if (!live_begin_frame()) {
-        return
-    }
+    return if (!live_begin_frame())
     begin_frame()
 
     ImGui_ImplOpenGL3_NewFrame()

--- a/examples/tutorial/narrative_layout_tour.das
+++ b/examples/tutorial/narrative_layout_tour.das
@@ -55,7 +55,7 @@ def update() {
 
     g_progress += 0.005f
     if (g_progress > 1.0f) {
-        g_progress -= 1.0f
+        g_progress--
     }
 
     SetNextWindowPos(ImVec2(60.0, 60.0), ImGuiCond.Always)

--- a/tests/integration/test_visual_aids_narrate.das
+++ b/tests/integration/test_visual_aids_narrate.das
@@ -36,7 +36,7 @@ def near2(a, b : float2; eps : float = 0.5f) : bool {
 def test_anchor_centered_widget_picks_right(t : T?) {
     //! Case 1: widget in the middle of a roomy viewport — right wins on priority.
     let bb = float4(500.0f, 300.0f, 600.0f, 340.0f)
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, BOX_SMALL, VIEW_HD, MARGIN, GAP, SHADOW, 0.0f, no_others)
     t |> success(near2(a, float2(616.0f, 300.0f)), "case 1 right: anchor=(bb.right+gap, bb.top)")
 }
@@ -45,7 +45,7 @@ def test_anchor_centered_widget_picks_right(t : T?) {
 def test_anchor_right_edge_flips_to_left(t : T?) {
     //! Case 2: widget near the right edge — right candidate overflows, flip to left.
     let bb = float4(1000.0f, 300.0f, 1100.0f, 340.0f)
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, BOX_SMALL, VIEW_HD, MARGIN, GAP, SHADOW, 0.0f, no_others)
     t |> success(near2(a, float2(784.0f, 300.0f)), "case 2 left: anchor=(bb.left-gap-box_w, bb.top)")
 }
@@ -54,7 +54,7 @@ def test_anchor_right_edge_flips_to_left(t : T?) {
 def test_anchor_wide_widget_picks_below(t : T?) {
     //! Case 3: widget too wide for right OR left to fit — drops to below.
     let bb = float4(100.0f, 250.0f, 700.0f, 300.0f)
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, BOX_WIDE, VIEW_SD, MARGIN, GAP, SHADOW, 0.0f, no_others)
     let expected_x = (100.0f + 700.0f) * 0.5f - BOX_WIDE.x * 0.5f  // = 250
     let expected_y = 300.0f + GAP                                   // = 316
@@ -65,7 +65,7 @@ def test_anchor_wide_widget_picks_below(t : T?) {
 def test_anchor_bottom_right_picks_above(t : T?) {
     //! Case 4: wide widget at the bottom — right/left/below all fail, above wins.
     let bb = float4(40.0f, 540.0f, 760.0f, 580.0f)
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, BOX_WIDE, VIEW_SD, MARGIN, GAP, SHADOW, 0.0f, no_others)
     let expected_x = (40.0f + 760.0f) * 0.5f - BOX_WIDE.x * 0.5f    // = 250
     let expected_y = 540.0f - GAP - BOX_WIDE.y                      // = 484
@@ -76,7 +76,7 @@ def test_anchor_bottom_right_picks_above(t : T?) {
 def test_anchor_top_left_widget_picks_right(t : T?) {
     //! Case 5: widget at top-left corner — right candidate fits, no flipping needed.
     let bb = float4(40.0f, 40.0f, 200.0f, 80.0f)
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, BOX_SMALL, VIEW_HD, MARGIN, GAP, SHADOW, 0.0f, no_others)
     t |> success(near2(a, float2(216.0f, 40.0f)), "case 5 right: top-left widget, plenty of room")
 }
@@ -87,7 +87,7 @@ def test_anchor_giant_widget_falls_back_to_clamped_right(t : T?) {
     //! fallback clamps right placement into viewport bounds.
     let view = float2(400.0f, 300.0f)
     let bb = float4(10.0f, 10.0f, 390.0f, 290.0f)
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, BOX_SMALL, view, MARGIN, GAP, SHADOW, 0.0f, no_others)
     let max_x = view.x - MARGIN - BOX_SMALL.x - SHADOW.x   // = 189
     t |> success(near2(a, float2(max_x, 10.0f)), "case 6 fallback: right candidate clamped to max_x")
@@ -99,7 +99,7 @@ def test_anchor_hud_zone_pushes_above(t : T?) {
     //! lands in the HUD zone, so above wins instead.
     let bb = float4(500.0f, 580.0f, 700.0f, 620.0f)
     let hud_h = 110.0f
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, BOX_SMALL, VIEW_HD, MARGIN, GAP, SHADOW, hud_h, no_others)
     let cx = (500.0f + 700.0f) * 0.5f
     let expected_x = cx - BOX_SMALL.x * 0.5f                // = 500
@@ -114,7 +114,7 @@ def test_anchor_text_wider_than_viewport_clamps_to_margin(t : T?) {
     let view = float2(400.0f, 300.0f)
     let bb = float4(100.0f, 100.0f, 200.0f, 140.0f)
     let big = float2(500.0f, 40.0f)
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(true, bb, big, view, MARGIN, GAP, SHADOW, 0.0f, no_others)
     t |> equal(a.x, MARGIN, "case 8 fallback: anchor.x clamps to edge_margin when text is too wide")
 }
@@ -122,7 +122,7 @@ def test_anchor_text_wider_than_viewport_clamps_to_margin(t : T?) {
 [test]
 def test_floating_narrate_returns_corner(t : T?) {
     //! Floating case (no target): anchor is the top-left corner of the viewport.
-    var no_others : array<float4>
+    let no_others : array<float4>
     let a = compute_narrate_anchor(false, float4(0.0f, 0.0f, 0.0f, 0.0f),
                                    BOX_SMALL, VIEW_HD, MARGIN, GAP, SHADOW, 0.0f, no_others)
     t |> success(near2(a, float2(MARGIN, MARGIN)), "no-target: anchor pinned to top-left corner")
@@ -155,7 +155,7 @@ def test_anchor_right_blocked_by_other_widget_flips_to_left(t : T?) {
     //! Case 10: right candidate fits the viewport but overlaps a sibling
     //! widget — flip to left, which fits and has no neighbor in the way.
     let bb = float4(500.0f, 300.0f, 600.0f, 340.0f)
-    var others <- [float4(620.0f, 290.0f, 900.0f, 380.0f)]
+    let others <- [float4(620.0f, 290.0f, 900.0f, 380.0f)]
     let a = compute_narrate_anchor(true, bb, BOX_SMALL, VIEW_HD, MARGIN, GAP, SHADOW, 0.0f, others)
     t |> success(near2(a, float2(284.0f, 300.0f)), "case 10: right blocked by sibling, falls to left")
 }
@@ -165,7 +165,7 @@ def test_anchor_all_sides_blocked_falls_back_to_clamped_right(t : T?) {
     //! Case 11: every candidate (R/L/Below/Above) overlaps a sibling — fall
     //! back to clamped right placement (existing graceful-degradation path).
     let bb = float4(500.0f, 300.0f, 600.0f, 340.0f)
-    var others <- [
+    let others <- [
         float4(610.0f, 290.0f, 900.0f, 380.0f),    // blocks right
         float4(100.0f, 290.0f, 490.0f, 380.0f),    // blocks left
         float4(380.0f, 350.0f, 720.0f, 500.0f),    // blocks below

--- a/widgets/imgui_boost.das
+++ b/widgets/imgui_boost.das
@@ -68,14 +68,14 @@ def private apply_widget_or_container(var func : FunctionPtr; var errors : das_s
     }
     let stateTypeName = describe(stateArg._type)
     let stateStruct = stateArg._type.structType
-    func.flags |= FunctionFlags.generated
+    func.flags.generated = true
     // Inject widget_ident : string at index 1 (between state and rest).
     // The user's body code references `widget_ident` literally when
     // calling widget_finalize / container_finalize — this param makes it in scope.
     var widthIdentVar = new Variable(at = func.at,
         name := "widget_ident",
         _type <- new TypeDecl(baseType = Type.tString, at = func.at))
-    widthIdentVar.flags |= VariableFlags.generated
+    widthIdentVar.flags.generated = true
     func.arguments |> emplace(widthIdentVar, 1)
     // Wrap the body: prepend widget_prelude(widget_ident) and, for containers,
     // container_path_push(widget_ident). The container path push runs every
@@ -172,8 +172,7 @@ class WidgetCallMacro : AstCallMacro {
     // narrative-text family. Signature after widget_ident injection:
     // (state; widget_ident; text : string) — length 3, last arg is string.
     def private accepts_positional_string() : bool {
-        return false if (render_fn == null)
-        return false if (length(render_fn.arguments) != 3)
+        return false if (render_fn == null || length(render_fn.arguments) != 3)
         let argT = render_fn.arguments[2]._type
         return false if (argT == null)
         return argT.baseType == Type.tString
@@ -424,7 +423,7 @@ class WidgetCallMacro : AstCallMacro {
                                         structType = unsafe(reinterpret<Structure?>(state_struct)),
                                         at = expr.at)
             var initCall = new ExprMakeStruct(at = expr.at, makeType = clone_type(typeRef))
-            initCall.makeStructFlags |= ExprMakeStructFlags.useInitializer
+            initCall.makeStructFlags.useInitializer = true
             // Seed named-init fields (init=/range= sugar) into the initializer.
             // `useInitializer=true` keeps struct defaults firing for un-seeded
             // fields; field LineInfo points at the call site so a wrong field
@@ -443,9 +442,9 @@ class WidgetCallMacro : AstCallMacro {
                 name := bareName,
                 _type <- typeRef,
                 init = initCall)
-            v.flags |= VariableFlags.generated
+            v.flags.generated = true
             if (!flagPublic) {
-                v.flags |= VariableFlags.private_variable
+                v.flags.private_variable = true
             }
             if (!flagNotLive) {
                 v.annotation |> add_annotation_argument("live", true)
@@ -680,8 +679,8 @@ class WidgetCallMacro : AstCallMacro {
             var fn = qmacro_function(wrapperName) $(k : $t(keyType); $a(wrapperArgs)) : $t(retType) {
                 $b(bodyStmts)
             }
-            fn.flags |= FunctionFlags.generated
-            fn.flags |= FunctionFlags.privateFunction
+            fn.flags.generated = true
+            fn.flags.privateFunction = true
             fn.body |> force_at(expr.at)
             if (!(mod |> add_function(fn))) {
                 macro_error(prog, expr.at,
@@ -737,14 +736,14 @@ def private apply_edit_widget(var func : FunctionPtr; var errors : das_string) :
         return false
     }
     let kind = string(func.name)
-    func.flags |= FunctionFlags.generated
+    func.flags.generated = true
     // Inject widget_ident : string at index 1 (between ptr and the rest).
     // Mirrors the [widget] macro injection so the user body can reference
     // `widget_ident` literally when calling widget_finalize / edit_finalize.
     var widthIdentVar = new Variable(at = func.at,
         name := "widget_ident",
         _type <- new TypeDecl(baseType = Type.tString, at = func.at))
-    widthIdentVar.flags |= VariableFlags.generated
+    widthIdentVar.flags.generated = true
     func.arguments |> emplace(widthIdentVar, 1)
     // Wrap the body: prepend widget_prelude(widget_ident) so PushID +
     // pending-focus apply uniformly. PopID is emitted by widget_finalize

--- a/widgets/imgui_visual_aids.das
+++ b/widgets/imgui_visual_aids.das
@@ -284,9 +284,7 @@ def private overlaps_any(c : float2; box_size : float2; bboxes : array<float4>) 
     let bx1 = c.x + box_size.x
     let by1 = c.y + box_size.y
     for (b in bboxes) {
-        if (!(bx1 <= b.x || c.x >= b.z || by1 <= b.y || c.y >= b.w)) {
-            return true
-        }
+        return true if (!(bx1 <= b.x || c.x >= b.z || by1 <= b.y || c.y >= b.w))
     }
     return false
 }
@@ -307,36 +305,26 @@ def public compute_narrate_anchor(
     //! right → left → below → above of the target; falls back to a
     //! viewport-clamped right placement if nothing fits cleanly (e.g. text
     //! wider than the viewport, or every neighbor blocks).
-    if (!has_target) {
-        return float2(edge_margin, edge_margin)
-    }
+    return float2(edge_margin, edge_margin) if (!has_target)
     let bb = widget_bbox
     let cx = (bb.x + bb.z) * 0.5f
 
     // 1. Right of widget
     var c = float2(bb.z + gap, bb.y)
     if (fits_viewport(c, box_size, viewport, edge_margin, shadow, hud_zone_h)
-        && !overlaps_any(c, box_size, other_bboxes)) {
-        return c
-    }
+        && !overlaps_any(c, box_size, other_bboxes)) return c
     // 2. Left of widget
     c = float2(bb.x - gap - box_size.x, bb.y)
     if (fits_viewport(c, box_size, viewport, edge_margin, shadow, hud_zone_h)
-        && !overlaps_any(c, box_size, other_bboxes)) {
-        return c
-    }
+        && !overlaps_any(c, box_size, other_bboxes)) return c
     // 3. Below widget (horizontally centered)
     c = float2(cx - box_size.x * 0.5f, bb.w + gap)
     if (fits_viewport(c, box_size, viewport, edge_margin, shadow, hud_zone_h)
-        && !overlaps_any(c, box_size, other_bboxes)) {
-        return c
-    }
+        && !overlaps_any(c, box_size, other_bboxes)) return c
     // 4. Above widget (horizontally centered)
     c = float2(cx - box_size.x * 0.5f, bb.y - gap - box_size.y)
     if (fits_viewport(c, box_size, viewport, edge_margin, shadow, hud_zone_h)
-        && !overlaps_any(c, box_size, other_bboxes)) {
-        return c
-    }
+        && !overlaps_any(c, box_size, other_bboxes)) return c
     // Fallback: keep right placement and clamp into viewport. Only fires when
     // no candidate fits — typically text wider than viewport, or a widget
     // that covers most of the screen.
@@ -370,25 +358,21 @@ def public compute_connector_start(
     let cy = anchor.y + box_size.y * 0.5f
     let dx = widget_center.x - cx
     let dy = widget_center.y - cy
-    if (abs(dx) > abs(dy)) {
-        return dx > 0.0f ? float2(anchor.x + box_size.x, cy) : float2(anchor.x, cy)
-    }
+    if (abs(dx) > abs(dy)) return dx > 0.0f ? float2(anchor.x + box_size.x, cy) : float2(anchor.x, cy)
     return dy > 0.0f ? float2(cx, anchor.y + box_size.y) : float2(cx, anchor.y)
 }
 
 def private narrate_hud_zone_h : float {
     //! Bottom screen reserve so narrates don't collide with the key_hud
     //! keycap row + modifier strip when the HUD is enabled.
-    if (!key_hud_enabled) {
-        return 0.0f
-    }
+    return 0.0f if (!key_hud_enabled)
     return key_hud_offset_y_from_bottom + key_hud_mod_pill_h + key_hud_mod_strip_y_gap
 }
 
 def private paint_narrates {
     if (empty(g_narrates)) return
     var dl = GetForegroundDrawList()
-    var io & = unsafe(GetIO())
+    let io & = unsafe(GetIO())
     let viewport = io.DisplaySize
     let edge_margin = 8.0f
     let gap = 16.0f
@@ -419,9 +403,7 @@ def private paint_narrates {
         // per-frame registry, typically ≤ 30 entries.
         var other_bboxes : array<float4>
         for (k, w in keys(imgui_boost_runtime::g_registry), values(imgui_boost_runtime::g_registry)) {
-            if (have_target && k == g_narrates[i].target) {
-                continue
-            }
+            continue if (have_target && k == g_narrates[i].target)
             other_bboxes |> push(w.bbox)
         }
         let anchor = compute_narrate_anchor(have_target, widget_bbox, box_size,


### PR DESCRIPTION
## Summary

Sweep the dasImgui tree with the latest daslang `utils/lint` (post-PR #33 default-on, post-daslang-PR #2672 parallel lint). 194 files in scope, 34 fixes across 6 files, 0 issues / 0 errors after.

Excluded: `examples/imgui_demo/imgui_demo.das` (legacy port-in-progress per the dasImgui port roadmap).

## Fixes by rule

| Rule | Count | Pattern |
|---|---|---|
| STYLE022 | 9 | `flags \|= FunctionFlags.generated` → `flags.generated = true` (bitfield-as-field assignment) |
| STYLE005 | 11 | Drop braces around single-statement early-exits — postfix `return X if (cond)` / braceless `if (cond) return X` |
| LINT003  | 12 | `var X` → `let X` where never reassigned (test bbox arrays, `var io & = unsafe(GetIO())`) |
| STYLE016 | 1  | Combined two adjacent `return false if (...)` guards with `\|\|` (short-circuits) |
| PERF013  | 1  | `g_progress -= 1.0f` → `g_progress--` (idiomatic float decrement) |

## Files touched

- `widgets/imgui_boost.das` (10): 9 STYLE022 + 1 STYLE016
- `widgets/imgui_visual_aids.das` (10): 9 STYLE005 + 1 LINT003
- `tests/integration/test_visual_aids_narrate.das` (11 LINT003)
- `examples/features/indexed_dynamic.das` (1 STYLE005)
- `examples/features/inputs_indexed.das` (1 STYLE005)
- `examples/tutorial/narrative_layout_tour.das` (1 PERF013)

## Test plan
- [x] `bin/Release/daslang.exe utils/lint/main.das -- modules/dasImgui/{bind,daslib,examples/features,examples/save_demo,examples/tutorial,src,tests,utils,widgets} -j 0 -q` → `194 files, 0 issue(s), 0 error(s), 3 skipped`
- [x] All 6 files round-trip through `format_file` cleanly
- [ ] Visual smoke of `narrative_layout_tour` and `indexed_dynamic` still works
- [ ] Run integration tests for `test_visual_aids_narrate.das` to confirm `let no_others / let others` still type-checks against `compute_narrate_anchor(... other_bboxes : array<float4>)`