### PR TITLE
imgui_live + theme: HDPI scaling on init

### DIFF
--- a/tests/integration/test_theme_scale.das
+++ b/tests/integration/test_theme_scale.das
@@ -1,0 +1,59 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui public
+require imgui/imgui_theme_daslang
+
+//! Unit smoke for HDPI theme scaling. Asserts the documented 1x logical
+//! constants land where ``apply_daslang_theme`` says they do, then runs
+//! ``ScaleAllSizes(2.0)`` (the same call ``live_imgui_init`` invokes when
+//! ``glfwGetWindowContentScale`` reports 2x — macOS retina, Windows 200%)
+//! and asserts paddings/spacings/rounding double. Border sizes intentionally
+//! do NOT scale — stock ``ImGuiStyle::ScaleAllSizes`` skips them, and we
+//! match that.
+
+[test]
+def test_apply_daslang_theme_base_constants(t : T?) {
+    let ctx = CreateContext(null)
+    SetCurrentContext(ctx)
+    apply_daslang_theme()
+    let style & = unsafe(GetStyle())
+    t |> equal(style.WindowPadding.x, 8.0f, "WindowPadding.x at scale=1")
+    t |> equal(style.WindowPadding.y, 8.0f, "WindowPadding.y at scale=1")
+    t |> equal(style.FramePadding.x, 6.0f, "FramePadding.x at scale=1")
+    t |> equal(style.FramePadding.y, 3.0f, "FramePadding.y at scale=1")
+    t |> equal(style.ItemSpacing.x, 8.0f, "ItemSpacing.x at scale=1")
+    t |> equal(style.ItemSpacing.y, 5.0f, "ItemSpacing.y at scale=1")
+    t |> equal(style.WindowRounding, 2.0f, "WindowRounding at scale=1")
+    t |> equal(style.FrameRounding, 2.0f, "FrameRounding at scale=1")
+    t |> equal(style.ScrollbarSize, 10.0f, "ScrollbarSize at scale=1")
+    t |> equal(style.GrabMinSize, 10.0f, "GrabMinSize at scale=1")
+    DestroyContext(ctx)
+}
+
+[test]
+def test_scale_all_sizes_doubles_at_2x(t : T?) {
+    let ctx = CreateContext(null)
+    SetCurrentContext(ctx)
+    apply_daslang_theme()
+    var style & = unsafe(GetStyle())
+    style |> ScaleAllSizes(2.0f)
+    t |> equal(style.WindowPadding.x, 16.0f, "WindowPadding.x scaled 2x")
+    t |> equal(style.WindowPadding.y, 16.0f, "WindowPadding.y scaled 2x")
+    t |> equal(style.FramePadding.x, 12.0f, "FramePadding.x scaled 2x")
+    t |> equal(style.FramePadding.y, 6.0f, "FramePadding.y scaled 2x")
+    t |> equal(style.ItemSpacing.x, 16.0f, "ItemSpacing.x scaled 2x")
+    t |> equal(style.ItemSpacing.y, 10.0f, "ItemSpacing.y scaled 2x")
+    t |> equal(style.WindowRounding, 4.0f, "WindowRounding scaled 2x")
+    t |> equal(style.FrameRounding, 4.0f, "FrameRounding scaled 2x")
+    t |> equal(style.ScrollbarSize, 20.0f, "ScrollbarSize scaled 2x")
+    t |> equal(style.GrabMinSize, 20.0f, "GrabMinSize scaled 2x")
+    // Border widths intentionally untouched by ScaleAllSizes — stock ImGui
+    // behavior. Hairline 1px borders on retina are a deliberate choice; we
+    // do not override it.
+    t |> equal(style.WindowBorderSize, 1.0f, "WindowBorderSize unscaled (stock ImGui)")
+    DestroyContext(ctx)
+}

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -118,6 +118,11 @@ def public harness_init(title : string; width : int = 800; height : int = 600) {
         imgui_headless_set_display_size(float(width), float(height))
         return
     }
