### PR TITLE
imgui_harness: migrate all 48 remaining examples/features/ files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,30 @@
   the full backend-agnostic dasImgui v2 surface into scope. Migration
   batch surfaced the gap (5 of 13 files needed a second require for
   `scope_builtin` before the harness was extended).
+- **Second migration batch (this PR) — all 48 remaining `examples/features/`
+  files ported to the harness API.** With the 15 already-migrated files
+  (foundation, active_widget, and the 13 from PR 3), every file under
+  `examples/features/` now uses `require imgui/imgui_harness`. Net
+  diff: +345 / -1680 across 48 files (mechanical 14-require chain →
+  single require, 25-line update/shutdown boilerplate → 5 helper calls).
+  Three sub-patterns covered:
+    - **Canonical (35 files)** — `await_quiescent`, `clip_rect`,
+      `containers_layout/_overlay/_window`, `display_image/_progress`,
+      `drag_drop`, `focus_widget`, `font_stack`, `hex_id_click`,
+      `id_override`, `indexed_dynamic`, `inputs_choice/_color/_drag/`
+      `_indexed/_numeric/_slider/_text`, `io_mirror`, `io_synth_drag/_text`,
+      `layout_primitives`, `list_box`, `plot_getter/_widgets`,
+      `popup_context_item`, `scroll_state`, `snapshot_unrendered`,
+      `style_override`, `transport_demo`, `triggers`, `widget_init_defaults`,
+      `widget_no_ident`.
+    - **Synth-IO (7 files)** — `columns_demo`, `dock_basic`, `layout_helpers`,
+      `glfw_synth_keys/_mouse`, `imgui_synth_keys/_mouse`. These call
+      `harness_apply_synth_io()` between `harness_begin_frame()` and
+      `harness_new_frame()` (the slot where `apply_synth_io_override()`
+      used to live).
+    - **edit_external (6 files)** — `edit_external_color/_combo/_scalars/`
+      `_special/_toggles/_vectors`. Preserve the `require daslib/safe_addr`
+      that the family uses for caller-owned pointer args.
+  Verified per-file: `compile_check` + `lint` + `format_file` clean,
+  headless smoke (60 frames) exit 0, windowed smoke (5 s timeout-killed)
+  ran. Full dastest integration: 111/111 PASS (unchanged).

--- a/examples/features/await_quiescent.das
+++ b/examples/features/await_quiescent.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: await_quiescent — Phase 2.5 quiescence probe.
@@ -27,13 +13,13 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_drag","args":{"target":"MAIN_WIN/DEMO_SLIDER","dx":80,"steps":6,"await":{"await_frames":3}}}' \
 //              localhost:9090/command           # response carries await_frames=3
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/await_quiescent.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/await_quiescent.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/await_quiescent.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 2.5 — await_quiescent", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.5 — await_quiescent", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
     DEMO_SLIDER.bounds = (0.0f, 1000.0f)
