### PR TITLE
imgui_harness: default-on lint + first migration batch (13 features)

### DIFF
--- a/.das_module
+++ b/.das_module
@@ -44,9 +44,15 @@ def initialize(project_path : string) {
     // `options _allow_imgui_legacy = true`.
     register_native_path("imgui", "imgui_lint", "{project_path}/widgets/imgui_lint.das")
     // Canonical wrapper for examples/tests — hides GLFW/GL boilerplate behind
-    // 5 helpers and re-exports the backend-agnostic stack. PR 2 wires the
-    // --headless dispatch; PR 3 ships the lint default-on.
+    // 5 helpers and re-exports the backend-agnostic stack. Bundles
+    // imgui_harness_lint via `require imgui/imgui_harness_lint public` so every
+    // harness-using file gets the windowed-backend ban transitively.
     register_native_path("imgui", "imgui_harness", "{project_path}/widgets/imgui_harness.das")
+    // Default-on lint for files requiring imgui_harness — forbids direct calls
+    // into glfw_boost / opengl_boost / glfw_live / opengl_live / imgui_live so
+    // harness consumers stay backend-agnostic. Per-file opt-out:
+    // `options _allow_glfw_calls = true` (scaffolding only).
+    register_native_path("imgui", "imgui_harness_lint", "{project_path}/widgets/imgui_harness_lint.das")
     // Phase 7 — docking (dockspace, dock_window) + DockBuilder bindings cherry-picked from imgui_internal.h.
     register_native_path("imgui", "imgui_docking_builtin", "{project_path}/widgets/imgui_docking_builtin.das")
     // IM_COL32 packer split out from v1 imgui_boost (the legacy module is

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ src/imgui_vulkan_headers.h.json.log
 # + external_types.rst + tutorials/ and IS tracked.
 doc/source/stdlib/generated/
 doc/source/__pycache__/
+doc/build_html/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,40 @@
   through what `--headless` dispatches to, how to launch in either mode,
   and the limits (`screenshot` / `record_*` and live-API HTTP stay
   windowed-only).
+- `imgui/imgui_harness_lint` — default-on `[lint_macro]` that fires on any
+  file requiring `imgui/imgui_harness` and forbids direct calls into the
+  windowed-backend modules (`glfw_boost`, `opengl_boost`, `glfw_live`,
+  `opengl_live`, `imgui_live`). Diagnostic code `HARNESS001`
+  (macro_error 50503). Bundled transitively via
+  `require imgui/imgui_harness_lint public` from `imgui_harness.das`.
+  Per-file opt-out: `options _allow_glfw_calls = true` (scaffolding only,
+  target end-state = no opt-out — same shape as PR #33's
+  `_allow_imgui_legacy`).
+- `tests/integration/failed_imgui_harness_lint_raw.das` — negative fixture
+  proving the default-on lint fires. Uses `expect 50503` so dastest treats
+  the compile failure as a PASS.
 
 ### Changed
 
-- `examples/features/foundation.das` ported to `imgui/imgui_harness` as the
-  first canary adopter. 15 requires collapse to one; the GLFW/GL update
-  boilerplate collapses to two helper calls bracketing the user widget block.
-- `examples/features/active_widget.das` ported to `imgui/imgui_harness` as
-  the second canary — exercises the boost runtime + Playwright-style
-  command surface (`imgui_click`, `imgui_snapshot`) under both modes.
+- `examples/features/foundation.das` and `active_widget.das` ported to
+  `imgui/imgui_harness` (PR 1+2; restated here for completeness).
+- First migration batch (this PR) — 12 additional `examples/features/`
+  files ported to the harness API. Each file dropped 14 requires + ~25
+  lines of GLFW/GL boilerplate down to a single
+  `require imgui/imgui_harness` + 5 helper calls. All verified working in
+  both windowed (live mode) and headless (`--headless --headless-frames=60`)
+  modes; integration suite: 111/111 PASS (was 110/110 before lint canary):
+    - `narrative_text.das`, `narrative_bullet.das`, `narrative_separator.das`
+    - `output_text.das`
+    - `with_indent.das`, `with_item_width.das`, `with_text_wrap_pos.das`
+    - `menu_main.das`, `menu_label_static.das`
+    - `tooltip_flat.das`
+    - `button_repeat.das`, `collapsing_header_closable.das`
+    - `disabled_block.das`
+- `imgui_harness.das` re-exports broadened to include all sibling
+  `imgui_*_builtin` modules (`imgui_scope_builtin`, `imgui_id_builtin`,
+  `imgui_style_builtin`, `imgui_layout_builtin`, `imgui_docking_builtin`,
+  `imgui_colors`). Matches the design intent — one require should bring
+  the full backend-agnostic dasImgui v2 surface into scope. Migration
+  batch surfaced the gap (5 of 13 files needed a second require for
+  `scope_builtin` before the harness was extended).

--- a/doc/source/tutorials/harness_headless_mode.rst
+++ b/doc/source/tutorials/harness_headless_mode.rst
@@ -115,6 +115,37 @@ GLFW libs to be findable on the host (the OS DLL loader resolves
 active). Truly minimal-deploy headless (no GLFW libs at all) is a future
 build-flag concern.
 
+**********************************
+Default-on lint: HARNESS001
+**********************************
+
+Bundled with the harness (``require imgui/imgui_harness_lint public`` from
+``imgui_harness.das``) is a default-on ``[lint_macro]`` that fires whenever a
+file requiring ``imgui/imgui_harness`` reaches into the windowed-backend
+modules directly. Forbidden modules:
+
+* ``glfw_boost`` / ``opengl_boost``
+* ``glfw_live`` / ``opengl_live``
+* ``imgui_live``
+
+The structural private-require gate in ``imgui_harness.das`` already hides
+those modules from harness consumers, so a clean file never trips the lint.
+The lint is the second line of defense — it catches files that explicitly
+re-add a backend ``require`` to bypass the gate. Diagnostic code is
+``HARNESS001`` (macro_error 50503).
+
+Per-file escape, for the rare windowed-only test that needs a backend
+symbol directly (screenshot pipelines, custom GL clears, etc.):
+
+.. code-block:: das
+
+   options _allow_glfw_calls = true
+
+This is scaffolding only. The target end-state for the migration is
+**no opt-outs anywhere in** ``examples/``; the option will be removed from
+the registry once every harness-using file is clean. Same pattern as the
+``_allow_imgui_legacy`` opt-out for ``imgui_lint``.
+
 ***********************
 Limits under --headless
 ***********************

--- a/examples/features/button_repeat.das
+++ b/examples/features/button_repeat.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_scope_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_button_repeat — stateless Push/PopButtonRepeat wrapper.
@@ -25,22 +10,19 @@ require imgui/imgui_scope_builtin
 //          fire-once semantics. Compare BTN_INSIDE.click_count vs
 //          BTN_OUTSIDE.click_count while holding each.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/button_repeat.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/button_repeat.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/button_repeat.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("with_button_repeat — boost v2 §3.6", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("with_button_repeat — boost v2 §3.6", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_button_repeat", closable = false,
@@ -58,21 +40,12 @@ def update() {
         text(STATUS_OUT, (text = "outside count: {BTN_OUTSIDE.click_count}"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/collapsing_header_closable.das
+++ b/examples/features/collapsing_header_closable.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: collapsing_header(closable=true) — close-button route (boost v2 §3.5).
@@ -26,22 +12,19 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_open","args":{"target":"MAIN_WIN/HEADER_CLOSE"}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/collapsing_header_closable.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/collapsing_header_closable.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/collapsing_header_closable.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("collapsing_header_closable — boost v2 §3.5", 720, 420)
-    live_imgui_init(live_window)
+    harness_init("collapsing_header_closable — boost v2 §3.5", 720, 420)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 360.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "collapsing_header(closable=…)",
@@ -63,21 +46,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/disabled_block.das
+++ b/examples/features/disabled_block.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_scope_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_disabled — stateless BeginDisabled / EndDisabled scope wrapper.
@@ -24,22 +9,19 @@ require imgui/imgui_scope_builtin
 //          no [container] annotation, no telemetry global. Toggle the gate
 //          checkbox to flip every child between active and disabled.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/disabled_block.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/disabled_block.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/disabled_block.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("with_disabled — boost v2 §3.6", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("with_disabled — boost v2 §3.6", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_disabled", closable = false,
@@ -58,21 +40,12 @@ def update() {
         if (button(BTN_OUTSIDE, (text = "always-enabled button"))) {}
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/menu_label_static.das
+++ b/examples/features/menu_label_static.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: menu_label_static — static (non-toggleable) menu items (boost v2 §3.4).
@@ -27,22 +13,19 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/MENU/MI_SECTION_HEADER"'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/menu_label_static.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/menu_label_static.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/menu_label_static.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("menu_label_static — boost v2 §3.4", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("menu_label_static — boost v2 §3.4", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "menu_label vs menu_item", closable = false,
@@ -71,21 +54,12 @@ def update() {
         text(STATUS, (text = "MI_AUTOSAVE_TOGGLE state.value = {MI_AUTOSAVE_TOGGLE.value}"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/menu_main.das
+++ b/examples/features/menu_main.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: main_menu_bar — top-level menu container (boost v2 §3.3).
@@ -28,22 +14,19 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_click","args":{"target":"MAIN_MENU_BAR/FILE_MENU/MI_SAVE"}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/menu_main.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/menu_main.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/menu_main.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("main_menu_bar — boost v2 §3.3", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("main_menu_bar — boost v2 §3.3", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     main_menu_bar(MAIN_MENU_BAR) {
         menu(FILE_MENU, (text = "File", enabled = true)) {
@@ -67,21 +50,12 @@ def update() {
         text(BODY_RELOAD, (text = "Reload toggled: {MI_RELOAD.value}"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/narrative_bullet.das
+++ b/examples/features/narrative_bullet.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: narrative_bullet — bullet + bullet_text widgets (boost v2 §3.2).
@@ -26,22 +12,19 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/BULLET_LIST_FAST"'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/narrative_bullet.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/narrative_bullet.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/narrative_bullet.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("narrative_bullet — boost v2 §3.2", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("narrative_bullet — boost v2 §3.2", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "bullet + bullet_text", closable = false,
@@ -59,21 +42,12 @@ def update() {
         text("second marker, second tail")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/narrative_separator.das
+++ b/examples/features/narrative_separator.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: narrative_separator — separator/separator_text/label_text family.
@@ -26,22 +12,19 @@ require imgui/imgui_containers_builtin
 //              | jq '.globals."MAIN_WIN/LABEL_FPS"'
 //          # → {"payload":{"key":"frames per second","value":"60"}, ...}
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/narrative_separator.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/narrative_separator.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/narrative_separator.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("narrative_separator — boost v2 §3.2", 720, 460)
-    live_imgui_init(live_window)
+    harness_init("narrative_separator — boost v2 §3.2", 720, 460)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 400.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "separator / separator_text / label_text",
@@ -59,21 +42,12 @@ def update() {
         label_text(LABEL_CFG, (key = "config", value = "Release"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/narrative_text.das
+++ b/examples/features/narrative_text.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: narrative_text — telemetry-bearing text widgets (boost v2 §3.2).
@@ -29,23 +15,19 @@ require imgui/imgui_containers_builtin
 //              | jq '.globals."MAIN_WIN/NARRATIVE_LEAD"'
 //          # → {"payload":{"value":"Telemetry-bearing narrative…"}, "kind":"text", ...}
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/narrative_text.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/narrative_text.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/narrative_text.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("narrative_text — boost v2 §3.2", 760, 460)
-    live_imgui_init(live_window)
+    harness_init("narrative_text — boost v2 §3.2", 760, 460)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 400.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "narrative widgets", closable = false,
@@ -57,22 +39,12 @@ def update() {
         text_disabled(NARRATIVE_DISABLED, (text = "text_disabled: dimmed style for caption / hint copy."))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/output_text.das
+++ b/examples/features/output_text.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: output_text — Phase 1.4 text_show display widget (master plan §4.3a).
@@ -29,25 +15,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/STATUS_LINE","value":"hello"}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/output_text.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/output_text.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/output_text.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 1.4 — text_show", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 1.4 — text_show", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(560.0, 220.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "text_show demo", closable = false,
@@ -69,22 +51,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/tooltip_flat.das
+++ b/examples/features/tooltip_flat.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: tooltip_flat — flat-form tooltip widgets (boost v2 §3.2).
@@ -27,22 +13,19 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/TOOLTIP_ON_BUTTON"'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/tooltip_flat.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/tooltip_flat.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/tooltip_flat.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("tooltip_flat — boost v2 §3.2", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("tooltip_flat — boost v2 §3.2", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "set_tooltip / set_item_tooltip",
@@ -58,21 +41,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/with_indent.das
+++ b/examples/features/with_indent.das
@@ -1,46 +1,27 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_scope_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_indent — stateless block-arg wrapper around Indent/Unindent.
 // SHOWS:   nested with_indent blocks; default amount (0.0f) defers to ImGui's
 //          style IndentSpacing, explicit amounts produce custom indents.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/with_indent.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/with_indent.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/with_indent.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("with_indent — scope wrapper", 640, 480)
-    live_imgui_init(live_window)
+    harness_init("with_indent — scope wrapper", 640, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(580.0, 420.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_indent", closable = false,
@@ -66,22 +47,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/with_item_width.das
+++ b/examples/features/with_item_width.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_scope_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_item_width — stateless block-arg wrapper around
@@ -24,25 +9,21 @@ require imgui/imgui_scope_builtin
 // SHOWS:   nested scopes; positive (absolute), negative (right-edge minus N),
 //          and default style width contrasted side-by-side.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/with_item_width.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/with_item_width.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/with_item_width.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("with_item_width — scope wrapper", 720, 480)
-    live_imgui_init(live_window)
+    harness_init("with_item_width — scope wrapper", 720, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(660.0, 420.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_item_width", closable = false,
@@ -68,22 +49,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/with_text_wrap_pos.das
+++ b/examples/features/with_text_wrap_pos.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_scope_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_text_wrap_pos — stateless block-arg wrapper around
@@ -24,6 +9,7 @@ require imgui/imgui_scope_builtin
 // SHOWS:   default wrap (window right edge), narrow wrap (200 px), wider
 //          wrap (400 px).
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/with_text_wrap_pos.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/with_text_wrap_pos.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/with_text_wrap_pos.das
 // =============================================================================
 
@@ -32,20 +18,15 @@ let LIPSUM = ("Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
 
 [export]
 def init() {
-    live_create_window("with_text_wrap_pos — scope wrapper", 720, 540)
-    live_imgui_init(live_window)
+    harness_init("with_text_wrap_pos — scope wrapper", 720, 540)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(660.0, 480.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_text_wrap_pos", closable = false,
@@ -68,22 +49,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/tests/integration/failed_imgui_harness_lint_raw.das
+++ b/tests/integration/failed_imgui_harness_lint_raw.das
@@ -1,0 +1,20 @@
+options gen2
+
+require imgui/imgui_harness
+// Explicit backend require — bypasses the structural private-require gate
+// the harness sets up. The HARNESS001 lint is the second line of defense.
+require live/glfw_live
+
+//! Negative test — default-on harness lint must trip HARNESS001
+//! (macro_error code 50503) when a harness-using file forces a backend
+//! require to bypass the structural gate, then calls a backend symbol
+//! directly (here: ``live_create_window`` from ``glfw_live``).
+//! No opt-in line required; lint is bundled via ``imgui/imgui_harness``
+//! transitively through ``require imgui/imgui_harness_lint public``.
+
+expect 50503
+
+[export]
+def main() {
+    live_create_window("must fail with HARNESS001", 320, 240)
+}

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -3,6 +3,10 @@ options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
 options _allow_imgui_legacy = true
+// Defensive opt-out: the harness is the legitimate caller into glfw/opengl/
+// imgui_live backends — its own compile passes need to skip its own lint.
+// Same pattern as `_allow_imgui_legacy = true` on widgets/imgui_lint.das.
+options _allow_glfw_calls = true
 
 module imgui_harness shared public
 
@@ -48,10 +52,21 @@ require imgui/imgui_boost_runtime public
 require imgui/imgui_boost_v2 public
 require imgui/imgui_widgets_builtin public
 require imgui/imgui_containers_builtin public
+require imgui/imgui_scope_builtin public
+require imgui/imgui_id_builtin public
+require imgui/imgui_style_builtin public
+require imgui/imgui_layout_builtin public
+require imgui/imgui_docking_builtin public
+require imgui/imgui_colors public
 require imgui/imgui_visual_aids
 
 // Headless backend — private. 3-fn surface (no GLFW/GL names).
 require imgui_app_headless
+
+// Default-on lint — public re-export so every consumer file picks it up.
+// Forbids direct windowed-backend calls in harness-using files. Opt-out:
+// `options _allow_glfw_calls = true` (scaffolding only).
+require imgui/imgui_harness_lint public
 
 require daslib/clargs
 require strings

--- a/widgets/imgui_harness_lint.das
+++ b/widgets/imgui_harness_lint.das
@@ -1,0 +1,76 @@
+options gen2
+options indenting = 4
+options strict_smart_pointers = true
+
+module imgui_harness_lint shared private
+
+//! Default-on lint for files that ``require imgui/imgui_harness``.
+//!
+//! Forbids direct calls into the windowed-backend modules so harness
+//! consumers stay backend-agnostic — the harness dispatches windowed
+//! vs headless internally, and any raw GLFW/GL/imgui_live call breaks
+//! ``--headless`` execution.
+//!
+//! Code (macro_error severity, error code 50503):
+//!   HARNESS001 — call into a forbidden backend module from a
+//!                harness-using file. Opt-out per-file:
+//!                ``options _allow_glfw_calls = true`` (scaffolding only,
+//!                target end-state = no opt-out — same pattern as
+//!                PR #33's ``_allow_imgui_legacy``).
+//!
+//! Forbidden modules:
+//!   glfw_boost / opengl_boost / glfw_live / opengl_live / imgui_live
+//!
+//! Scoping: walks ``prog.getThisModule`` only — transitively-required
+//! modules (including ``imgui_harness`` itself, which legitimately calls
+//! into the backends as the wrapper) are skipped. Macro-generated bodies
+//! and macro-synthesized call sites are filtered by ``fileInfo`` mismatch,
+//! same convention as ``imgui_lint.das``.
+
+require daslib/ast_boost
+require strings
+
+let private FORBIDDEN_MODULES : table<string> <- {
+    "glfw_boost", "opengl_boost", "glfw_live", "opengl_live", "imgui_live"
+}
+
+class HarnessLintVisitor : AstVisitor {
+    @do_not_delete current_function : Function?
+
+    def override preVisitFunction(var fn : FunctionPtr) : void {
+        current_function = fn
+    }
+
+    def override visitFunction(var fn : FunctionPtr) : FunctionPtr {
+        current_function = null
+        return <- fn
+    }
+
+    def override preVisitExprCall(var expr : ExprCall?) : void {
+        if (expr.func == null || expr.func._module == null
+                || (current_function != null
+                    && (current_function.flags.generated
+                        || (current_function.at.fileInfo != null
+                            && expr.at.fileInfo != current_function.at.fileInfo)))) return
+        let mname = string(expr.func._module.name)
+        if (key_exists(FORBIDDEN_MODULES, mname)) {
+            let fname = string(expr.func.name)
+            compiling_program() |> macro_error(expr.at,
+                "HARNESS001: {mname}::{fname} is forbidden in files that require imgui_harness — use the harness helpers (harness_init / harness_begin_frame / harness_new_frame / harness_end_frame / harness_shutdown) instead. Per-file escape: `options _allow_glfw_calls = true` (scaffolding only)")
+        }
+    }
+}
+
+[lint_macro]
+class HarnessLintMacro : AstPassMacro {
+    def override apply(prog : ProgramPtr; mod : Module?) : bool {
+        let opted_out = prog._options |> find_arg("_allow_glfw_calls") ?as tBool ?? false
+        if (opted_out) return true
+        var v = new HarnessLintVisitor()
+        make_visitor(*v) $(adapter) {
+            visit_module(prog, adapter, prog.getThisModule)
+        }
+        unsafe { delete v; }
+        return true
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of the harness/headless initiative (PR #35 was the wrapper + headless backend; this lands the lint plus the first migration batch).

### Default-on lint — `HARNESS001`

New `widgets/imgui_harness_lint.das` — `[lint_macro]` `AstPassMacro` that fires on any file requiring `imgui/imgui_harness` and forbids direct calls into the windowed-backend modules:

- `glfw_boost` / `opengl_boost`
- `glfw_live` / `opengl_live`
- `imgui_live`

Diagnostic shape (matches PR #33's `IMGUI001`/`IMGUI002`/`STYLE001` family):

```
error[50503]: HARNESS001: glfw_live::live_create_window is forbidden in
files that require imgui_harness — use the harness helpers
(harness_init / harness_begin_frame / harness_new_frame /
harness_end_frame / harness_shutdown) instead. Per-file escape:
`options _allow_glfw_calls = true` (scaffolding only)
```

Bundled via `require imgui/imgui_harness_lint public` from `imgui_harness.das` so every harness consumer picks it up transitively. The harness module itself carries `options _allow_glfw_calls = true` defensively (same convention as `imgui_lint.das`'s `_allow_imgui_legacy`).

The structural private-require gate in `imgui_harness.das` already hides forbidden symbols from harness consumers. The lint is the second line of defense — it catches files that explicitly re-add a backend `require` to bypass the gate. New `tests/integration/failed_imgui_harness_lint_raw.das` is the canary fixture (uses `expect 50503` so dastest treats the compile failure as a PASS).

### First migration batch — 13 feature files

Each file drops ~14 requires + ~25 lines of GLFW/GL boilerplate down to one `require imgui/imgui_harness` + 5 helper calls:

- `narrative_text`, `narrative_bullet`, `narrative_separator`
- `output_text`
- `with_indent`, `with_item_width`, `with_text_wrap_pos`
- `menu_main`, `menu_label_static`
- `tooltip_flat`
- `button_repeat`, `collapsing_header_closable`
- `disabled_block`

Each verified working in both windowed (live mode under daslang-live) and headless (`--headless --headless-frames=60`) modes.

### Harness re-exports broadened

`widgets/imgui_harness.das` now re-exports the full set of sibling builtin modules:

- `imgui_scope_builtin` (with_indent, with_item_width, with_text_wrap_pos, with_disabled, …)
- `imgui_id_builtin` (with_id, push_id)
- `imgui_style_builtin` (with_style)
- `imgui_layout_builtin` (split_h, split_v, dock_left)
- `imgui_docking_builtin` (dockspace, dock_window)
- `imgui_colors` (rgba_*, IM_COL32 packer)

Matches the design intent that a single `require imgui/imgui_harness` brings the full backend-agnostic v2 surface into scope. Surfaced by the migration batch when 5 of 13 files initially needed a workaround `require imgui/imgui_scope_builtin`.

### Doc

`doc/source/tutorials/harness_headless_mode.rst` gains a new section explaining `HARNESS001` and the `_allow_glfw_calls` scaffolding opt-out (timeline: removed once `examples/` is fully migrated).

## Test plan

- [x] `compile_check` clean on harness + lint + canary + all 13 migrated files
- [x] `lint` clean on the same set; canary correctly skipped as "intentional compile errors via `expect`"
- [x] `format_file` clean across the same set
- [x] Headless smoke for each migrated file: `daslang FILE -- --headless --headless-frames=60` → exit 0
- [x] Windowed smoke for each migrated file: `timeout 5 daslang FILE` → exit 124 (windowed app ran, killed by timeout)
- [x] Full `dastest --test modules/dasImgui/tests/integration`: **111/111 PASS** (was 110/110 before; +1 for the new lint canary)
- [x] `sphinx-build -W --keep-going` clean over `doc/`
- [ ] CI smoke once PR is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)