+    // Opt into per-monitor DPI on Windows so glfwCreateWindow scales the
+    // requested size by the monitor scale (no-op on macOS/Linux, where
+    // the windowing system already handles it). live_imgui_init then
+    // reads glfwGetWindowContentScale and applies it to fonts + theme.
+    glfwWindowHint(int(GLFW_SCALE_TO_MONITOR), 1)
     live_create_window(title, width, height)
     live_imgui_init(live_window)
 }

--- a/widgets/imgui_live.das
+++ b/widgets/imgui_live.das
@@ -13,8 +13,10 @@ require imgui public
 require imgui_app
 require glfw/glfw_boost
 require daslib/archive
+require daslib/safe_addr
 require live/live_commands
 require live_host
+require math
 require imgui/imgui_live_core public
 require imgui/imgui_theme_daslang
 
@@ -22,15 +24,34 @@ let private STORE_KEY = "__imgui_ctx"
 
 var public live_imgui_ctx : ImGuiContext?
 
+//! HDPI scale picked up from ``glfwGetWindowContentScale`` at init: 1.0 on a
+//! plain display, 2.0 on macOS retina, 1.25/1.5/2.0 on Windows DPI scaling.
+//! Set once inside :ref:`live_imgui_init <function-imgui_live_live_imgui_init>`
+//! (windowed path); stays at 1.0 in headless mode. User code can read this
+//! to scale custom drawing — line widths, viewport math, etc.
+var public live_imgui_content_scale : float = 1.0f
+
 def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#version 330") : ImGuiContext? {
-    //! Idempotent ImGui context create + backend init; safe across reload (reuses preserved ctx). Call from your script's ``init()``.
+    //! Idempotent ImGui context create + backend init; safe across reload (reuses preserved ctx).
+    //! Reads the window's content scale, loads JetBrains Mono at ``14 * scale`` px,
+    //! applies the daslang theme, and calls ``ScaleAllSizes(scale)`` so paddings/
+    //! spacings/rounding match the display. Call from your script's ``init()``.
     if (live_imgui_ctx != null) {
         SetCurrentContext(live_imgui_ctx)
         return live_imgui_ctx
     }
     live_imgui_ctx = CreateContext(null)
-    load_daslang_font()
+    if (window != null) {
+        var xs = 1.0f
+        var ys = 1.0f
+        glfwGetWindowContentScale(window, safe_addr(xs), safe_addr(ys))
+        // Some backends report 0 if the monitor is unavailable; clamp so
+        // we never divide visual sizes to nothing.
+        live_imgui_content_scale = max(max(xs, ys), 1.0f)
+    }
+    load_daslang_font(14.0f * live_imgui_content_scale)
     apply_daslang_theme()
+    ScaleAllSizes(unsafe(GetStyle()), live_imgui_content_scale)
     ImGui_ImplGlfw_InitForOpenGL(window, true)
     ImGui_ImplOpenGL3_Init(glsl_version)
     return live_imgui_ctx

--- a/widgets/imgui_theme_daslang.das
+++ b/widgets/imgui_theme_daslang.das
@@ -14,6 +14,14 @@ require daslib/module_path
 //! <function-imgui_live_live_imgui_init>`) and every window, button, slider,
 //! tab and plot picks it up. Daslang port of the
 //! ``daslang_imgui_style.h`` reference header.
+//!
+//! HDPI: ``apply_daslang_theme`` stores logical (1x) constants — paddings,
+//! spacings, rounding. For high-DPI displays, follow up with
+//! ``GetStyle() |> ScaleAllSizes(scale)`` and load the font at
+//! ``14 * scale`` px. The :ref:`live_imgui_init
+//! <function-imgui_live_live_imgui_init>` path does both automatically from
+//! ``glfwGetWindowContentScale``; if you bring your own ImGui context, mirror
+//! that pattern.
 
 // ===== Palette =====
 // Site colors precomputed as float4 RGBA. Tweak here to shift the whole