@@ -41,13 +27,9 @@ def init() {
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
+    if (!harness_begin_frame()) return
     advance_coroutines()
-    NewFrame()
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 200.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "await_quiescent — phase 2.5", closable = false,
@@ -56,22 +38,12 @@ def update() {
         slider_float(DEMO_SLIDER, (text = "Optional: drag to spawn a coroutine"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/clip_rect.das
+++ b/examples/features/clip_rect.das
@@ -4,22 +4,7 @@ options gen2
 // default-on lint so the demo compiles cleanly.
 options _allow_imgui_legacy = true
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_scope_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_clip_rect — Push/PopClipRect scope wrapper.
@@ -27,22 +12,19 @@ require imgui/imgui_scope_builtin
 //          inside to the given rectangle. Typical use: rendering DrawList
 //          shapes that should not bleed outside a widget box.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/clip_rect.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/clip_rect.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/clip_rect.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("with_clip_rect — boost v2 §3.6", 720, 480)
-    live_imgui_init(live_window)
+    harness_init("with_clip_rect — boost v2 §3.6", 720, 480)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 420.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_clip_rect", closable = false,
@@ -71,21 +53,12 @@ def update() {
         text(NOTE, (text = "Below the clip block — uncropped Text renders normally."))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/columns_demo.das
+++ b/examples/features/columns_demo.das
@@ -1,22 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_layout_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: columns_demo — §4.6 `columns(N, ${a}, ${b}, …)` call_macro.
@@ -26,26 +10,22 @@ require imgui/imgui_visual_aids
 //          - Each column's children are addressed by the surrounding window's
 //            path (columns is not a container — it doesn't push a path leaf).
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/columns_demo.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/columns_demo.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/columns_demo.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("§4.6 — columns demo", 640, 480)
-    live_imgui_init(live_window)
+    harness_init("§4.6 — columns demo", 640, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.FirstUseEver)
     SetNextWindowSize(ImVec2(560.0f, 380.0f), ImGuiCond.FirstUseEver)
@@ -69,22 +49,12 @@ def update() {
         button(AFTER_BTN, (text = "After"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/containers_layout.das
+++ b/examples/features/containers_layout.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: containers_layout — Phase 0b.3 tab_bar / tab_item / tree_node /
@@ -29,25 +15,21 @@ require imgui/imgui_containers_builtin
 //                            "args":{"target":"LAYOUT_WIN/SETTINGS_TAB/PHYSICS_TREE/GRAVITY","value":12.5}}' \
 //                       localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/containers_layout.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/containers_layout.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/containers_layout.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 0b.3 — containers (layout family)", 800, 700)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.3 — containers (layout family)", 800, 700)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     GRAVITY.bounds = (0.0f, 50.0f)
     DENSITY.bounds = (0.0f, 10.0f)
@@ -122,22 +104,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/containers_overlay.das
+++ b/examples/features/containers_overlay.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: containers_overlay — Phase 0b.3 popup / popup_modal / tooltip /
@@ -29,6 +15,7 @@ require imgui/imgui_containers_builtin
 //                            "args":{"target":"OVERLAY_WIN/PALETTE_COMBO","value":2}}' \
 //                       localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/containers_overlay.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/containers_overlay.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/containers_overlay.das
 // =============================================================================
 
@@ -39,20 +26,15 @@ var TASK_ROW : table<int; ClickState>
 
 [export]
 def init() {
-    live_create_window("Phase 0b.3 — containers (overlay family)", 800, 640)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.3 — containers (overlay family)", 800, 640)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.FirstUseEver)
     SetNextWindowSize(ImVec2(720.0f, 580.0f), ImGuiCond.FirstUseEver)
@@ -150,22 +132,12 @@ def update() {
         text("task = {task_label} (idx {TASK_LIST.value})")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/containers_window.das
+++ b/examples/features/containers_window.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: containers_window — Phase 0b.3 window/child/group containers.
@@ -29,25 +15,21 @@ require imgui/imgui_containers_builtin
 //                            "args":{"target":"DETAIL_WIN"}}' \
 //                       localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/containers_window.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/containers_window.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/containers_window.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 0b.3 — containers (window family)", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.3 — containers (window family)", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     // Leaf widgets nested inside containers get hierarchical registry keys:
     // "MAIN_WIN/SAVE" / "MAIN_WIN/SPEED" / "MAIN_WIN/LEFT_PANEL/WIRE" / …
@@ -101,22 +83,12 @@ def update() {
         text("ping clicks: {PING.click_count}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/display_image.das
+++ b/examples/features/display_image.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: display_image — image() widget against the ImGui font atlas texture.
@@ -27,22 +13,19 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/IMG_BASIC".payload'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/display_image.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/display_image.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/display_image.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("display_image — boost v2 §3.2", 720, 420)
-    live_imgui_init(live_window)
+    harness_init("display_image — boost v2 §3.2", 720, 420)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 360.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "image() against font atlas",
@@ -76,21 +59,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/display_progress.das
+++ b/examples/features/display_progress.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require math
 
 // =============================================================================
@@ -25,6 +11,7 @@ require math
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/PB_DRIVEN".payload.fraction'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/display_progress.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/display_progress.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/display_progress.das
 // =============================================================================
 
@@ -32,20 +19,16 @@ var private g_t : float = 0.0f
 
 [export]
 def init() {
-    live_create_window("progress_bar — boost v2 §3.2", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("progress_bar — boost v2 §3.2", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
+    if (!harness_begin_frame()) return
     g_t += 1.0f / 60.0f
     let frac = 0.5f + 0.5f * sin(g_t * 2.0f)
 
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "progress_bar", closable = false,
@@ -58,21 +41,12 @@ def update() {
         progress_bar(PB_PLAIN, (fraction = 0.75f))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/dock_basic.das
+++ b/examples/features/dock_basic.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_docking_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: dock_basic — Phase 7 dockspace + dock_window with a DockBuilder-
@@ -44,6 +29,7 @@ require imgui/imgui_visual_aids
 // path, so child dock_windows live under ``DOCK_ROOT/<name>`` — mirrors how
 // ``window(MAIN_WIN, ...)`` prefixes its children in containers_builtin.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/dock_basic.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/dock_basic.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/dock_basic.das
 // =============================================================================
 
@@ -78,8 +64,7 @@ def setup_default_layout(dock_id : uint) {
 
 [export]
 def init() {
-    live_create_window("Phase 7 — docking", 1024, 720)
-    live_imgui_init(live_window)
+    harness_init("Phase 7 — docking", 1024, 720)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
     io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
@@ -87,13 +72,9 @@ def init() {
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     dockspace(DOCK_ROOT, (flags = ImGuiDockNodeFlags.PassthruCentralNode)) {
         //! Seed the layout once per session (or after imgui_dock_reset flips
@@ -127,22 +108,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/drag_drop.das
+++ b/examples/features/drag_drop.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: drag_drop — [container]s drag_drop_source + drag_drop_target.
@@ -25,6 +11,7 @@ require imgui/imgui_containers_builtin
 //          "MY_INT" payload and writes it into RECEIVED. DROP_COUNT
 //          increments on each successful release-over-target.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/drag_drop.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/drag_drop.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/drag_drop.das
 // =============================================================================
 
@@ -34,20 +21,15 @@ var DROP_COUNT : int = 0
 
 [export]
 def init() {
-    live_create_window("drag_drop — source + target", 720, 480)
-    live_imgui_init(live_window)
+    harness_init("drag_drop — source + target", 720, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(660.0, 420.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "drag_drop", closable = false,
@@ -87,22 +69,12 @@ def update() {
         text("Drops accepted: {DROP_COUNT}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/edit_external_color.das
+++ b/examples/features/edit_external_color.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require daslib/safe_addr
 
 // =============================================================================
@@ -26,6 +12,7 @@ require daslib/safe_addr
 // DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/CE4","value":{"x":0.8,"y":0.2,"z":0.4,"w":1.0}}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_external_color.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_external_color.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/edit_external_color.das
 // =============================================================================
 
@@ -36,17 +23,13 @@ var private g_pck4 : float4 = float4(0.1f, 0.2f, 0.3f, 0.4f)
 
 [export]
 def init() {
-    live_create_window("edit_external_color — boost v2 §3.7", 800, 620)
-    live_imgui_init(live_window)
+    harness_init("edit_external_color — boost v2 §3.7", 800, 620)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(760.0, 560.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "edit_* color", closable = false,
@@ -61,21 +44,12 @@ def update() {
                                                 has_ref_col = true))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/edit_external_combo.das
+++ b/examples/features/edit_external_combo.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require daslib/safe_addr
 
 // =============================================================================
@@ -27,6 +13,7 @@ require daslib/safe_addr
 // DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/COMBO_THEME","value":2}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_external_combo.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_external_combo.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/edit_external_combo.das
 // =============================================================================
 
@@ -38,17 +25,13 @@ let private g_difficulties : array<string> <- ["Easy", "Normal", "Hard", "Insane
 
 [export]
 def init() {
-    live_create_window("edit_external_combo — boost v2 §3.7", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("edit_external_combo — boost v2 §3.7", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "edit_combo", closable = false,
@@ -66,21 +49,12 @@ def update() {
         text(STATUS_DIFF, (text = "selected difficulty idx = {g_difficulty_idx}"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/edit_external_scalars.das
+++ b/examples/features/edit_external_scalars.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require daslib/safe_addr
 
 // =============================================================================
@@ -31,6 +17,7 @@ require daslib/safe_addr
 //          curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/SLIDER_F".payload.value'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_external_scalars.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_external_scalars.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/edit_external_scalars.das
 // =============================================================================
 
@@ -44,17 +31,13 @@ var private g_input_d : double = 6.28lf
 
 [export]
 def init() {
-    live_create_window("edit_external_scalars — boost v2 §3.7", 760, 480)
-    live_imgui_init(live_window)
+    harness_init("edit_external_scalars — boost v2 §3.7", 760, 480)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 420.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "edit_* scalars", closable = false,
@@ -78,21 +61,12 @@ def update() {
                                                  text = "input double", step = 0.01lf))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/edit_external_special.das
+++ b/examples/features/edit_external_special.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require daslib/safe_addr
 require math
 
@@ -30,6 +16,7 @@ require math
 //              localhost:9090/command
 //          # → sets g_angle_rad to ~π/2 (90° on the slider).
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_external_special.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_external_special.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/edit_external_special.das
 // =============================================================================
 
@@ -37,17 +24,13 @@ var private g_angle_rad : float = 0.7854f  // π/4 → ~45° initial
 
 [export]
 def init() {
-    live_create_window("edit_external_special — boost v2 §3.7", 720, 320)
-    live_imgui_init(live_window)
+    harness_init("edit_external_special — boost v2 §3.7", 720, 320)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 260.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "edit_slider_angle", closable = false,
@@ -61,21 +44,12 @@ def update() {
         text(STATUS, (text = "g_angle_rad = {g_angle_rad} (≈ {int(g_angle_rad * 180.0f / PI)}°)"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/edit_external_toggles.das
+++ b/examples/features/edit_external_toggles.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require daslib/safe_addr
 
 // =============================================================================
@@ -26,6 +12,7 @@ require daslib/safe_addr
 // DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/CB_GATE","value":true}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_external_toggles.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_external_toggles.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/edit_external_toggles.das
 // =============================================================================
 
@@ -35,17 +22,13 @@ var private g_flags : int = 5
 
 [export]
 def init() {
-    live_create_window("edit_external_toggles — boost v2 §3.7", 720, 380)
-    live_imgui_init(live_window)
+    harness_init("edit_external_toggles — boost v2 §3.7", 720, 380)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 320.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "edit_* toggles", closable = false,
@@ -64,21 +47,12 @@ def update() {
                                                  text = "bit 3 (value 8)", flags_value = 8))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/edit_external_vectors.das
+++ b/examples/features/edit_external_vectors.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require daslib/safe_addr
 
 // =============================================================================
@@ -27,6 +13,7 @@ require daslib/safe_addr
 // DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/SF3","value":{"x":0.5,"y":0.6,"z":0.7}}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_external_vectors.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_external_vectors.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/edit_external_vectors.das
 // =============================================================================
 
@@ -51,17 +38,13 @@ var private g_di4 : int4 = int4(10, 20, 30, 40)
 
 [export]
 def init() {
-    live_create_window("edit_external_vectors — boost v2 §3.7", 800, 760)
-    live_imgui_init(live_window)
+    harness_init("edit_external_vectors — boost v2 §3.7", 800, 760)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(760.0, 700.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "edit_* vectors", closable = false,
@@ -91,21 +74,12 @@ def update() {
         edit_drag_int4(safe_addr(g_di4), (id = "DI4", text = "int4"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/focus_widget.das
+++ b/examples/features/focus_widget.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: focus_widget — Phase 2.4 keyboard focus dispatch.
@@ -30,25 +16,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_focus","args":{"target":"MAIN_WIN/DEMO_TEXT"}}' \
 //              localhost:9090/command                     # → Result.err (display-only)
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/focus_widget.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/focus_widget.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/focus_widget.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 2.4 — focus_widget", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.4 — focus_widget", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 240.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "focus_widget — phase 2.4", closable = false,
@@ -63,22 +45,12 @@ def update() {
         text("buffer = {DEMO_INPUT.value}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/font_stack.das
+++ b/examples/features/font_stack.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_scope_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_font — Push/PopFont scope wrapper.
@@ -25,22 +10,19 @@ require imgui/imgui_scope_builtin
 //          and AOT shape are exercised. Replace `font_ptr` with a real
 //          PushFont target when integrating a multi-font app.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/font_stack.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/font_stack.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/font_stack.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("with_font — boost v2 §3.6", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("with_font — boost v2 §3.6", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_font", closable = false,
@@ -57,21 +39,12 @@ def update() {
         text(NOTE, (text = "When a real second font is loaded, swap default_font with the new ImFont? handle."))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/glfw_synth_keys.das
+++ b/examples/features/glfw_synth_keys.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: glfw_synth_keys — GLFW-side synthetic keyboard driver (chain shim).
@@ -31,27 +16,22 @@ require imgui/imgui_visual_aids
 //          curl -X POST -d '{"name":"key_chord","args":{"mods":["Ctrl"],"key":"A"}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/glfw_synth_keys.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/glfw_synth_keys.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/glfw_synth_keys.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("glfw_synth_keys", 720, 320)
-    live_imgui_init(live_window)
+    harness_init("glfw_synth_keys", 720, 320)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()    // re-assert synth Ctrl/Shift/Alt/Super so ImGui's
-                                 // shortcut shortcuts (Ctrl+A, etc.) see them.
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(40.0, 40.0), ImGuiCond.Always)
     SetNextWindowSize(ImVec2(640.0, 240.0), ImGuiCond.Always)
@@ -65,22 +45,12 @@ def update() {
         text("Shift held: {IsKeyDown(ImGuiKey.LeftShift) || IsKeyDown(ImGuiKey.RightShift)}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/glfw_synth_mouse.das
+++ b/examples/features/glfw_synth_mouse.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: glfw_synth_mouse — GLFW-side synthetic mouse driver (chain shim).
@@ -27,27 +12,22 @@ require imgui/imgui_visual_aids
 // DRIVE:   curl -X POST -d '{"name":"mouse_pos","args":{"x":200,"y":150}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/glfw_synth_mouse.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/glfw_synth_mouse.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/glfw_synth_mouse.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("glfw_synth_mouse", 640, 480)
-    live_imgui_init(live_window)
+    harness_init("glfw_synth_mouse", 640, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()    // re-assert synth cursor pos + held modifier
-                                 // keys after ImGui_ImplGlfw's per-frame poll.
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     // Anchored window so SYNTH_BTN's bbox is stable across runs.
     SetNextWindowPos(ImVec2(50.0, 50.0), ImGuiCond.Always)
@@ -61,22 +41,12 @@ def update() {
         text("SYNTH_BTN clicks: {SYNTH_BTN.click_count}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/hex_id_click.das
+++ b/examples/features/hex_id_click.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: hex_id_click — Phase 2.3 hex_id-targeted dispatch.
@@ -29,25 +15,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_click","args":{"target":"0xa3d68f08"}}' \
 //              localhost:9090/command                    # → {"ok":true,"value":"MAIN_WIN/DEMO_BTN", ...}
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/hex_id_click.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/hex_id_click.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/hex_id_click.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 2.3 — hex_id_click", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.3 — hex_id_click", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 220.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "hex_id_click — phase 2.3", closable = false,
@@ -60,22 +42,12 @@ def update() {
         text("clicks: {DEMO_BTN.click_count}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/id_override.das
+++ b/examples/features/id_override.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_id_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: id_override — §4.8 ID-override surface in full.
@@ -37,25 +22,21 @@ require imgui/imgui_id_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command
 //          # → widgets register under MAIN_WIN/section_a/SAVE_A_BTN etc.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/id_override.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/id_override.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/id_override.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("§4.8 — id_override (with_id)", 720, 540)
-    live_imgui_init(live_window)
+    harness_init("§4.8 — id_override (with_id)", 720, 540)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.FirstUseEver)
     SetNextWindowSize(ImVec2(640.0f, 480.0f), ImGuiCond.FirstUseEver)
@@ -108,22 +89,12 @@ def update() {
                                 id = "rps_a", path = "rps_b"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/imgui_synth_keys.das
+++ b/examples/features/imgui_synth_keys.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: imgui_synth_keys — ImGui-bypass synthetic keyboard driver.
@@ -32,27 +17,22 @@ require imgui/imgui_visual_aids
 //          curl -X POST -d '{"name":"imgui_key_chord","args":{"mods":["Ctrl"],"key":"A"}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/imgui_synth_keys.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/imgui_synth_keys.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/imgui_synth_keys.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("imgui_synth_keys", 720, 320)
-    live_imgui_init(live_window)
+    harness_init("imgui_synth_keys", 720, 320)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()    // dispatches imgui_synth_tick — purges
-                                 // backend events and injects synth state.
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(40.0, 40.0), ImGuiCond.Always)
     SetNextWindowSize(ImVec2(640.0, 240.0), ImGuiCond.Always)
@@ -66,22 +46,12 @@ def update() {
         text("Shift held: {IsKeyDown(ImGuiKey.LeftShift) || IsKeyDown(ImGuiKey.RightShift)}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/imgui_synth_mouse.das
+++ b/examples/features/imgui_synth_mouse.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: imgui_synth_mouse — ImGui-bypass synthetic mouse driver.
@@ -28,27 +13,22 @@ require imgui/imgui_visual_aids
 // DRIVE:   curl -X POST -d '{"name":"imgui_mouse_pos","args":{"x":200,"y":150}}' \
 //              localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/imgui_synth_mouse.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/imgui_synth_mouse.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/imgui_synth_mouse.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("imgui_synth_mouse", 640, 480)
-    live_imgui_init(live_window)
+    harness_init("imgui_synth_mouse", 640, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()    // dispatches imgui_synth_tick — purges
-                                 // backend events and injects synth state.
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(50.0, 50.0), ImGuiCond.Always)
     SetNextWindowSize(ImVec2(420.0, 280.0), ImGuiCond.Always)
@@ -61,22 +41,12 @@ def update() {
         text("SYNTH_BTN clicks: {SYNTH_BTN.click_count}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/indexed_dynamic.das
+++ b/examples/features/indexed_dynamic.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_containers_builtin
-require imgui/imgui_widgets_builtin
+require imgui/imgui_harness
 require math
 
 // =============================================================================
@@ -31,6 +17,7 @@ require math
 //                "target":"DYN_WIN/BUMP_LAST"}}' localhost:9090/command
 //          # -> last channel's .value increments by 0.1
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/indexed_dynamic.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/indexed_dynamic.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/indexed_dynamic.das
 // =============================================================================
 
@@ -41,8 +28,7 @@ var private CHANNEL_VOL : table<int; SliderStateFloat>
 
 [export]
 def init() {
-    live_create_window("indexed_dynamic", 600, 500)
-    live_imgui_init(live_window)
+    harness_init("indexed_dynamic", 600, 500)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
@@ -59,12 +45,8 @@ def find_max_key(t : table<int; SliderStateFloat>) : int {
 
 [export]
 def update() {
-    return if (!live_begin_frame())
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    return if (!harness_begin_frame())
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(520.0, 440.0), ImGuiCond.Always)
     window(DYN_WIN, (text = "indexed_dynamic", closable = false, flags = ImGuiWindowFlags.None)) {
@@ -109,22 +91,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/inputs_choice.das
+++ b/examples/features/inputs_choice.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: inputs_choice — combo (items-array, single-call) + list_box
@@ -27,6 +13,7 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/SHIRT_SIZE","value":1}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/inputs_choice.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/inputs_choice.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_choice.das
 //
 // NOT YET COVERED HERE:
@@ -39,20 +26,15 @@ var SHIRT_ROW : table<int; ClickState>
 
 [export]
 def init() {
-    live_create_window("Phase 0b.2 — choice inputs", 720, 500)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.2 — choice inputs", 720, 500)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(660.0, 460.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Choice inputs — phase 0b.2", closable = false,
@@ -89,22 +71,12 @@ def update() {
         text("imgui_set with target=MAIN_WIN/FRUIT, value=N jumps to N-th item next frame")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/inputs_color.das
+++ b/examples/features/inputs_color.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: inputs_color — every Phase 0b.2 Color* widget in one window.
@@ -24,25 +10,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_click","args":{"target":"MAIN_WIN/PALETTE_RED"}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/inputs_color.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/inputs_color.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_color.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 0b.2 — color inputs", 800, 760)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.2 — color inputs", 800, 760)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 720.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Color inputs — phase 0b.2", closable = false,
@@ -90,22 +72,12 @@ def update() {
         text("palette clicks: red={PALETTE_RED.click_count}, green={PALETTE_GREEN.click_count}, blue={PALETTE_BLUE.click_count}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/inputs_drag.das
+++ b/examples/features/inputs_drag.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: inputs_drag — every Phase 0b.2 Drag* widget in one window.
@@ -29,25 +15,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/PRICE","value":[5, 12]}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/inputs_drag.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/inputs_drag.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_drag.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 0b.2 — drag inputs", 800, 700)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.2 — drag inputs", 800, 700)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 660.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Drag inputs — phase 0b.2", closable = false,
@@ -114,22 +96,12 @@ def update() {
         text("price = [{PRICE.value.x}, {PRICE.value.y}]")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/inputs_indexed.das
+++ b/examples/features/inputs_indexed.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: inputs_indexed — table-keyed slider widgets per API_REWORK §4.4.
@@ -26,6 +12,7 @@ require imgui/imgui_containers_builtin
 //               "target":"MIX_WIN/CHANNEL_VOL[3]","value":0.7}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/inputs_indexed.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/inputs_indexed.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_indexed.das
 // =============================================================================
 
@@ -41,8 +28,7 @@ let TRACK_NAMES : array<string> <- ["bass", "lead", "drum", "vocals"]
 
 [export]
 def init() {
-    live_create_window("inputs_indexed", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("inputs_indexed", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
     // Pre-populate so first-frame snapshot already has the right bounds + value.
@@ -58,12 +44,8 @@ def init() {
 
 [export]
 def update() {
-    return if (!live_begin_frame())
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    return if (!harness_begin_frame())
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 520.0), ImGuiCond.Always)
     // Use the boost `window` container so indexed leaves get the path
@@ -86,22 +68,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/inputs_numeric.das
+++ b/examples/features/inputs_numeric.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: inputs_numeric — every Phase 0b.2 Input* numeric widget in one window.
@@ -26,25 +12,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/VEL_XYZ","value":[1.0,2.0,3.0]}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/inputs_numeric.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/inputs_numeric.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_numeric.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 0b.2 — input numeric", 800, 760)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.2 — input numeric", 800, 760)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 720.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Numeric inputs — phase 0b.2", closable = false,
@@ -92,22 +74,12 @@ def update() {
         text("viewport = [{VIEWPORT_LTRB.value.x}, {VIEWPORT_LTRB.value.y}, {VIEWPORT_LTRB.value.z}, {VIEWPORT_LTRB.value.w}]")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/inputs_slider.das
+++ b/examples/features/inputs_slider.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: inputs_slider — every Phase 0b.2 Slider* widget in one window.
@@ -26,25 +12,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/WAVE_RGB","value":[0.1,0.5,0.9]}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/inputs_slider.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/inputs_slider.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_slider.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 0b.2 — slider inputs", 800, 800)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.2 — slider inputs", 800, 800)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 760.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Slider inputs — phase 0b.2", closable = false,
@@ -111,22 +93,12 @@ def update() {
         text("levels: L={VOL_L.value}, R={VOL_R.value}, bus={BUS_GAIN.value}dB")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/inputs_text.das
+++ b/examples/features/inputs_text.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require strings
 require math
 
@@ -35,6 +21,7 @@ require math
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/FONT","value":2}}' \
 //               localhost:9090/command   (combo_getter index)
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/inputs_text.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/inputs_text.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/inputs_text.das
 // =============================================================================
 
@@ -42,20 +29,15 @@ let FONTS = ["Sans", "Serif", "Mono", "Cursive", "Display"]
 
 [export]
 def init() {
-    live_create_window("Phase 0b.4 — text inputs", 760, 620)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.4 — text inputs", 760, 620)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 580.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Text inputs — phase 0b.4", closable = false,
@@ -101,22 +83,12 @@ def update() {
         text("imgui_set with target=MAIN_WIN/FONT + int value picks the dropdown row")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/io_mirror.das
+++ b/examples/features/io_mirror.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: io_mirror — Phase 1.3 io mirror in imgui_snapshot.
@@ -27,25 +13,21 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command
 //          → top-level "io": {"mouse_pos":{"x":..,"y":..}, "mouse_buttons":[..,..,..]}
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/io_mirror.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/io_mirror.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/io_mirror.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 1.3 — io mirror", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 1.3 — io mirror", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(560.0, 240.0), ImGuiCond.Always)
     window(IO_DEMO_WIN, (text = "io mirror demo", closable = false,
@@ -59,22 +41,12 @@ def update() {
         button(NUDGE_BTN, (text = "Nudge"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/io_synth_drag.das
+++ b/examples/features/io_synth_drag.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: io_synth_drag — Phase 2.2 L1 mouse-drag synthesis.
@@ -28,13 +14,13 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '{active: .io.active_widget, value: .globals."MAIN_WIN/DEMO_SLIDER".payload.value}'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/io_synth_drag.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/io_synth_drag.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/io_synth_drag.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 2.2 — io_synth_drag", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.2 — io_synth_drag", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
     DEMO_SLIDER.bounds = (0.0f, 1000.0f)
@@ -42,13 +28,9 @@ def init() {
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
+    if (!harness_begin_frame()) return
     advance_coroutines()
-    NewFrame()
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 220.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "io_synth_drag — phase 2.2", closable = false,
@@ -59,22 +41,12 @@ def update() {
         text("slider value = {DEMO_SLIDER.value}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/io_synth_text.das
+++ b/examples/features/io_synth_text.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: io_synth_text — Phase 2.2 L1 keyboard input synthesis.
@@ -29,6 +15,7 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/DEMO_INPUT".payload.value'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/io_synth_text.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/io_synth_text.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/io_synth_text.das
 // =============================================================================
 
@@ -36,21 +23,16 @@ var auto_focused = false
 
 [export]
 def init() {
-    live_create_window("Phase 2.2 — io_synth_text", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.2 — io_synth_text", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
+    if (!harness_begin_frame()) return
     advance_coroutines()
-    NewFrame()
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 220.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "io_synth_text — phase 2.2", closable = false,
@@ -65,22 +47,12 @@ def update() {
         text("buffer = {DEMO_INPUT.value}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/layout_helpers.das
+++ b/examples/features/layout_helpers.das
@@ -1,22 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_layout_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: layout_helpers — §4.6 split_h / split_v / dock_left.
@@ -33,26 +17,22 @@ require imgui/imgui_visual_aids
 //                            "args":{"target":"LAYOUT_WIN/SPLIT_MAIN","value":0.7}}' \
 //                       localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/layout_helpers.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/layout_helpers.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/layout_helpers.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("§4.6 — layout helpers", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("§4.6 — layout helpers", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.FirstUseEver)
     SetNextWindowSize(ImVec2(720.0f, 540.0f), ImGuiCond.FirstUseEver)
@@ -82,22 +62,12 @@ def update() {
                 })
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/layout_primitives.das
+++ b/examples/features/layout_primitives.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: layout_primitives — same_line / new_line / spacing / dummy.
@@ -25,22 +11,19 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals|keys|map(select(startswith("MAIN_WIN/LAY_")))'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/layout_primitives.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/layout_primitives.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/layout_primitives.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("layout_primitives — boost v2 §3.2", 720, 420)
-    live_imgui_init(live_window)
+    harness_init("layout_primitives — boost v2 §3.2", 720, 420)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(680.0, 360.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "same_line / new_line / spacing / dummy",
@@ -65,21 +48,12 @@ def update() {
         text(LAY_AFTER_NEW, (text = "after new_line — guaranteed fresh row."))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/list_box.das
+++ b/examples/features/list_box.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: list_box — unified [container] for BeginListBox/EndListBox. The
@@ -27,6 +13,7 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/LANG","value":3}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/list_box.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/list_box.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/list_box.das
 // =============================================================================
 
@@ -36,20 +23,15 @@ var LANG_ROW : table<int; ClickState>
 
 [export]
 def init() {
-    live_create_window("list_box — unified scope form", 720, 540)
-    live_imgui_init(live_window)
+    harness_init("list_box — unified scope form", 720, 540)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(660.0, 480.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "list_box", closable = false,
@@ -76,22 +58,12 @@ def update() {
         text("imgui_set value=N steers next-frame selection.")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/plot_getter.das
+++ b/examples/features/plot_getter.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require math
 
 // =============================================================================
@@ -27,6 +13,7 @@ require math
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/SINE_PLOT"'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/plot_getter.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/plot_getter.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/plot_getter.das
 // =============================================================================
 
@@ -34,20 +21,15 @@ let SAMPLES = 64
 
 [export]
 def init() {
-    live_create_window("Phase 2.7 — plot_getter", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.7 — plot_getter", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 360.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "plot_getter — phase 2.7", closable = false,
@@ -63,22 +45,12 @@ def update() {
                               float2(640.0, 120.0))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/plot_widgets.das
+++ b/examples/features/plot_widgets.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require math
 
 // =============================================================================
@@ -27,6 +13,7 @@ require math
 //          → globals."MAIN_WIN/SINE_WAVE".payload = {title, bounds, samples}
 //                  ."MAIN_WIN/HISTOGRAM".payload  = {...}
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/plot_widgets.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/plot_widgets.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/plot_widgets.das
 // =============================================================================
 
@@ -48,20 +35,15 @@ def fill_histogram(var arr : array<float>) {
 
 [export]
 def init() {
-    live_create_window("Phase 1.5 — plot widgets", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 1.5 — plot widgets", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     g_phase += 0.05f
 
@@ -78,22 +60,12 @@ def update() {
         plot_histogram(HISTOGRAM, "Hist", hist_data, 0.0f, 1.5f, float2(0.0f, 80.0f))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/popup_context_item.das
+++ b/examples/features/popup_context_item.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: popup_context_item — [container] for BeginPopupContextItem/EndPopup.
@@ -23,6 +9,7 @@ require imgui/imgui_containers_builtin
 // SHOWS:   right-click any TARGET_BTN row to open its action menu; selected
 //          action increments PICKED counter and updates LAST_ACTION text.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/popup_context_item.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/popup_context_item.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/popup_context_item.das
 // =============================================================================
 
@@ -30,20 +17,15 @@ var LAST_ACTION : string = "(none yet)"
 
 [export]
 def init() {
-    live_create_window("popup_context_item — container", 640, 480)
-    live_imgui_init(live_window)
+    harness_init("popup_context_item — container", 640, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(580.0, 420.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "popup_context_item", closable = false,
@@ -71,22 +53,12 @@ def update() {
         text("Last action: {LAST_ACTION}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/scroll_state.das
+++ b/examples/features/scroll_state.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 var SCROLLY_ROW : table<int; NarrativeState>
 var LOG_ROW : table<int; NarrativeState>
@@ -30,25 +16,21 @@ var LOG_ROW : table<int; NarrativeState>
 //                  .scroll_max  = [0, max_y]
 //                  .size        = [400, 200]
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/scroll_state.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/scroll_state.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/scroll_state.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 1.2 — scroll state", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 1.2 — scroll state", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(420.0, 240.0), ImGuiCond.Always)
     window(SCROLLY_WIN, (text = "Scrolly window", closable = false,
@@ -75,22 +57,12 @@ def update() {
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/snapshot_unrendered.das
+++ b/examples/features/snapshot_unrendered.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: snapshot_unrendered — Phase 1.1 long-lived registry contract.
@@ -27,13 +13,13 @@ require imgui/imgui_containers_builtin
 //          → globals contains both MAIN_WIN/VISIBLE_VAL (rendered, has bbox)
 //          and NEVER_RENDERED (rendered=false, no bbox, payload still present).
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/snapshot_unrendered.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/snapshot_unrendered.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/snapshot_unrendered.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 1.1 — snapshot unrendered", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 1.1 — snapshot unrendered", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
@@ -50,12 +36,8 @@ def private register_only_never_rendered() {
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 240.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Phase 1.1 — registry covers unrendered widgets",
@@ -68,22 +50,12 @@ def update() {
         text("NEVER_RENDERED.value = {NEVER_RENDERED.value}  (state readable; widget never painted)")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/style_override.das
+++ b/examples/features/style_override.das
@@ -1,21 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_style_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: style_override — §4.7 `with_style((key, val), ...)` { ... }.
@@ -27,25 +12,21 @@ require imgui/imgui_style_builtin
 //          curl -X POST -d '{"name":"imgui_click","args":{"target":"STYLED_BTN"}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/style_override.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/style_override.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/style_override.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("§4.7 — with_style", 640, 480)
-    live_imgui_init(live_window)
+    harness_init("§4.7 — with_style", 640, 480)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.FirstUseEver)
     SetNextWindowSize(ImVec2(560.0f, 400.0f), ImGuiCond.FirstUseEver)
@@ -74,22 +55,12 @@ def update() {
         button(UNSTYLED_BTN, (text = "Plain button"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/transport_demo.das
+++ b/examples/features/transport_demo.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: transport_demo — Phase 2.6 lambda transport.
@@ -26,25 +12,21 @@ require imgui/imgui_containers_builtin
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command \
 //              | jq '.globals."MAIN_WIN/DEMO_BTN"'
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/transport_demo.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/transport_demo.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/transport_demo.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 2.6 — transport_demo", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 2.6 — transport_demo", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 200.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "transport_demo — phase 2.6", closable = false,
@@ -56,22 +38,12 @@ def update() {
         text("clicks: {DEMO_BTN.click_count}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/triggers.das
+++ b/examples/features/triggers.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: triggers — every Phase 0b.1 trigger widget in one window.
@@ -28,25 +14,21 @@ require imgui/imgui_containers_builtin
 //          curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/DIFFICULTY","value":2}}' \
 //               localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/triggers.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/triggers.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/triggers.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("Phase 0b.1 — triggers", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("Phase 0b.1 — triggers", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 560.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "Triggers — phase 0b.1", closable = false,
@@ -103,22 +85,12 @@ def update() {
         text("difficulty = {DIFFICULTY.value}")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/widget_init_defaults.das
+++ b/examples/features/widget_init_defaults.das
@@ -1,20 +1,6 @@
 options gen2
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 require daslib/json public
 require daslib/json_boost public
 
@@ -26,6 +12,7 @@ require daslib/json_boost public
 //          ExprMakeStruct(useInitializer) on the macro-emitted global.
 // DRIVE:   curl -X POST -d '{"name":"imgui_snapshot"}' localhost:9090/command
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/widget_init_defaults.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/widget_init_defaults.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/widget_init_defaults.das
 // =============================================================================
 
@@ -68,20 +55,15 @@ def show_defaults(var state : DefaultsState; text : string) : int {
 
 [export]
 def init() {
-    live_create_window("widget_init_defaults", 800, 600)
-    live_imgui_init(live_window)
+    harness_init("widget_init_defaults", 800, 600)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.5
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(720.0, 320.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "widget_init_defaults", closable = false,
@@ -90,22 +72,12 @@ def update() {
         show_defaults(DEFAULTS, (text = "show_defaults"))
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/features/widget_no_ident.das
+++ b/examples/features/widget_no_ident.das
@@ -5,42 +5,27 @@ options gen2
 // of becoming a hard build error.
 options _allow_imgui_legacy = true
 
-require imgui
-require imgui_app
-require glfw/glfw_boost
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live/opengl_live
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
+require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: widget_no_ident — smoke of the three [widget] call forms.
 // SHOWS:   1. EXPLICIT  text(IDENT, (text=...))     — leading ident
 //          2. AUTO-GEN  text((text=...))            — first arg is named-tuple
 //          3. POSITIONAL text("string")             — single-string sugar
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/widget_no_ident.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/widget_no_ident.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/widget_no_ident.das
 // =============================================================================
 
 [export]
 def init() {
-    live_create_window("widget_no_ident smoke", 720, 360)
-    live_imgui_init(live_window)
+    harness_init("widget_no_ident smoke", 720, 360)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    NewFrame()
+    if (!harness_begin_frame()) return
+    harness_new_frame()
 
     SetNextWindowSize(ImVec2(640.0, 300.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "no-ident forms",
@@ -61,21 +46,12 @@ def update() {
         separator_text("separator_text positional form")
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]


### PR DESCRIPTION
## Summary

Completes the migration of `examples/features/` to the harness API. With this PR + the 15 already-migrated files (foundation, active_widget, and the 13 from #36), **every file under `examples/features/` now uses `require imgui/imgui_harness`** instead of the 14-require GLFW/OpenGL chain.

Net diff: **+345 / -1680 lines** across 48 files.

### Three sub-patterns covered

| Pattern | Count | Files |
|---|---|---|
| Canonical | 35 | `await_quiescent`, `clip_rect`, `containers_layout/_overlay/_window`, `display_image/_progress`, `drag_drop`, `focus_widget`, `font_stack`, `hex_id_click`, `id_override`, `indexed_dynamic`, `inputs_choice/_color/_drag/_indexed/_numeric/_slider/_text`, `io_mirror`, `io_synth_drag/_text`, `layout_primitives`, `list_box`, `plot_getter/_widgets`, `popup_context_item`, `scroll_state`, `snapshot_unrendered`, `style_override`, `transport_demo`, `triggers`, `widget_init_defaults`, `widget_no_ident` |
| Synth-IO | 7 | `columns_demo`, `dock_basic`, `layout_helpers`, `glfw_synth_keys/_mouse`, `imgui_synth_keys/_mouse` — call `harness_apply_synth_io()` between `harness_begin_frame()` and `harness_new_frame()` (the slot where `apply_synth_io_override()` used to live). |
| edit_external | 6 | `edit_external_color/_combo/_scalars/_special/_toggles/_vectors` — preserve `require daslib/safe_addr` for caller-owned pointer args. |

Three coroutine-using files (`await_quiescent`, `io_synth_drag`, `io_synth_text`) place `advance_coroutines()` in the same begin↔new slot that holds `harness_apply_synth_io()`, matching the already-migrated `await_quiescent` precedent from PR 1.

## Test plan

- [x] Per-file `compile_check` + `lint` + `format_file` clean across all 48 (verified by 10 parallel migration agents)
- [x] Per-file headless smoke (60 frames) → exit 0 for all 48
- [x] Per-file windowed smoke (5 s timeout-killed) → exit 124 for all 48
- [x] Full `examples/features/` headless smoke (2-frame): 63/63 PASS
- [x] Full `dastest --test modules/dasImgui/tests/integration`: **111/111 PASS** (unchanged from #36 — playwright tests spawn daslang-live on the migrated features and drive them through the windowed backend cleanly)
- [ ] CI smoke once PR is open

## Next

`examples/features/` migration complete. Remaining harness-migration work in PRs 5..N:
- `examples/tutorial/` — tutorial RST docs may reference the old require shape; verify and migrate scripts + doc
- `examples/imgui_demo/` — the big imgui_demo port; some files carry `options _allow_imgui_legacy = true` already
- Final batch: remove `_allow_glfw_calls` from the daslang option registry once no source file uses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)