### PR TITLE
imgui_harness wrapper + --headless mode (imgui_app_headless C++ backend)

### DIFF
--- a/.das_module
+++ b/.das_module
@@ -6,6 +6,7 @@ def initialize(project_path : string) {
     if (das_is_dll_build()) {
         register_dynamic_module("{project_path}/dasModuleImgui.shared_module", "Module_dasIMGUI")
         register_dynamic_module("{project_path}/imguiApp.shared_module", "Module_imgui_app")
+        register_dynamic_module("{project_path}/imguiAppHeadless.shared_module", "Module_imgui_app_headless")
     }
     // v1 imgui_boost registration disabled during the boost-v2 refactor.
     // The file at `daslib/imgui_boost.das` is intentionally non-compileable

--- a/.das_module
+++ b/.das_module
@@ -42,6 +42,10 @@ def initialize(project_path : string) {
     // every dasImgui consumer gets it transitively. Per-file opt-out:
     // `options _allow_imgui_legacy = true`.
     register_native_path("imgui", "imgui_lint", "{project_path}/widgets/imgui_lint.das")
+    // Canonical wrapper for examples/tests — hides GLFW/GL boilerplate behind
+    // 5 helpers and re-exports the backend-agnostic stack. PR 2 wires the
+    // --headless dispatch; PR 3 ships the lint default-on.
+    register_native_path("imgui", "imgui_harness", "{project_path}/widgets/imgui_harness.das")
     // Phase 7 — docking (dockspace, dock_window) + DockBuilder bindings cherry-picked from imgui_internal.h.
     register_native_path("imgui", "imgui_docking_builtin", "{project_path}/widgets/imgui_docking_builtin.das")
     // IM_COL32 packer split out from v1 imgui_boost (the legacy module is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,29 @@
   `harness_begin_frame`, `harness_new_frame`, `harness_end_frame`,
   `harness_shutdown`) plus optional `harness_apply_synth_io`. Re-exports the
   backend-agnostic dasImgui v2 stack so example files need only a single
-  `require imgui/imgui_harness` line. The `--headless` CLI flag is parsed
-  but panics with a clear "land PR 2 first" message — full headless dispatch
-  + the `imgui_app_headless` C++ backend land in a follow-up PR.
+  `require imgui/imgui_harness` line.
+- `imgui_app_headless.shared_module` — display-less C++ backend (3-fn
+  surface: `imgui_headless_init_fonts`, `imgui_headless_set_display_size`,
+  `imgui_headless_advance_dt`). No GLFW, no OpenGL, no gl3w. Used by
+  `imgui_harness` when its `--headless` arm is active; the GLFW/GL symbol
+  set is structurally absent from headless scope.
+- `--headless` CLI flag in `imgui_harness` — pass after the daslang `--`
+  separator (`daslang FILE.das -- --headless`) to run with no window and no
+  GL context. CPU-only font atlas, real wall-clock `DeltaTime`, `Render()`
+  output discarded. Synth IO (`imgui_mouse_play`, `imgui_key_chord`, …)
+  works in both modes via the existing `imgui_*` `[live_command]` family.
+- `--headless-frames=N` CLI flag — auto-exit after `N` frames. Useful for
+  unattended CI smokes that have no out-of-band exit signal.
+- New tutorial: `doc/source/tutorials/harness_headless_mode.rst` — walks
+  through what `--headless` dispatches to, how to launch in either mode,
+  and the limits (`screenshot` / `record_*` and live-API HTTP stay
+  windowed-only).
 
 ### Changed
 
 - `examples/features/foundation.das` ported to `imgui/imgui_harness` as the
-  canary adopter. 15 requires collapse to one; the GLFW/GL update boilerplate
-  collapses to two helper calls bracketing the user widget block.
+  first canary adopter. 15 requires collapse to one; the GLFW/GL update
+  boilerplate collapses to two helper calls bracketing the user widget block.
+- `examples/features/active_widget.das` ported to `imgui/imgui_harness` as
+  the second canary — exercises the boost runtime + Playwright-style
+  command surface (`imgui_click`, `imgui_snapshot`) under both modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- `imgui/imgui_harness` — canonical wrapper module for examples/tests. Hides
+  GLFW/OpenGL backend boilerplate behind five helpers (`harness_init`,
+  `harness_begin_frame`, `harness_new_frame`, `harness_end_frame`,
+  `harness_shutdown`) plus optional `harness_apply_synth_io`. Re-exports the
+  backend-agnostic dasImgui v2 stack so example files need only a single
+  `require imgui/imgui_harness` line. The `--headless` CLI flag is parsed
+  but panics with a clear "land PR 2 first" message — full headless dispatch
+  + the `imgui_app_headless` C++ backend land in a follow-up PR.
+
+### Changed
+
+- `examples/features/foundation.das` ported to `imgui/imgui_harness` as the
+  canary adopter. 15 requires collapse to one; the GLFW/GL update boilerplate
+  collapses to two helper calls bracketing the user widget block.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,3 +233,53 @@ IF(OPENGL_FOUND)
 ELSE()
     MESSAGE(STATUS "OpenGL not found — skipping imguiApp module")
 ENDIF()
+
+# imguiAppHeadless.shared_module — display-less backend for CI / Playwright
+# runs. Companion to imguiApp; no GLFW, no OpenGL, no gl3w. Used by
+# imgui/imgui_harness when its --headless arm is active.
+add_library(imguiAppHeadless SHARED ${DAS_IMGUI_DIR}/src/module_imgui_app_headless.cpp)
+target_compile_features(imguiAppHeadless PRIVATE cxx_std_17)
+target_compile_definitions(imguiAppHeadless PRIVATE
+    DAS_MOD_EXPORTS DAS_ENABLE_DLL=1
+    IMGUI_DISABLE_OBSOLETE_FUNCTIONS=1
+    IMGUI_API=${IMGUI_PUBLIC_ATTR}
+    $<$<CONFIG:Release>:DAS_NO_ASSERTIONS>
+    $<$<CONFIG:MinSizeRel>:DAS_NO_ASSERTIONS>
+    $<$<CONFIG:RelWithDebInfo>:DAS_NO_ASSERTIONS>
+)
+target_include_directories(imguiAppHeadless PRIVATE
+    ${DASLANG_DIR}/include
+    ${imgui_INCLUDE_DIR}
+    ${DAS_IMGUI_DIR}/src
+)
+if(WIN32)
+    if(EXISTS "${DASLANG_DIR}/lib/Release/libDaScriptDyn.lib")
+        target_link_libraries(imguiAppHeadless PRIVATE
+            ${DASLANG_DIR}/lib/$<CONFIG>/libDaScriptDyn.lib
+            ${DASLANG_DIR}/lib/$<CONFIG>/libDaScriptDyn_runtime.lib
+        )
+    else()
+        target_link_libraries(imguiAppHeadless PRIVATE
+            ${DASLANG_DIR}/lib/libDaScriptDyn.lib
+            ${DASLANG_DIR}/lib/libDaScriptDyn_runtime.lib
+        )
+    endif()
+elseif(APPLE)
+    target_link_libraries(imguiAppHeadless PRIVATE
+        ${DASLANG_DIR}/lib/liblibDaScriptDyn.dylib
+        ${DASLANG_DIR}/lib/liblibDaScriptDyn_runtime.dylib
+    )
+else()
+    target_link_libraries(imguiAppHeadless PRIVATE
+        ${DASLANG_DIR}/lib/liblibDaScriptDyn.so
+        ${DASLANG_DIR}/lib/liblibDaScriptDyn_runtime.so
+    )
+endif()
+SETUP_OPTIONS(imguiAppHeadless)
+set_target_properties(imguiAppHeadless PROPERTIES
+    SUFFIX ".shared_module"
+    PREFIX ""
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${DAS_IMGUI_DIR}"
+    LIBRARY_OUTPUT_DIRECTORY "${DAS_IMGUI_DIR}"
+)
+target_link_libraries(imguiAppHeadless PRIVATE dasModuleImgui)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,42 @@ containers, auto-emitted state structs, live-reload, and a JSON-driven
 command surface. See the [dasImgui tutorials](doc/source/tutorials/index.rst)
 starting at `boost_basics` for a complete walkthrough.
 
+For examples and tests, use `imgui/imgui_harness` — it hides the GLFW/GL
+backend boilerplate behind five helpers and re-exports the backend-agnostic
+v2 stack, so the test file is purely widget logic:
+
+```das
+options gen2
+
+require imgui/imgui_harness
+
+[export] def init() {
+    harness_init("My Example", 800, 600)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export] def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    window(MAIN_WIN, (text = "Hello")) {
+        text("Hello from daslang!")
+    }
+    harness_end_frame()
+}
+
+[export] def shutdown() { harness_shutdown() }
+
+[export] def main() {
+    init()
+    while (!exit_requested()) { update() }
+    shutdown()
+}
+```
+
+`--headless` mode (for CI / Playwright-driven tests without a display) is
+wired in a follow-up PR; the harness API surface above is the final shape.
+
 Run with `-project_root` pointing to the directory containing `modules/`:
 
 ```bash
@@ -84,6 +120,7 @@ daslang.exe -project_root . my_app.das
 |--------|---------|-------------|
 | `imgui` | `require imgui/imgui_boost` | Core Dear ImGui bindings |
 | `imgui_app` | `require imgui_app` | GLFW + OpenGL3 application runtime |
+| `imgui_harness` | `require imgui/imgui_harness` | Canonical wrapper for examples/tests — hides GLFW/GL boilerplate, re-exports the backend-agnostic v2 stack |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,20 @@ require imgui/imgui_harness
 }
 ```
 
-`--headless` mode (for CI / Playwright-driven tests without a display) is
-wired in a follow-up PR; the harness API surface above is the final shape.
+Same script runs headless (no window, no GL context) by passing
+`--headless` after the daslang `--` separator:
+
+```bash
+daslang.exe my_example.das -- --headless --headless-frames=600
+```
+
+Headless mode skips the GLFW + OpenGL chain entirely (the harness uses a
+parallel `imguiAppHeadless.shared_module` C++ backend with a CPU-only
+font atlas). `--headless-frames=N` auto-exits after `N` frames; omit it
+when the script's own logic calls `request_exit()`. See
+[doc/source/tutorials/harness_headless_mode.rst](doc/source/tutorials/harness_headless_mode.rst)
+for what gets dispatched in either mode and the limits (`screenshot` /
+`record_*` and the live-API HTTP endpoint stay windowed-only).
 
 Run with `-project_root` pointing to the directory containing `modules/`:
 
@@ -120,7 +132,8 @@ daslang.exe -project_root . my_app.das
 |--------|---------|-------------|
 | `imgui` | `require imgui/imgui_boost` | Core Dear ImGui bindings |
 | `imgui_app` | `require imgui_app` | GLFW + OpenGL3 application runtime |
-| `imgui_harness` | `require imgui/imgui_harness` | Canonical wrapper for examples/tests — hides GLFW/GL boilerplate, re-exports the backend-agnostic v2 stack |
+| `imgui_app_headless` | (private, used by harness) | Display-less ImGui backend (CPU font atlas, no GLFW, no GL) for `--headless` runs |
+| `imgui_harness` | `require imgui/imgui_harness` | Canonical wrapper for examples/tests — hides GLFW/GL boilerplate, re-exports the backend-agnostic v2 stack, dispatches windowed vs `--headless` at runtime |
 
 ## Examples
 

--- a/doc/source/tutorials/harness_headless_mode.rst
+++ b/doc/source/tutorials/harness_headless_mode.rst
@@ -1,0 +1,140 @@
+.. _tutorial_harness_headless_mode:
+
+#############################
+Harness + headless mode
+#############################
+
+``imgui/imgui_harness`` is the canonical wrapper for dasImgui examples and
+tests. It hides the GLFW/OpenGL backend boilerplate behind five helpers and
+adds a ``--headless`` CLI mode that runs the same script with no window and
+no GL context — for CI, smoke tests, and Playwright drivers without a
+display server.
+
+This tutorial covers what ``--headless`` does to the harness internals,
+how to launch a script in either mode, and the limits of headless
+(``screenshot`` / ``record_*`` and the live-API HTTP endpoint stay
+windowed-only).
+
+************
+Why headless
+************
+
+A dasImgui test today opens a real GLFW window and a real OpenGL context.
+That makes CI runners pick a display server (xvfb on Linux, an interactive
+session on Windows), and pins every smoke test to the cost of a windowed
+run. Most tests don't need either — they just exercise widget logic, the
+boost layer, or live-command dispatch.
+
+The harness keeps the same script source but lets the runtime pick:
+
+* Windowed (default) — open a window, run the GLFW + OpenGL chain, render
+  to the back buffer. Identical to the pre-harness path.
+* Headless (``-- --headless``) — create an ImGui context with a CPU-only
+  font atlas, no window, no GL. ``Render()`` runs and the resulting
+  ``ImDrawData`` is discarded.
+
+************************
+Running tests headless
+************************
+
+The harness parses one CLI flag, lazily on first ``harness_*`` call:
+
+.. code-block:: bash
+
+   # Windowed (default).
+   daslang.exe modules/dasImgui/examples/features/foundation.das
+
+   # Headless. Note the `--` separator: daslang's interpreter mode
+   # consumes everything after it as user-script argv.
+   daslang.exe modules/dasImgui/examples/features/foundation.das -- --headless
+
+   # Headless with a 600-frame auto-exit cap (useful for unattended CI
+   # smokes that have no out-of-band exit signal).
+   daslang.exe modules/dasImgui/examples/features/foundation.das -- --headless --headless-frames=600
+
+In windowed mode the script's loop terminates when the window closes
+(``live_begin_frame`` calls ``request_exit()``). In headless there is no
+window, so the script runs until either (a) something inside the script
+calls ``request_exit()`` or (b) ``--headless-frames=N`` is set and the
+counter hits ``N`` (the harness then calls ``request_exit()`` itself).
+
+************************************
+What --headless does internally
+************************************
+
+The harness exports five helpers; each branches on
+``harness_is_headless()`` at call time:
+
+``harness_init(title, width, height)``
+   * Windowed: ``live_create_window`` + ``live_imgui_init``.
+   * Headless: ``CreateContext`` + ``StyleColorsDark`` + CPU font-atlas
+     build + ``DisplaySize``. No window, no GL context.
+
+``harness_begin_frame() : bool``
+   * Windowed: poll GLFW events, run boost ``begin_frame``, then
+     ``ImGui_ImplOpenGL3_NewFrame`` + ``ImGui_ImplGlfw_NewFrame``.
+   * Headless: feed ``ImGuiIO::DeltaTime`` from real wall-clock, run
+     boost ``begin_frame``, advance the headless frame counter. If
+     ``--headless-frames=N`` is set and the counter reaches ``N``, call
+     ``request_exit()`` and return ``false`` (the script's loop exits).
+
+``harness_apply_synth_io()`` *(optional)*
+   Drains the synth IO timeline (``imgui_mouse_play``, ``imgui_key_chord``,
+   …). Identical in both modes — windowed needs it to win the GLFW
+   backend's per-frame poll race; headless needs it because it's the only
+   IO source. Call between ``harness_begin_frame`` and
+   ``harness_new_frame``.
+
+``harness_new_frame()``
+   ``ImGui::NewFrame()``. Identical in both modes.
+
+``harness_end_frame()``
+   * Windowed: boost ``end_of_frame`` + ``Render`` + viewport/clear +
+     ``ImGui_ImplOpenGL3_RenderDrawData`` + ``live_end_frame`` (swap
+     buffers).
+   * Headless: ``end_of_frame`` + ``Render``. The resulting
+     ``ImDrawData`` is discarded — there is no GL backend to consume it.
+
+``harness_shutdown()``
+   * Windowed: ``live_imgui_shutdown`` + ``live_destroy_window``.
+   * Headless: ``DestroyContext`` on the harness-owned ImGui context.
+
+The C++ side uses two side-by-side shared modules:
+
+* ``imguiApp.shared_module`` — the windowed backend (GLFW + OpenGL, plus
+  the ``imgui_synth_*`` event injectors that drive synth IO in either
+  mode).
+* ``imguiAppHeadless.shared_module`` — three thin helpers
+  (``imgui_headless_init_fonts``, ``imgui_headless_set_display_size``,
+  ``imgui_headless_advance_dt``). No GLFW, no OpenGL, no gl3w. Loaded by
+  the harness alongside ``imguiApp`` so runtime dispatch can pick.
+
+Both DLLs link into every dasImgui binary, so headless still requires
+GLFW libs to be findable on the host (the OS DLL loader resolves
+``imguiApp.shared_module``'s deps regardless of whether ``--headless`` is
+active). Truly minimal-deploy headless (no GLFW libs at all) is a future
+build-flag concern.
+
+***********************
+Limits under --headless
+***********************
+
+* ``screenshot`` and ``record_start`` / ``record_stop`` from
+  ``opengl/opengl_live`` assume a GL framebuffer. They have no headless
+  analogue and either no-op or panic depending on the path. Tests that
+  capture screenshots or APNGs stay windowed.
+* The live-API HTTP endpoint at ``localhost:9090/command`` is installed
+  by the ``daslang-live`` host only. ``daslang.exe`` (the interpreter)
+  runs the script without the HTTP server, so Playwright drivers that
+  send JSON commands over HTTP need a windowed ``daslang-live`` host. A
+  headless live-driver host is a separate future change.
+* ``daslang-live`` itself is always windowed — it doesn't pass argv to
+  scripts, so the harness's ``--headless`` flag is unreachable from a
+  live-reload session. ``harness_is_headless()`` returns ``false`` under
+  ``daslang-live`` regardless.
+
+These limits are by design for the first headless landing — the bulk of
+existing tests don't touch screenshots or HTTP, so a single ``--headless``
+toggle covers them. Tests that need the windowed-only surfaces opt out of
+the harness lint per-file (``options _allow_glfw_calls = true``) and run
+windowed indefinitely.

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -25,3 +25,4 @@ construction.
    driving_outside.rst
    visual_aids_tour.rst
    recording.rst
+   harness_headless_mode.rst

--- a/examples/features/active_widget.das
+++ b/examples/features/active_widget.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: active_widget — Phase 2.1 foundation gate.
@@ -30,25 +16,22 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_click","args":{"target":"MAIN_WIN/DEMO_BTN","await":{"fire_and_forget":true}}}' \
 //              localhost:9090/command          # → bare {"ok":true,"value":"..."} (no timeout_sec)
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/active_widget.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/active_widget.das -- --headless --headless-frames=600
 // LIVE:       daslang-live modules/dasImgui/examples/features/active_widget.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 2.1 — active_widget foundation", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.1 — active_widget foundation", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 280.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "active_widget — phase 2.1", closable = false,
@@ -68,22 +51,12 @@ def update() {
         text("slider value = {DEMO_SLIDER.value}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/foundation.das
+++ b/examples/features/foundation.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: foundation — Phase 0b.0 [widget] foundation contract.
@@ -35,23 +21,15 @@ require imgui/imgui_containers_builtin
 
 [export]
 def init() {
-    //! Reload-aware. live_imgui_init is idempotent: cold start runs
-    //! CreateContext + ImGui_Impl* setup; reload reuses the ctx pointer
-    //! restored by imgui_live's [after_reload].
-    live_create_window("Phase 0b.0 — foundation", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.0 — foundation", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 320.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Foundation — phase 0b.0", closable = false,
@@ -79,30 +57,16 @@ def update() {
         text("volume = {VOLUME.value}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    //! Reload-aware. live_imgui_shutdown skips during reload; tears down
-    //! only on process exit.
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]
 def main() {
-    //! Standalone entrypoint. daslang-live drives init/update/shutdown
-    //! directly and ignores main(); plain `daslang.exe <file>` runs this loop.
     init()
     while (!exit_requested()) {
         update()

--- a/src/module_imgui_app_headless.cpp
+++ b/src/module_imgui_app_headless.cpp
@@ -1,0 +1,75 @@
+#include "daScript/daScript.h"
+
+#include "imgui_stub.h"
+
+using namespace das;
+
+// =====================================================================
+// imgui_app_headless — display-less ImGui backend.
+//
+// Companion to imgui_app for CI / Playwright-driven runs where no
+// display server (GLFW/OpenGL) is available. Exposes a deliberately
+// minimal 3-function surface used by imgui/imgui_harness when its
+// --headless arm is active. Does NOT mirror imgui_app's GLFW/GL
+// surface — keeping those names absent from headless scope is the
+// structural guarantee behind the harness lint (no GLFW/GL symbol can
+// resolve in a harness-using file under headless).
+//
+// Synth IO (das_imgui_synth_*) lives in imgui_app — those functions
+// only touch ImGui::GetIO()->AddXxxEvent and have no GLFW/GL deps,
+// so they work in both modes; the harness imports both modules.
+// =====================================================================
+
+DAS_MOD_API void das_imgui_headless_init_fonts() {
+    ImGuiIO & io = ImGui::GetIO();
+    if (!io.Fonts->IsBuilt()) {
+        io.Fonts->Build();
+    }
+    // Satisfy ImGui's "is texture present?" assertion paths without an
+    // OpenGL backend — any non-zero TexID is acceptable when no draw
+    // data is consumed.
+    io.Fonts->TexID = (ImTextureID)1;
+}
+
+DAS_MOD_API void das_imgui_headless_set_display_size(float w, float h) {
+    ImGui::GetIO().DisplaySize = ImVec2(w, h);
+}
+
+DAS_MOD_API void das_imgui_headless_advance_dt(float dt) {
+    ImGui::GetIO().DeltaTime = dt;
+}
+
+class Module_imgui_app_headless : public Module {
+    ModuleLibrary lib;
+public:
+    Module_imgui_app_headless() : Module("imgui_app_headless") {
+    }
+    bool initialized = false;
+    virtual bool initDependencies() override {
+        if ( initialized ) return true;
+        auto mod_imgui = Module::require("imgui");
+        if ( !mod_imgui ) return false;
+        if ( !mod_imgui->initDependencies() ) return false;
+        initialized = true;
+        lib.addModule(this);
+        lib.addBuiltInModule();
+        lib.addModule(mod_imgui);
+        addExtern<DAS_BIND_FUN(das_imgui_headless_init_fonts)>(*this,lib,"imgui_headless_init_fonts",
+            SideEffects::worstDefault, "das_imgui_headless_init_fonts");
+        addExtern<DAS_BIND_FUN(das_imgui_headless_set_display_size)>(*this,lib,"imgui_headless_set_display_size",
+            SideEffects::worstDefault, "das_imgui_headless_set_display_size");
+        addExtern<DAS_BIND_FUN(das_imgui_headless_advance_dt)>(*this,lib,"imgui_headless_advance_dt",
+            SideEffects::worstDefault, "das_imgui_headless_advance_dt");
+        return true;
+    }
+    virtual ModuleAotType aotRequire ( TextWriter & tw ) const override {
+        tw << "#include \"../modules/dasImgui/src/imgui_stub.h\"\n";
+        tw << "DAS_MOD_API void das_imgui_headless_init_fonts();\n";
+        tw << "DAS_MOD_API void das_imgui_headless_set_display_size(float w, float h);\n";
+        tw << "DAS_MOD_API void das_imgui_headless_advance_dt(float dt);\n";
+        return ModuleAotType::cpp;
+    }
+};
+
+REGISTER_DYN_MODULE(Module_imgui_app_headless, Module_imgui_app_headless);
+REGISTER_MODULE(Module_imgui_app_headless);

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -1,0 +1,138 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+options _allow_imgui_legacy = true
+
+module imgui_harness shared public
+
+//! Canonical wrapper for dasImgui examples and tests.
+//!
+//! Hides the GLFW/OpenGL backend boilerplate behind five helpers
+//! (``harness_init`` / ``harness_begin_frame`` / ``harness_new_frame`` /
+//! ``harness_end_frame`` / ``harness_shutdown``, plus optional
+//! ``harness_apply_synth_io``). Examples ``require imgui_harness`` and never
+//! touch GLFW/GL symbols directly.
+//!
+//! Mode dispatch (windowed vs headless) is internal. Pass ``--headless`` after
+//! the daslang ``--`` separator to run without a window:
+//! ``daslang FILE.das -- --headless``. Headless mode is wired in PR 2 — until
+//! then, ``--headless`` triggers a panic with a clear "land PR 2 first"
+//! message; windowed mode is fully functional.
+//!
+//! Re-exports the backend-agnostic dasImgui stack so consumers need only a
+//! single ``require imgui_harness`` line.
+
+// Backend-agnostic stack — re-exported public.
+require imgui public
+require imgui/imgui_boost_v2 public
+require imgui/imgui_boost_runtime public
+require imgui/imgui_widgets_builtin public
+require imgui/imgui_containers_builtin public
+require live/live_api public
+require live/live_commands public
+require live/live_vars public
+require live_host public
+
+// Windowed backend — private. Lint (PR 3) forbids user-scope leakage.
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/opengl_live
+require imgui/imgui_live
+require imgui/imgui_visual_aids
+
+require daslib/clargs
+
+var private g_headless : bool = false
+var private g_parsed : bool = false
+
+def private ensure_parsed() {
+    // Lazy CLI parse on first harness_* call. clargs `find_bool_flag_raw_value`
+    // doesn't error on unknown args, so future test-side clargs structs coexist.
+    if (g_parsed) return
+    g_parsed = true
+    let args <- get_user_args()
+    let raw = find_bool_flag_raw_value(args, "--headless")
+    g_headless = (raw |> unwrap_or("false")) == "true"
+}
+
+def private panic_pr1_headless() {
+    panic("imgui_harness: --headless is not yet implemented (land PR 2 first)")
+}
+
+def public harness_is_headless() : bool {
+    //! True if ``--headless`` was on the command line. Stable across the process.
+    ensure_parsed()
+    return g_headless
+}
+
+def public harness_init(title : string; width : int = 800; height : int = 600) {
+    //! Windowed: ``live_create_window`` + ``live_imgui_init``. Headless (PR 2+):
+    //! ``CreateContext`` + ``Fonts->Build`` + ``DisplaySize``, no window.
+    if (harness_is_headless()) {
+        panic_pr1_headless()
+        return
+    }
+    live_create_window(title, width, height)
+    live_imgui_init(live_window)
+}
+
+def public harness_begin_frame() : bool {
+    //! Returns false to skip update (window closed). Windowed: ``live_begin_frame``
+    //! + ``begin_frame`` + ``Impl_OpenGL3_NewFrame`` + ``Impl_Glfw_NewFrame``.
+    //! Headless (PR 2+): ``begin_frame`` + ``io.DeltaTime`` advance.
+    if (harness_is_headless()) {
+        panic_pr1_headless()
+        return false
+    }
+    if (!live_begin_frame()) return false
+    begin_frame()
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    return true
+}
+
+def public harness_apply_synth_io() {
+    //! Optional — call between ``harness_begin_frame`` and ``harness_new_frame``
+    //! when the test drives synthetic IO. Windowed: ``apply_synth_io_override``
+    //! (wins the GLFW backend race). Headless (PR 2+): no-op.
+    return if (harness_is_headless())
+    apply_synth_io_override()
+}
+
+def public harness_new_frame() {
+    //! ``ImGui::NewFrame()``. Identical in both modes.
+    NewFrame()
+}
+
+def public harness_end_frame() {
+    //! Windowed: ``end_of_frame`` + ``Render`` + viewport/clear +
+    //! ``Impl_OpenGL3_RenderDrawData`` + ``live_end_frame``. Headless (PR 2+):
+    //! ``end_of_frame`` + ``Render`` (DrawData discarded).
+    if (harness_is_headless()) {
+        panic_pr1_headless()
+        return
+    }
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_end_frame()
+}
+
+def public harness_shutdown() {
+    //! Windowed: ``live_imgui_shutdown`` + ``live_destroy_window``.
+    //! Headless (PR 2+): ``DestroyContext``.
+    if (harness_is_headless()) {
+        panic_pr1_headless()
+        return
+    }
+    live_imgui_shutdown()
+    live_destroy_window()
+}

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -16,9 +16,9 @@ module imgui_harness shared public
 //!
 //! Mode dispatch (windowed vs headless) is internal. Pass ``--headless`` after
 //! the daslang ``--`` separator to run without a window:
-//! ``daslang FILE.das -- --headless``. Headless mode is wired in PR 2 — until
-//! then, ``--headless`` triggers a panic with a clear "land PR 2 first"
-//! message; windowed mode is fully functional.
+//! ``daslang FILE.das -- --headless``. Add ``--headless-frames=N`` to auto-exit
+//! after ``N`` frames (default 0 = run until ``request_exit()``); useful for
+//! CI smoke runs that have no out-of-band exit signal.
 //!
 //! Re-exports the backend-agnostic dasImgui stack so consumers need only a
 //! single ``require imgui_harness`` line.
@@ -43,23 +43,31 @@ require live/opengl_live
 require imgui/imgui_live
 require imgui/imgui_visual_aids
 
-require daslib/clargs
+// Headless backend — private. 3-fn surface (no GLFW/GL names).
+require imgui_app_headless
 
-var private g_headless : bool = false
-var private g_parsed : bool = false
+require daslib/clargs
+require strings
+
+var private g_headless          : bool = false
+var private g_headless_max_frames : int = 0
+var private g_parsed            : bool = false
+
+var private g_headless_ctx      : ImGuiContext? = null
+var private g_headless_frame    : int = 0
+var private g_headless_dt       : float = 1.0f / 60.0f
+var private g_headless_last_uptime : float = -1.0f
 
 def private ensure_parsed() {
-    // Lazy CLI parse on first harness_* call. clargs `find_bool_flag_raw_value`
-    // doesn't error on unknown args, so future test-side clargs structs coexist.
-    if (g_parsed) return
+    // Lazy CLI parse on first harness_* call. clargs `find_*` helpers don't
+    // error on unknown args, so future test-side clargs structs coexist.
+    return if (g_parsed)
     g_parsed = true
     let args <- get_user_args()
-    let raw = find_bool_flag_raw_value(args, "--headless")
-    g_headless = (raw |> unwrap_or("false")) == "true"
-}
-
-def private panic_pr1_headless() {
-    panic("imgui_harness: --headless is not yet implemented (land PR 2 first)")
+    let raw_headless = find_bool_flag_raw_value(args, "--headless")
+    g_headless = (raw_headless |> unwrap_or("false")) == "true"
+    let raw_frames = find_flag_raw_value(args, "--headless-frames")
+    g_headless_max_frames = to_int(raw_frames |> unwrap_or("0"))
 }
 
 def public harness_is_headless() : bool {
@@ -69,10 +77,14 @@ def public harness_is_headless() : bool {
 }
 
 def public harness_init(title : string; width : int = 800; height : int = 600) {
-    //! Windowed: ``live_create_window`` + ``live_imgui_init``. Headless (PR 2+):
-    //! ``CreateContext`` + ``Fonts->Build`` + ``DisplaySize``, no window.
+    //! Windowed: ``live_create_window`` + ``live_imgui_init``. Headless:
+    //! ``CreateContext`` + ``StyleColorsDark`` + font atlas build +
+    //! ``DisplaySize`` — no window, no GL context.
     if (harness_is_headless()) {
-        panic_pr1_headless()
+        g_headless_ctx = CreateContext(null)
+        StyleColorsDark(null)
+        imgui_headless_init_fonts()
+        imgui_headless_set_display_size(float(width), float(height))
         return
     }
     live_create_window(title, width, height)
@@ -80,14 +92,27 @@ def public harness_init(title : string; width : int = 800; height : int = 600) {
 }
 
 def public harness_begin_frame() : bool {
-    //! Returns false to skip update (window closed). Windowed: ``live_begin_frame``
-    //! + ``begin_frame`` + ``Impl_OpenGL3_NewFrame`` + ``Impl_Glfw_NewFrame``.
-    //! Headless (PR 2+): ``begin_frame`` + ``io.DeltaTime`` advance.
+    //! Returns false to skip update (window closed in windowed mode; auto-exit
+    //! cap reached in headless). Windowed: ``live_begin_frame`` + ``begin_frame``
+    //! + ``Impl_OpenGL3_NewFrame`` + ``Impl_Glfw_NewFrame``. Headless:
+    //! ``begin_frame`` + ``imgui_headless_advance_dt`` (real wall-clock dt).
     if (harness_is_headless()) {
-        panic_pr1_headless()
-        return false
+        if (g_headless_max_frames > 0 && g_headless_frame >= g_headless_max_frames) {
+            request_exit()
+            return false
+        }
+        let now = get_uptime()
+        if (g_headless_last_uptime >= 0.0f) {
+            let dt = now - g_headless_last_uptime
+            g_headless_dt = dt > 0.0f ? dt : (1.0f / 60.0f)
+        }
+        g_headless_last_uptime = now
+        imgui_headless_advance_dt(g_headless_dt)
+        begin_frame()
+        g_headless_frame++
+        return true
     }
-    if (!live_begin_frame()) return false
+    return false if (!live_begin_frame())
     begin_frame()
     ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
@@ -96,9 +121,11 @@ def public harness_begin_frame() : bool {
 
 def public harness_apply_synth_io() {
     //! Optional — call between ``harness_begin_frame`` and ``harness_new_frame``
-    //! when the test drives synthetic IO. Windowed: ``apply_synth_io_override``
-    //! (wins the GLFW backend race). Headless (PR 2+): no-op.
-    return if (harness_is_headless())
+    //! when the test drives synthetic IO via the ``imgui_*`` ``[live_command]``
+    //! family (``imgui_mouse_play``, ``imgui_key_chord``, …). Windowed:
+    //! re-asserts synth pos so it wins the GLFW backend's per-frame poll race.
+    //! Headless: drains the same synth timeline (no backend to race with, but
+    //! held state still needs the per-frame tick).
     apply_synth_io_override()
 }
 
@@ -109,10 +136,11 @@ def public harness_new_frame() {
 
 def public harness_end_frame() {
     //! Windowed: ``end_of_frame`` + ``Render`` + viewport/clear +
-    //! ``Impl_OpenGL3_RenderDrawData`` + ``live_end_frame``. Headless (PR 2+):
-    //! ``end_of_frame`` + ``Render`` (DrawData discarded).
+    //! ``Impl_OpenGL3_RenderDrawData`` + ``live_end_frame``. Headless:
+    //! ``end_of_frame`` + ``Render`` (DrawData discarded; no GL output).
     if (harness_is_headless()) {
-        panic_pr1_headless()
+        end_of_frame()
+        Render()
         return
     }
     end_of_frame()
@@ -128,11 +156,21 @@ def public harness_end_frame() {
 
 def public harness_shutdown() {
     //! Windowed: ``live_imgui_shutdown`` + ``live_destroy_window``.
-    //! Headless (PR 2+): ``DestroyContext``.
+    //! Headless: ``DestroyContext`` (the harness owns the ctx in headless mode).
     if (harness_is_headless()) {
-        panic_pr1_headless()
+        if (g_headless_ctx != null) {
+            DestroyContext(g_headless_ctx)
+            g_headless_ctx = null
+        }
         return
     }
     live_imgui_shutdown()
     live_destroy_window()
+}
+
+def public harness_frame_count() : int {
+    //! Headless-mode frame counter (incremented inside ``harness_begin_frame``).
+    //! Returns 0 in windowed mode — windowed frame count is the ImGui core
+    //! ``GetFrameCount()``.
+    return g_headless_frame
 }

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -23,24 +23,31 @@ module imgui_harness shared public
 //! Re-exports the backend-agnostic dasImgui stack so consumers need only a
 //! single ``require imgui_harness`` line.
 
-// Backend-agnostic stack — re-exported public.
-require imgui public
-require imgui/imgui_boost_v2 public
-require imgui/imgui_boost_runtime public
-require imgui/imgui_widgets_builtin public
-require imgui/imgui_containers_builtin public
-require live/live_api public
-require live/live_commands public
-require live/live_vars public
-require live_host public
+// NOTE on require ordering: the windowed backend (imgui_app + glfw/opengl)
+// must be required BEFORE the live_api / live_commands family. Reordering
+// these tickles a daslang-live readiness regression where /status never
+// returns 200 to a popen parent — likely a [_macro]-driven debug-agent
+// install racing with GLFW backend init. The harness mirrors the canonical
+// order used by every pre-harness example/test verbatim.
 
-// Windowed backend — private. Lint (PR 3) forbids user-scope leakage.
+// Windowed backend (must come first; see ordering note above).
+require imgui public
 require imgui_app
 require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/opengl_live
+
+// Live-host + boost-runtime stack — re-exported public.
+require live/live_api public
+require live/live_commands public
+require live/live_vars public
+require live_host public
 require imgui/imgui_live
+require imgui/imgui_boost_runtime public
+require imgui/imgui_boost_v2 public
+require imgui/imgui_widgets_builtin public
+require imgui/imgui_containers_builtin public
 require imgui/imgui_visual_aids
 
 // Headless backend — private. 3-fn surface (no GLFW/GL names).


### PR DESCRIPTION
## Summary

Lands the canonical wrapper for dasImgui examples/tests plus a display-less backend so tests can run without a window.

- **`imgui/imgui_harness`** — 5 helpers (`harness_init` / `harness_begin_frame` / `harness_new_frame` / `harness_end_frame` / `harness_shutdown`) plus optional `harness_apply_synth_io`. Re-exports the backend-agnostic dasImgui v2 stack so example/test files need only a single `require imgui/imgui_harness` line. Foundation.das collapses 15 requires → 1 and 25 lines of GLFW/GL update boilerplate → 4 helper calls.
- **`imguiAppHeadless.shared_module`** — display-less C++ backend. 3-fn surface (`imgui_headless_init_fonts`, `imgui_headless_set_display_size`, `imgui_headless_advance_dt`). No GLFW, no OpenGL, no gl3w. Used by the harness when its `--headless` arm is active. By exposing only headless helpers (NOT mirroring imgui_app's GLFW/GL surface as no-op stubs), the GLFW/GL symbol set is structurally absent from headless scope — the lint guarantee landing in the next PR becomes a fact, not a comment.
- **`--headless` CLI flag** — pass after the daslang `--` separator (`daslang FILE.das -- --headless`). CPU-only font atlas, real wall-clock `DeltaTime`, `Render()` output discarded. `--headless-frames=N` auto-exits after N frames for unattended CI smokes.
- **Two canary ports** — `examples/features/foundation.das` and `examples/features/active_widget.das` migrated to the harness.
- **Synth IO**: works in both modes via the existing `imgui_*` `[live_command]` family in `imgui_live_core` (`imgui_mouse_play`, `imgui_key_chord`, …) — those route through `das_imgui_synth_*` C++ helpers that bypass GLFW. No separate `imgui_synth_live.das` companion needed.
- **Docs**: new tutorial `doc/source/tutorials/harness_headless_mode.rst`, README bumped, CHANGELOG entry.

## Commits

1. `imgui_harness: canonical wrapper module + foundation canary` — 5-helper API, windowed dispatch, foundation.das port.
2. `imgui_harness: wire --headless dispatch + imgui_app_headless backend` — C++ backend + CMake target + headless dispatch + active_widget.das port + tutorial RST.
3. `imgui_harness: require windowed backend before live_api stack` — workaround for a daslang-live require-order bug surfaced during integration testing. Without this reorder, `dastest`'s `wait_until_ready` GETs to `localhost:9090/status` time out from the popen parent (external curl from a sibling shell still works). Filed upstream as [GaijinEntertainment/daScript#2677](https://github.com/GaijinEntertainment/daScript/issues/2677).

## Test plan

- [x] `compile_check` clean on harness + both canary scripts + 5 spot-check unmigrated examples.
- [x] `lint` clean on harness + both canary scripts.
- [x] `format_file` clean (already-formatted).
- [x] `daslang foundation.das` — windowed run, 3s, no crash.
- [x] `daslang active_widget.das` — windowed run, 3s, no crash.
- [x] `daslang foundation.das -- --headless --headless-frames=60` — clean exit rc=0.
- [x] `daslang active_widget.das -- --headless --headless-frames=60` — clean exit rc=0.
- [x] **`dastest --test modules/dasImgui/tests/integration` — 110/110 pass in 503s.**
- [x] `sphinx-build -W --keep-going` clean over `modules/dasImgui/doc`.

## Follow-ups (not in this PR)

- PR 3: `imgui_harness_lint.das` default-on (forbids glfw_boost / opengl_boost / glfw_live / opengl_live / imgui_live symbols + raw `gl*` calls in any file requiring `imgui_harness`). Per-file scaffolding opt-out: `options _allow_glfw_calls = true`. Bulk opt-out PR for the remaining ~78 unmigrated example files.
- PRs 4..N: bulk migration batches, drop opt-outs as each batch lands. Final batch removes `_allow_glfw_calls` from the option registry entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)