@@ -157,8 +165,9 @@ def public daslang_font_ttf_path() : string {
 
 def public load_daslang_font(size_px : float = 14.0f) : ImFont? {
     //! Load JetBrains Mono into the current ImGui font atlas at
-    //! ``size_px`` (14 in dev, 16 on retina/hi-dpi). Call once from
-    //! ``init()`` *before* :ref:`apply_daslang_theme
+    //! ``size_px``. Pass ``14 * content_scale`` for HDPI to keep the font
+    //! crisp instead of bilinear-upscaled by ``ImGuiIO.FontGlobalScale``.
+    //! Call once from ``init()`` *before* :ref:`apply_daslang_theme
     //! <function-imgui_theme_daslang_apply_daslang_theme>`. Returns the
     //! loaded ``ImFont?`` — null when the TTF is missing, in which case
     //! ImGui silently falls back to ProggyClean.


### PR DESCRIPTION
## Summary

- `widgets/imgui_live.das` — `live_imgui_init` now reads `glfwGetWindowContentScale` from the window, caches it in `var public live_imgui_content_scale`, and applies it to both the font (`load_daslang_font(14 * scale)`) and the style (`ScaleAllSizes` after `apply_daslang_theme`). Headless / no-window path stays at 1.0.
- `widgets/imgui_harness.das` — sets `GLFW_SCALE_TO_MONITOR` before `live_create_window`. Windows scales the window-creation size by monitor DPI; no-op on macOS/Linux.
- `widgets/imgui_theme_daslang.das` — docstrings only. Module header documents that the theme stores 1x logical constants and `ScaleAllSizes` runs after; `load_daslang_font` docstring says "pass `14 * content_scale` for HDPI".
- `tests/integration/test_theme_scale.das` (new) — two `[test]` cases: base constants at scale=1, then `ScaleAllSizes(2.0f)` doubles paddings/spacings/rounding. Includes an assertion that `WindowBorderSize` does NOT scale (stock ImGui behavior; hairline 1px borders on retina are a deliberate choice that this PR matches).

## Why

The daslang theme that landed in #39 stored hardcoded constants (`WindowPadding(8,8)`, `FramePadding(6,3)`, `ScrollbarSize=10`, font at 14px). On a retina display the result was readable but cramped — half the physical size of the original daslang.io reference. On Windows at 200% DPI the window opened at 800×600 physical pixels (tiny), with bilinear-blurry fonts. There was no DPI awareness anywhere; `glfwGetWindowContentScale` was already bound but never queried.

This PR plumbs content scale once at init (read-once; runtime DPI changes when dragging between monitors deliberately out of scope for v1) and applies it via `style.ScaleAllSizes(scale)` + a sharper font raster at `14 * scale` px. The `GLFW_SCALE_TO_MONITOR` hint covers the Windows side so users don't have to manually multiply `harness_init`'s requested size.

## Platforms

- **macOS retina**: `glfwGetWindowContentScale` returns 2.0; theme/font scaled, window already opens at logical size.
- **Windows DPI 100/125/150/200**: GLFW resizes the window per `GLFW_SCALE_TO_MONITOR`, then content scale matches.
- **Linux**: depends on compositor (Wayland reports correctly; X11 often 1.0). Code path identical; quality of the scale value varies by platform but our handling doesn't change.

## Test plan

- [x] Build daslang Release + dasImgui shared modules locally
- [x] `daslang modules/dasImgui/examples/imgui_demo/main.das` — visual check on retina mac, font crisp, padding scaled correctly, clean exit (0 stderr)
- [ ] CI: tests.yml matrix (ubuntu, macos, windows) green
- [ ] `tests/integration/test_theme_scale.das` passes — assertion on `ScaleAllSizes(2.0)` matches the stock-ImGui behavior we encode

🤖 Generated with [Claude Code](https://claude.com/claude-code)