### PR TITLE
imgui_demo: columns.das sweep + app_log port + drop 9 dead opt-outs

### DIFF
--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module app_console
 

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module app_custom_rendering
 

--- a/examples/imgui_demo/app_dockspace.das
+++ b/examples/imgui_demo/app_dockspace.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module app_dockspace
 

--- a/examples/imgui_demo/app_documents.das
+++ b/examples/imgui_demo/app_documents.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module app_documents
 

--- a/examples/imgui_demo/app_log.das
+++ b/examples/imgui_demo/app_log.das
@@ -127,8 +127,13 @@ def ShowExampleAppLog() {
             }
 
             with_style((ImGuiStyleVar.ItemSpacing, float2(0.0f, 0.0f))) {
-                if (passes_filter(LOG_FILTER, "")) {
+                if (!is_active(LOG_FILTER)) {
                     // Filter inactive — clipper-cull the line range.
+                    // (Don't use `passes_filter("")` as the gate: an
+                    // exclude-only filter like `-error` has no include
+                    // terms, so `PassFilter("")` returns true even though
+                    // the filter is active — clipper path would then
+                    // render lines the user explicitly excluded.)
                     list_clipper(length(LOG_ITEMS)) <| $(start, end_) {
                         for (i in range(start, end_)) {
                             text(LOG_ITEM_TEXT[i], (text = LOG_ITEMS[i]))

--- a/examples/imgui_demo/app_log.das
+++ b/examples/imgui_demo/app_log.das
@@ -1,12 +1,163 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module app_log
 
 require imgui
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_layout_builtin
+require imgui/imgui_scope_builtin
+require imgui/imgui_style_builtin
+require daslib/safe_addr
 
-// Mirrors imgui_demo.cpp:7609-7639 — static void ShowExampleAppLog(bool* p_open).
+// Mirrors imgui_demo.cpp:7478-7637 — ExampleAppLog class + ShowExampleAppLog().
+//
+// The C++ original is a class holding a contiguous text buffer
+// (`ImGuiTextBuffer`), per-line offset table (`ImVector<int>`), a
+// `ImGuiTextFilter`, and an `AutoScroll` bool. The class exposes
+// `AddLog(fmt, ...)` and `Draw(title)` methods.
+//
+// Daslang port shape:
+//   - Module-scope `var private` globals replace the per-instance fields.
+//     `LOG_ITEMS : array<string>` holds one line per entry (skipping the
+//     contiguous-buffer + line-offset bookkeeping the C++ version needs
+//     for clipper random access — random access by index is O(1) on the
+//     daslang array form too).
+//   - `text_filter(LOG_FILTER, ...)` rides on the bound `ImGuiTextFilter`
+//     wrapper; `passes_filter(LOG_FILTER, line)` matches the C++ pattern.
+//   - Per-line text widgets use an indexed `table<int; NarrativeState>`
+//     so each rendered row owns its own state global. `clear_log()`
+//     releases the table along with the lines.
+//   - Visible-region culling on the unfiltered path uses the boost
+//     `list_clipper` wrapper (added alongside this port). When the
+//     filter is active we drop to a plain `for` since the result is
+//     not random-access by physical row.
+//   - The C++ debug button calls `AddLog` directly; we keep the same
+//     entry-points (`add_log`, `clear_log`) module-public so future
+//     callers can post diagnostic lines.
+
+// =============================================================================
+// Module-scope persistent state
+// =============================================================================
+
+var private LOG_ITEMS : array<string>
+var private LOG_AUTO_SCROLL = true
+var private LOG_DEBUG_COUNTER = 0
+
+// Indexed widget state for the rendered log lines.
+var private LOG_ITEM_TEXT : table<int; NarrativeState>
+
+// =============================================================================
+// Public helpers — append / clear
+// =============================================================================
+
+def public add_log(line : string) {
+    //! Append a single line to the log buffer. Caller pre-formats the
+    //! string (the C++ `AddLog(fmt, ...)` varargs form is collapsed).
+    LOG_ITEMS |> push_clone(line)
+}
+
+def public clear_log() {
+    //! Drop every log line and release the per-row text-widget state.
+    LOG_ITEMS |> clear()
+    LOG_ITEM_TEXT |> clear()
+}
+
+// =============================================================================
+// ShowExampleAppLog — main panel
+// =============================================================================
+
 def ShowExampleAppLog() {
-    // TODO: port section (imgui_demo.cpp:7609-7639)
+    // Debug button row — header above the log proper. The C++ original
+    // uses two Begin()/End() pairs on the same window title to append to
+    // the existing log window; daslang's [container] window macro doesn't
+    // model that idiom, so the debug controls live inline at the top.
+    window(LOG_WIN, (text = "Example: Log", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+
+        if (small_button(LOG_BTN_ADD5, (text = "[Debug] Add 5 entries"))) {
+            let categories = fixed_array("info", "warn", "error")
+            let words = fixed_array("Bumfuzzled", "Cattywampus", "Snickersnee",
+                                    "Abibliophobia", "Absquatulate",
+                                    "Nincompoop", "Pauciloquent")
+            for (n in range(5)) {
+                let category = categories[LOG_DEBUG_COUNTER % length(categories)]
+                let word = words[LOG_DEBUG_COUNTER % length(words)]
+                add_log("[{LOG_DEBUG_COUNTER}] [{category}] " +
+                        "Hello, current time is {GetTime()}, " +
+                        "here's a word: '{word}'")
+                LOG_DEBUG_COUNTER++
+            }
+        }
+
+        separator(LOG_SEP_HEADER)
+
+        // Options popup body — opened on demand by the Options button.
+        popup(LOG_OPTS_POPUP, (text = "Options", flags = ImGuiWindowFlags.None)) {
+            if (checkbox(LOG_AUTOSCROLL_CHECK, (text = "Auto-scroll",
+                                                  init = LOG_AUTO_SCROLL))) {
+                LOG_AUTO_SCROLL = LOG_AUTOSCROLL_CHECK.value
+            }
+        }
+        if (button(LOG_BTN_OPTS, (text = "Options"))) {
+            open_popup(LOG_OPTS_POPUP)
+        }
+        same_line(LOG_SL_1)
+        let clear = button(LOG_BTN_CLEAR, (text = "Clear"))
+        same_line(LOG_SL_2)
+        let copy = button(LOG_BTN_COPY, (text = "Copy"))
+        same_line(LOG_SL_3)
+        text_filter(LOG_FILTER, (text = "Filter (\"incl,-excl\") (\"error\")",
+                                  width = -100.0f))
+
+        separator(LOG_SEP_FILTER)
+
+        // Scrolling region with horizontal scroll for long lines.
+        child(LOG_SCROLL_CHILD, (text = "scrolling",
+                                  size = float2(0.0f, 0.0f),
+                                  child_flags = ImGuiChildFlags.None,
+                                  window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+
+            if (clear) {
+                clear_log()
+            }
+            if (copy) {
+                log_to_clipboard()
+            }
+
+            with_style((ImGuiStyleVar.ItemSpacing, float2(0.0f, 0.0f))) {
+                if (passes_filter(LOG_FILTER, "")) {
+                    // Filter inactive — clipper-cull the line range.
+                    list_clipper(length(LOG_ITEMS)) <| $(start, end_) {
+                        for (i in range(start, end_)) {
+                            text(LOG_ITEM_TEXT[i], (text = LOG_ITEMS[i]))
+                        }
+                    }
+                } else {
+                    // Filter active — random access by physical row no
+                    // longer maps to visible rows, so render the matches
+                    // sequentially.
+                    for (i in range(length(LOG_ITEMS))) {
+                        let line = LOG_ITEMS[i]
+                        if (passes_filter(LOG_FILTER, line)) {
+                            text(LOG_ITEM_TEXT[i], (text = line))
+                        }
+                    }
+                }
+            }
+
+            if (copy) {
+                log_finish()
+            }
+
+            // Tail-follow: scroll to bottom only if we were already at the
+            // bottom when the frame started (scroll != scroll_max means
+            // the user dragged away — don't yank them back).
+            if (LOG_AUTO_SCROLL &&
+                LOG_SCROLL_CHILD.scroll.y >= LOG_SCROLL_CHILD.scroll_max.y) {
+                set_scroll_here_y(1.0f)
+            }
+        }
+    }
 }

--- a/examples/imgui_demo/app_small.das
+++ b/examples/imgui_demo/app_small.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module app_small
 

--- a/examples/imgui_demo/columns.das
+++ b/examples/imgui_demo/columns.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module columns
 
@@ -36,10 +35,9 @@ require daslib/safe_addr
 //         `selectable` toggles — the boost selectable owns its own bool and
 //         we keep the demo focused on columns, not selection model. See note
 //         at PortSecondBasicTable.
-//       * The "Horizontal Scrolling" sub-section uses `ImGuiListClipper`, which
-//         the daslang binding exposes as a constructed object with Begin/Step/
-//         End methods. We use the binding directly inside the
-//         `child(...) { ... }` container.
+//       * The "Horizontal Scrolling" sub-section uses the `list_clipper`
+//         boost helper to cull 2000 virtual rows down to the visible
+//         region inside the `child(...) { ... }` container.
 // =============================================================================
 
 // ----- Sub-section TreeNodes (outer + 6 sub-sections) -----
@@ -63,6 +61,8 @@ var COLUMNS_MIXED_BAR = 1.0f
 //       NOT auto-emit table<K; ST> globals for indexed-ident forms) -----
 var private COLUMNS_BASIC_SEL1 : table<int; ToggleState>
 var private COLUMNS_BASIC_SEL2 : table<int; ToggleState>
+var private COLUMNS_BORDERS_ROW_SEP : table<int; EmptyMarkerState>
+var private COLUMNS_BORDERS_BTN : table<int; ClickState>
 var private COLUMNS_TREE_OUTER : table<int; TreeNodeState>
 var private COLUMNS_TREE_INNER : table<int; TreeNodeState>
 
@@ -72,7 +72,7 @@ var private COLUMNS_TREE_INNER : table<int; TreeNodeState>
 def ShowDemoWindowColumns() {
     tree_node(COLUMNS_OUTER,
         (text = "Legacy Columns API", flags = ImGuiTreeNodeFlags.None)) {
-        SameLine()
+        same_line()
         text_disabled("(?)")
         item_tooltip(COLUMNS_OUTER_HELP) {
             with_text_wrap_pos(GetFontSize() * 35.0f) {
@@ -98,25 +98,25 @@ def private BasicSection() {
         text("Without border:")
         // 3-way, no border. Dynamic 14-item loop ⇒ call columns_open/next_col
         // directly (the columns(N, ...) macro requires N literal blocks).
-        Columns(3, "mycolumns3", false)
-        Separator()
+        columns_open(3, "mycolumns3", false)
+        separator(COLUMNS_BASIC_SEP_TOP)
         for (n in range(14)) {
             selectable(COLUMNS_BASIC_SEL1[n], (text = "Item {n}"))
-            NextColumn()
+            next_col()
         }
         columns_close()
-        Separator()
+        separator(COLUMNS_BASIC_SEP_MID)
 
         text("With border:")
         // 4-way, with border. Header row + 3 data rows; structure is regular
         // but still loop-driven on row count.
-        Columns(4, "mycolumns", true)
-        Separator()
-        text("ID"); NextColumn()
-        text("Name"); NextColumn()
-        text("Path"); NextColumn()
-        text("Hovered"); NextColumn()
-        Separator()
+        columns_open(4, "mycolumns")
+        separator(COLUMNS_BASIC_SEP_HDR_TOP)
+        text("ID"); next_col()
+        text("Name"); next_col()
+        text("Path"); next_col()
+        text("Hovered"); next_col()
+        separator(COLUMNS_BASIC_SEP_HDR_BOT)
         let names = fixed_array("One", "Two", "Three")
         let paths = fixed_array("/path/one", "/path/two", "/path/three")
         for (i in range(3)) {
@@ -127,13 +127,13 @@ def private BasicSection() {
                 (text = "{i}",
                  flags = ImGuiSelectableFlags.SpanAllColumns))
             let hovered = IsItemHovered()
-            NextColumn()
-            text("{names[i]}"); NextColumn()
-            text("{paths[i]}"); NextColumn()
-            text("{hovered ? 1 : 0}"); NextColumn()
+            next_col()
+            text("{names[i]}"); next_col()
+            text("{paths[i]}"); next_col()
+            text("{hovered ? 1 : 0}"); next_col()
         }
         columns_close()
-        Separator()
+        separator(COLUMNS_BASIC_SEP_BOT)
     }
 }
 
@@ -150,17 +150,17 @@ def private BordersSection() {
         if (COLUMNS_BORDERS_COUNT < 2) {
             COLUMNS_BORDERS_COUNT = 2
         }
-        SameLine()
+        same_line()
         edit_checkbox(safe_addr(COLUMNS_BORDERS_H),
             (id = "COLUMNS_BORDERS_H", text = "horizontal"))
-        SameLine()
+        same_line()
         edit_checkbox(safe_addr(COLUMNS_BORDERS_V),
             (id = "COLUMNS_BORDERS_V", text = "vertical"))
-        // Dynamic column count ⇒ raw Columns() call.
-        Columns(COLUMNS_BORDERS_COUNT, "", COLUMNS_BORDERS_V)
+        // Dynamic column count + dynamic border ⇒ columns_open with all args.
+        columns_open(COLUMNS_BORDERS_COUNT, "", COLUMNS_BORDERS_V)
         for (i in range(COLUMNS_BORDERS_COUNT * lines_count)) {
             if (COLUMNS_BORDERS_H && GetColumnIndex() == 0) {
-                Separator()
+                separator(COLUMNS_BORDERS_ROW_SEP[i])
             }
             // C++ uses ImGui::Text("%c%c%c", 'a' + i, ...); daslang has no
             // int→char primitive — splice via a precomputed alphabet table.
@@ -174,15 +174,15 @@ def private BordersSection() {
             text("Avail {GetContentRegionAvail().x}")
             text("Offset {GetColumnOffset(-1)}")
             text("Long text that is likely to clip")
-            // Per-cell button — indexed; full-width via Button raw call so we
-            // can pass ImVec2(-FLT_MIN, 0). The boost button widget defaults
-            // size to (0,0).
-            if (Button("Button##{i}", ImVec2(-3.40282347e+38f, 0.0f))) {}
-            NextColumn()
+            // Per-cell full-width button via `size=` (-FLT_MIN, 0) → stretch.
+            button(COLUMNS_BORDERS_BTN[i],
+                (text = "Button##{i}",
+                 size = float2(-3.40282347e+38f, 0.0f)))
+            next_col()
         }
         columns_close()
         if (COLUMNS_BORDERS_H) {
-            Separator()
+            separator(COLUMNS_BORDERS_SEP_BOT)
         }
     }
 }
@@ -193,7 +193,7 @@ def private BordersSection() {
 def private MixedItemsSection() {
     tree_node(COLUMNS_MIXED, (text = "Mixed items", flags = ImGuiTreeNodeFlags.None)) {
         columns(3, ${
-            Separator()
+            separator(COLUMNS_MIXED_SEP_TOP)
             text("Hello")
             button(COLUMNS_MIXED_BTN_BANANA, (text = "Banana"))
         }, ${
@@ -235,7 +235,7 @@ def private MixedItemsSection() {
                 text("Blah blah blah")
             }
         })
-        Separator()
+        separator(COLUMNS_MIXED_SEP)
     }
 }
 
@@ -245,7 +245,7 @@ def private MixedItemsSection() {
 def private WordWrappingSection() {
     tree_node(COLUMNS_WRAP, (text = "Word-wrapping", flags = ImGuiTreeNodeFlags.None)) {
         columns(2, ${
-            Separator()
+            separator(COLUMNS_WRAP_SEP_L)
             text_wrapped(COLUMNS_WRAP_TXT_L1,
                 (text = "The quick brown fox jumps over the lazy dog."))
             text_wrapped(COLUMNS_WRAP_TXT_L2, (text = "Hello Left"))
@@ -254,7 +254,7 @@ def private WordWrappingSection() {
                 (text = "The quick brown fox jumps over the lazy dog."))
             text_wrapped(COLUMNS_WRAP_TXT_R2, (text = "Hello Right"))
         })
-        Separator()
+        separator(COLUMNS_WRAP_SEP_BOT)
     }
 }
 
@@ -270,23 +270,16 @@ def private HorizontalScrollingSection() {
             (text = "##ScrollingRegion", size = child_size,
              child_flags = ImGuiChildFlags.None,
              window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
-            Columns(10, "", true)
-            // ImGuiListClipper culls the 2000 virtual rows down to the visible
-            // window — same pattern as the C++ demo. The class has a default
-            // ctor on the C++ side; require `unsafe` because the binding
-            // doesn't mark the type safe-to-construct.
-            unsafe {
-                var clipper = ImGuiListClipper()
-                clipper |> Begin(2000, -1.0f)
-                while (clipper |> Step()) {
-                    for (i in range(clipper.DisplayStart, clipper.DisplayEnd)) {
-                        for (j in range(10)) {
-                            text("Line {i} Column {j}...")
-                            NextColumn()
-                        }
+            columns_open(10)
+            // Cull the 2000 virtual rows to the visible region via the
+            // list_clipper boost helper (wraps ImGuiListClipper Begin/Step/End).
+            list_clipper(2000) <| $(start, end_) {
+                for (i in range(start, end_)) {
+                    for (j in range(10)) {
+                        text("Line {i} Column {j}...")
+                        next_col()
                     }
                 }
-                clipper |> End()
             }
             columns_close()
         }
@@ -298,45 +291,45 @@ def private HorizontalScrollingSection() {
 // =============================================================================
 def private TreeSection() {
     tree_node(COLUMNS_TREE, (text = "Tree", flags = ImGuiTreeNodeFlags.None)) {
-        Columns(2, "tree", true)
+        columns_open(2, "tree")
         for (x in range(3)) {
             tree_node(COLUMNS_TREE_OUTER[x],
                 (text = "Node{x}", flags = ImGuiTreeNodeFlags.None)) {
-                NextColumn()
+                next_col()
                 text("Node contents")
-                NextColumn()
+                next_col()
                 for (y in range(3)) {
                     let inner_key = x * 10 + y
                     tree_node(COLUMNS_TREE_INNER[inner_key],
                         (text = "Node{x}.{y}", flags = ImGuiTreeNodeFlags.None)) {
-                        NextColumn()
+                        next_col()
                         text("Node contents")
                         text("Even more contents")
                         tree_node(COLUMNS_TREE_LEAF,
                             (text = "Tree in column", flags = ImGuiTreeNodeFlags.None)) {
                             text("The quick brown fox jumps over the lazy dog")
                         }
-                        NextColumn()
+                        next_col()
                     }
                     if (!COLUMNS_TREE_INNER[inner_key].opened) {
-                        // The outer NextColumn pair is owned by the open
+                        // The outer next_col pair is owned by the open
                         // branch in C++ (gated by `if (open2)`). Mirror that:
                         // when the inner tree was NOT expanded, the outer
                         // already advanced once for the title; we still need
                         // to fill the body column.
-                        NextColumn()
+                        next_col()
                         text("Node contents")
-                        NextColumn()
+                        next_col()
                     }
                 }
             }
-            // C++ structure: the outer NextColumns inside the open-branch
+            // C++ structure: the outer next_col pair inside the open-branch
             // already advanced when expanded. When the outer tree was NOT
             // expanded, we still need to skip past its two columns to land
             // on the next row.
             if (!COLUMNS_TREE_OUTER[x].opened) {
-                NextColumn()
-                NextColumn()
+                next_col()
+                next_col()
             }
         }
         columns_close()

--- a/examples/imgui_demo/imgui_demo.das
+++ b/examples/imgui_demo/imgui_demo.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module imgui_demo
 
@@ -27,11 +26,12 @@ require app_dockspace public
 require app_documents public
 require app_small public
 
-// Module-scope toggle for the Example App: Console panel. A full Examples
-// menu wiring (matching imgui_demo.cpp's `ImGui::ShowDemoWindow` Examples
-// submenu) waits for the other example-app stubs to be ported; for now
-// the Console gets a single checkbox at the bottom of the demo window.
+// Module-scope toggles for the Example App panels. A full Examples menu
+// wiring (matching imgui_demo.cpp's `ImGui::ShowDemoWindow` Examples
+// submenu) waits for the remaining example-app stubs to be ported; for
+// now each gets its own checkbox at the bottom of the demo window.
 var private SHOW_APP_CONSOLE = false
+var private SHOW_APP_LOG = false
 
 // Mirrors imgui_demo.cpp:275-6455 — void ImGui::ShowDemoWindow(bool* p_open).
 // Renamed to avoid collision with ImGui's built-in ShowDemoWindow binding.
@@ -41,11 +41,11 @@ var private SHOW_APP_CONSOLE = false
 def RunImGuiDemo() {
     window(DEMO_WIN, (text = "Dear ImGui Demo (daslang port — Phase 2a skeleton)",
                        closable = false, flags = ImGuiWindowFlags.None)) {
-        Text("Phase 2a skeleton — 0/24 SECTION blocks ported + 1 example app (Console).")
-        Text("Section stubs render below; example apps and meta windows are")
-        Text("not yet wired into the menu — temporary checkboxes at the bottom")
-        Text("toggle individual app windows.")
-        Separator()
+        text("Phase 2a skeleton — 0/24 SECTION blocks ported + 2 example apps (Console, Log).")
+        text("Section stubs render below; example apps and meta windows are")
+        text("not yet wired into the menu — temporary checkboxes at the bottom")
+        text("toggle individual app windows.")
+        separator(DEMO_SEP_HEADER)
 
         ShowDemoWindowWidgets()
         ShowDemoWindowLayout()
@@ -54,9 +54,11 @@ def RunImGuiDemo() {
         ShowDemoWindowColumns()
         ShowDemoWindowInputs()
 
-        Separator()
+        separator(DEMO_SEP_FOOTER)
         edit_checkbox(safe_addr(SHOW_APP_CONSOLE),
                       (id = "EXAMPLES_SHOW_CONSOLE", text = "Show Example: Console"))
+        edit_checkbox(safe_addr(SHOW_APP_LOG),
+                      (id = "EXAMPLES_SHOW_LOG", text = "Show Example: Log"))
     }
 
     // Example-app windows live OUTSIDE the demo window — each opens its own.
@@ -68,5 +70,8 @@ def RunImGuiDemo() {
         if (take_close_request()) {
             SHOW_APP_CONSOLE = false
         }
+    }
+    if (SHOW_APP_LOG) {
+        ShowExampleAppLog()
     }
 }

--- a/examples/imgui_demo/main.das
+++ b/examples/imgui_demo/main.das
@@ -1,5 +1,4 @@
 options gen2
-options _allow_imgui_legacy = true
 
 require imgui
 require imgui_app

--- a/examples/imgui_demo/popups.das
+++ b/examples/imgui_demo/popups.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module popups
 

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module tables
 

--- a/examples/imgui_demo/user_guide.das
+++ b/examples/imgui_demo/user_guide.das
@@ -1,6 +1,5 @@
 options gen2
 options indenting = 4
-options _allow_imgui_legacy = true
 
 module user_guide
 

--- a/widgets/imgui_layout_builtin.das
+++ b/widgets/imgui_layout_builtin.das
@@ -202,9 +202,13 @@ def dock_left(var state : SliderStateFloat; blk : block) {
 
 // ===== columns =====
 
-def public columns_open(n : int) {
-    //! Open an N-column block (borders on). Underlying primitive emitted by the ``columns(N, …)`` call_macro.
-    Columns(n, "", true)
+def public columns_open(n : int; id : string = ""; border : bool = true) {
+    //! Open an N-column block. `id` (default empty) is the ImGui id-stack
+    //! tag used for column-width persistence; `border` (default on) draws
+    //! the vertical dividers. Primitive emitted by the ``columns(N, …)``
+    //! call_macro; callable directly when the column count or shape is
+    //! dynamic.
+    Columns(n, id, border)
 }
 
 def public next_col() {
@@ -215,6 +219,23 @@ def public next_col() {
 def public columns_close() {
     //! Close a columns block (return to single-column layout). Underlying primitive emitted by the ``columns(N, …)`` call_macro.
     Columns(1, "", false)
+}
+
+// ===== list_clipper =====
+
+def public list_clipper(items_count : int;
+                        body : block<(start : int; end_ : int) : void>) {
+    //! Cull a virtual list of `items_count` items to the visible region.
+    //! The block fires once per visible chunk with `[start, end_)` indices;
+    //! render exactly those rows inside the block.
+    unsafe {
+        var clipper = ImGuiListClipper()
+        clipper |> Begin(items_count, -1.0f)
+        while (clipper |> Step()) {
+            invoke(body, clipper.DisplayStart, clipper.DisplayEnd)
+        }
+        clipper |> End()
+    }
 }
 
 [call_macro(name = "columns")]

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -57,6 +57,9 @@ let private ALLOWED_IMGUI : table<string> <- {
     "GetWindowSize", "GetWindowPos", "GetWindowWidth", "GetWindowHeight",
     "GetItemRectMin", "GetItemRectMax", "GetItemRectSize",
     "CalcTextSize", "CalcItemWidth",
+    // Column position queries (read-only) — paired with the columns_open /
+    // next_col / columns_close primitives in imgui_layout_builtin.
+    "GetColumnIndex", "GetColumnWidth", "GetColumnOffset", "GetColumnsCount",
     // Font / color helpers (read-only)
     "GetFont", "GetFontSize",
     "GetTextLineHeight", "GetTextLineHeightWithSpacing",

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -1234,8 +1234,20 @@ def public passes_filter(var state : TextFilterState; line : string) : bool {
     //! `PassFilter(filter, text)` standalone helper at
     //! `src/dasIMGUI.main.cpp:305`. While the editor is empty the
     //! underlying `Filters` `ImVector` is empty too and PassFilter returns
-    //! true for all lines.
+    //! true for all lines. NB: an exclude-only filter (e.g. `-error`) has
+    //! no include terms either, so `passes_filter(state, "")` returns
+    //! `true` even though the filter is active — use `is_active(state)`,
+    //! not `passes_filter(state, "")`, to detect the active/inactive
+    //! transition.
     return PassFilter(state.filter, line)
+}
+
+def public is_active(var state : TextFilterState) : bool {
+    //! `ImGuiTextFilter::IsActive()` — true iff parsing produced at least
+    //! one include OR exclude term. Use this to gate filter-active vs
+    //! filter-inactive code paths (e.g. clipper-cull vs sequential scan
+    //! in scrolling log views).
+    return state.filter |> IsActive()
 }
 
 // ===== Combo (callback-getter) =====


### PR DESCRIPTION
## Summary

Resumes the Phase 2a imgui_demo port after the harness / lint / theme detours.

**Two commits.**

### `97a2365` widgets: `columns_open` defaults + `list_clipper` helper + `GetColumn*` allowlist

- `columns_open(n; id : string = ""; border : bool = true)` — backwards-compat default trailing params. Dynamic-shape `Columns(n, id, border)` consumers (Basic 3+4-col, Borders dynamic count, Tree 2-col) now go through the boost primitive instead of raw imgui.
- `list_clipper(items_count, body)` — `block<(start, end_)>` callback wraps `ImGuiListClipper` Begin/Step/End. Drops the four-line `unsafe { ... }` boilerplate from every visible-region-cull consumer (Horizontal Scrolling sub-section + Example: Log virtual-line render).
- `GetColumnIndex` / `GetColumnWidth` / `GetColumnOffset` / `GetColumnsCount` → `ALLOWED_IMGUI` (read-only column position queries; mirrors existing `GetItemRect*` / `GetCursorPos*` reads).

### `bc4fc52` imgui_demo: columns.das raw-sweep + app_log port + drop dead opt-outs

- **`columns.das`** — drops `_allow_imgui_legacy`; raw `Columns/NextColumn/Separator/SameLine/Button(size=)` swept to wrappers; the Horizontal Scrolling section's inline `ImGuiListClipper` trio moves to the new `list_clipper` helper; new indexed widget tables for the BordersSection per-row separator + button.
- **`app_log.das`** — port of `ExampleAppLog` (cpp:7478-7637). Module-scope `array<string>` of log lines replaces the C++ contiguous-buffer + line-offset table (random access is O(1) on the daslang array form). `text_filter` + `passes_filter` ride the bound `ImGuiTextFilter` wrapper from PR #32; unfiltered render uses `list_clipper` for visible-region culling, filtered path drops to a plain `for` since the result is not random-access by physical row.
- **`imgui_demo.das`** — wires `Show Example: Log` toggle + dispatch. Sweeps the dispatcher's own raw `Text` / `Separator` and drops its opt-out.
- **9 dead `_allow_imgui_legacy` opt-outs dropped** — `app_console`, `app_custom_rendering`, `app_dockspace`, `app_documents`, `app_small`, `main`, `popups`, `tables`, `user_guide`. PR #33's bulk defensive rollout left these on files that don't actually have raw imgui calls; audited by removing the option and counting `IMGUI002` errors. The remaining 7 files (`about` / `app_main_menu` / `inputs` / `layout` / `style_editor` / `widgets` + `imgui_layout_builtin` and friends in `widgets/`) carry genuine raw survivors and keep the opt-out until individually swept.

## Test plan

- [x] `daslang -dry-run -project_root D:/DASPKG/dasImgui examples/imgui_demo/main.das` — clean
- [x] `daslang -dry-run` on each swept file individually — clean
- [x] `daslang -dry-run` on `tests/integration/test_columns.das` and `examples/features/columns_demo.das` — clean (columns_open's new default params are backwards-compatible)
- [x] Per-file `_allow_imgui_legacy`-removal audit confirms the 9 dropped opt-outs are dead scaffolding (0 `IMGUI002` errors when removed); the 7 kept ones each have 2-133 genuine raw-call errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)