### PR TITLE
one-shell APNG recording — with_recording_app at logical 1x

### DIFF
--- a/doc/source/tutorials/recording.rst
+++ b/doc/source/tutorials/recording.rst
@@ -4,12 +4,18 @@
 Recording APNGs
 #######################
 
-Every APNG in this tutorial set was produced the same way: a tiny
-**subject** app hosted under ``daslang-live``, then a **driver** script
-running in a second shell that toggled visual aids, called
-``record_start``, narrated each interaction, performed the action, and
-called ``record_stop``. This is the meta tutorial — the driver script
-is the artifact, and the embedded recording demonstrates itself.
+Every APNG in this tutorial set was produced the same way: a **driver**
+script that uses :code:`with_recording_app` to spawn a tiny **subject**
+app as :code:`daslang-live`, toggles visual aids, calls ``record_start``,
+narrates each interaction, performs the action, and lets the helper
+shut down. This is the meta tutorial — the driver script is the
+artifact, and the embedded recording demonstrates itself.
+
+The helper passes :code:`--imgui-content-scale=1.0` +
+:code:`--no-hdpi-framebuffer` to the spawned :code:`daslang-live` so
+APNGs stay at logical 1x — small files, fast encode, even on retina.
+Tutorials run by users directly (no driver) keep their native HDPI
+look.
 
 Source files:
 
@@ -45,44 +51,40 @@ The driver
 Anatomy of a driver
 ===================
 
-1. **Connect to the live host.** ``ImguiApp`` bundles the base URL +
-   transport into a value every playwright helper takes as its first
-   argument. ``wait_until_ready`` polls until the HTTP server answers,
-   so the driver can be launched concurrently with daslang-live and
-   recover from the cold-start gap.
+The driver's :code:`main` is a single :code:`with_recording_app(...)
+$(app) { ... }` call. The helper owns the boilerplate; the body owns
+the timeline.
 
-2. **Resolve widget centers.** ``wait_for_render`` polls
-   ``imgui_snapshot`` until the named widget shows up in the registry
-   (covers the first-frame gap where the subject's window exists but
-   hasn't rendered yet). The helper ``widget_bbox`` / ``widget_center``
-   extract the geometry from the snapshot JSON.
+1. **Helper-owned: spawn + ready-wait.** :code:`with_recording_app`
+   spawns :code:`daslang-live <feature_path>` with
+   :code:`--imgui-content-scale=1.0` + :code:`--no-hdpi-framebuffer`
+   (and forwards :code:`-project_root` from the driver's own argv),
+   waits for the HTTP server to answer :code:`/status` 200, and yields
+   an :code:`ImguiApp` to the body block.
 
-3. **Enable visual aids — BEFORE ``record_start``.**
+2. **Body-owned: resolve widget centers.** Inside the body,
+   :code:`wait_for_render` polls :code:`imgui_snapshot` until the named
+   widget shows up in the registry (covers the first-frame gap where
+   the subject's window exists but hasn't rendered yet). The helper
+   :code:`widget_bbox` / :code:`widget_center` extract the geometry
+   from the snapshot JSON.
 
-   .. code-block:: das
+3. **Helper-owned: enable visual aids + ``record_start``.** The
+   helper posts :code:`imgui_mouse_trail` + :code:`imgui_cursor_sprite`
+   :code:`(enabled=true)` and then :code:`record_start` with the
+   :code:`(file, fps, max_seconds)` you passed in. The writer pulls
+   from a PBO ring on the GL side (4 buffers by default) —
+   :code:`glReadPixels` returns immediately, the actual readback
+   happens 3 frames later, the encoder runs on a worker thread.
+   Frames drop only if the worker can't keep up with the GL output
+   rate, and even then dropping is graceful (the APNG just gets
+   slightly choppier — never breaks).
 
-      post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-      post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
+   The absolute APNG path is :code:`<dasimgui>/doc/source/_static/tutorials/<basename>`,
+   resolved via :code:`get_this_module_dir()` so caller cwd is
+   irrelevant.
 
-   ``imgui_mouse_trail`` draws a fading line behind the synthetic
-   cursor. ``imgui_cursor_sprite`` draws a visible pointer at
-   ``io.MousePos``. Without these, the recording shows widget state
-   changing but no cursor — confusing for viewers.
-
-4. **``record_start``.** Opens an APNG writer at ``file`` (relative to
-   daslang-live's cwd, which is why every tutorial's shell-1 command
-   ``cd``\\s into the asset directory first). ``fps`` controls the time
-   stamps written into the APNG frame headers — not how often frames
-   are captured. ``max_seconds`` caps the recording length.
-
-   The writer pulls from a PBO ring on the GL side (4 buffers by
-   default) — ``glReadPixels`` returns immediately, the actual readback
-   happens 3 frames later, the encoder runs on a worker thread. Frames
-   drop only if the worker can't keep up with the GL output rate, and
-   even then dropping is graceful (the APNG just gets slightly choppier
-   — never breaks).
-
-5. **Narrate, then act — repeat.** The locked pacing rule:
+4. **Body-owned: narrate, then act — repeat.** The locked pacing rule:
 
    .. code-block:: text
 
@@ -90,18 +92,16 @@ Anatomy of a driver
       sleep  = 3500u →  narrate disappears with ~500 ms gap
       sleep  = 1500u →  result-dwell after the action
 
-   ``frames`` counts the APP's frame counter (60 fps under vsync), NOT
-   the recorder's fps. So ``frames = 180`` is 3 seconds of real time,
-   regardless of whether the recorder is at 30 fps or 60 fps.
+   :code:`frames` counts the APP's frame counter (60 fps under vsync),
+   NOT the recorder's fps. So :code:`frames = 180` is 3 seconds of
+   real time, regardless of whether the recorder is at 30 fps or
+   60 fps.
 
-6. **``record_stop``.** Flushes the APNG writer, joins the encoder
-   thread, returns ``(saved, frames, duration_s, dropped, ok)`` so the
-   driver can spot-check stats.
-
-7. **Disable visual aids.** The host stays alive after the driver
-   exits — clean up the cursor sprite + trail so the next driver (or
-   a developer poking at the live host manually) starts from a clean
-   slate.
+5. **Helper-owned: ``record_stop`` + shutdown.** When the body
+   returns, the helper posts :code:`record_stop` (flushes the writer,
+   joins the encoder thread, prints :code:`(saved, frames, duration_s,
+   dropped, ok)`), disables the visual aids, posts :code:`/shutdown`,
+   drains stdout. The driver process exits when daslang-live does.
 
 The visual-aids stack
 =====================
@@ -132,23 +132,21 @@ Two more for keyboard work:
 The driver workflow in shell
 ============================
 
-The two-shell pattern every tutorial uses:
+One shell, one command:
 
 .. code-block:: bash
 
-   # shell 1 — host with cwd = the asset dir so the APNG lands there
-   cd modules/dasImgui/doc/source/_static/tutorials
-   ../../../../../../bin/Release/daslang-live.exe \
-       ../../../../examples/tutorial/recording.das
+   bin/Release/daslang.exe -project_root <dasimgui> \
+       <dasimgui>/tests/integration/record_recording.das
 
-   # shell 2 — fire the driver, exits when done
-   bin/Release/daslang.exe modules/dasImgui/tests/integration/record_recording.das
+The helper spawns daslang-live, runs the body, posts :code:`/shutdown`,
+drains stdout. Wall time = :code:`max_seconds` + ~3s headroom. The APNG
+lands at :code:`<dasimgui>/doc/source/_static/tutorials/recording.apng`.
 
-The host stays alive after the driver exits; if the recording was bad,
-re-run shell 2 — no need to restart daslang-live. The driver script
-nukes the previous file (``rm -f <name>.apng``) at the top, or
-``record_start`` returns ``{"error":"already recording"}`` if a prior
-session leaked.
+If you want to iterate without re-recording the host's state, drive a
+manually-launched host via :code:`mcp__daslang__live_command` instead
+(see "Verifying a recording" in :code:`skills/recording.md`). The
+driver script is for the canonical artifact pass.
 
 Stop conditions
 ===============

--- a/examples/tutorial/recording.das
+++ b/examples/tutorial/recording.das
@@ -22,21 +22,24 @@ require imgui/imgui_visual_aids
 //
 // Every previous tutorial's APNG was produced by the same workflow:
 //
-//   shell 1: daslang-live  hosts a SUBJECT app          (this .das)
-//   shell 2: daslang       runs a DRIVER script that:
-//              - turns on imgui_mouse_trail + imgui_cursor_sprite
-//              - calls record_start
-//              - posts imgui_narrate before each interaction
-//              - moves the cursor / clicks / drags / sets values
-//              - calls record_stop
+//   daslang  runs a DRIVER script that:
+//     - uses with_recording_app to SPAWN this SUBJECT app as daslang-live
+//     - the helper auto-toggles imgui_mouse_trail + imgui_cursor_sprite
+//     - the helper auto-bracketts record_start / record_stop
+//     - the body posts imgui_narrate + cursor moves + clicks / drags
 //
 // The DRIVER is the artifact that teaches recording — the subject is
 // just whatever app you want to record. This file is intentionally tiny
 // (one slider, one button) so the recording recipe is obvious: every
-// frame of the APNG corresponds to one specific driver call.
+// frame of the APNG corresponds to one specific driver-body call.
 //
 // The driver script for this tutorial is:
 //   tests/integration/record_recording.das
+//
+// The helper passes --imgui-content-scale=1.0 + --no-hdpi-framebuffer
+// to the spawned daslang-live so APNG capture stays at logical 1x.
+// When you run this tutorial DIRECTLY (no driver), no flags are passed,
+// so retina users get native HDPI scaling.
 //
 // Read the driver alongside the walkthrough in the RST companion — the
 // .das + driver + APNG triple is the tutorial.

--- a/skills/recording.md
+++ b/skills/recording.md
@@ -1,6 +1,6 @@
 # Recording APNG demos
 
-dasImgui ships its tutorial site at `doc/source/` with an APNG per tutorial page (`doc/source/_static/tutorials/*.apng`). Recordings are produced by **two-shell driver scripts** under `tests/integration/record_*.das` that talk to a running `daslang-live` host via its HTTP live-API (port 9090). Recordings are NOT in CI — they're manually-driven artifact producers, committed as binary APNGs alongside the driver script.
+dasImgui ships its tutorial site at `doc/source/` with an APNG per tutorial page (`doc/source/_static/tutorials/*.apng`). Recordings are produced by **one-shell driver scripts** under `tests/integration/record_*.das` that spawn their own `daslang-live` host via `with_recording_app` and post live-commands to it over HTTP. Recordings are NOT in CI — they're manually-driven artifact producers, committed as binary APNGs alongside the driver script.
 
 This page is the recipe. Read before writing or revising any `record_*.das` driver.
 
@@ -8,9 +8,9 @@ This page is the recipe. Read before writing or revising any `record_*.das` driv
 
 A recording has three independent layers:
 
-1. **Host**: `daslang-live.exe` running a feature file (`examples/tutorial/X.das` or `examples/imgui_demo/harness_X.das`). The host opens a window, runs your `update()` loop at 60 fps, listens for live-commands on port 9090.
-2. **Driver**: `daslang.exe tests/integration/record_X.das` runs once, posts live-commands to the host, waits for them to play out, exits. Sequence: `record_start` → `imgui_narrate` → `imgui_mouse_play` → sleep → `record_stop`.
-3. **Visual overlays**: `imgui_cursor_sprite` (red+white circle at synth pos) + `imgui_mouse_trail` (fading dotted line behind cursor). Both paint to the **foreground draw list** during the host's `end_of_frame()`. Enabled via live-commands before `record_start`.
+1. **Host**: `daslang-live.exe` running a feature file (`examples/tutorial/X.das` or `examples/features/X.das`). The host opens a window, runs your `update()` loop at 60 fps, listens for live-commands on port 9090. `with_recording_app` **spawns this host for you** with `--imgui-content-scale=1.0` + `--no-hdpi-framebuffer` so the framebuffer + ImGui style both stay at logical resolution (encoder-friendly APNGs even on retina). Tutorials run by users directly (no `--imgui-content-scale`) keep their native HDPI look.
+2. **Driver**: `daslang.exe tests/integration/record_X.das` runs once. The `with_recording_app(feature, output, max_seconds) $(app) { ... }` helper spawns the host, waits ready, enables `imgui_cursor_sprite` + `imgui_mouse_trail`, posts `record_start`, invokes the body for the narrate/click/drag timeline, posts `record_stop`, disables the aids, and `/shutdown`s the host. Driver exits when the host process does.
+3. **Visual overlays**: `imgui_cursor_sprite` (red+white circle at synth pos) + `imgui_mouse_trail` (fading dotted line behind cursor). Both paint to the **foreground draw list** during the host's `end_of_frame()`. The helper toggles them around the body; tour-specific overlays (`imgui_key_hud`, `imgui_focus_rect`) are body-managed (see `record_visual_aids.das`).
 
 The recorder captures the host's framebuffer at `fps` Hz starting on `record_start` and saves an APNG when `record_stop` fires.
 
@@ -18,7 +18,7 @@ The recorder captures the host's framebuffer at `fps` Hz starting on `record_sta
 
 If the host is a **tutorial** (`examples/tutorial/*.das`, `live_*` lifecycle): nothing extra — these files already call `apply_synth_io_override()` between `ImGui_ImplGlfw_NewFrame()` and `NewFrame()`.
 
-If the host is a **harness** (`examples/features/*.das` or `examples/imgui_demo/harness_*.das`, `harness_*` lifecycle): the harness **must call `harness_apply_synth_io()`** between `harness_begin_frame()` and `harness_new_frame()`. Without it:
+If the host is a **harness** (`examples/features/*.das`, `harness_*` lifecycle): the harness **must call `harness_apply_synth_io()`** between `harness_begin_frame()` and `harness_new_frame()`. Without it:
 
 - `synth_cursor_owned` stays `false` (GLFW's mouse poll wins the per-frame race);
 - `imgui_cursor_sprite` paints at the real OS cursor (off-window) → invisible in recording;
@@ -27,30 +27,18 @@ If the host is a **harness** (`examples/features/*.das` or `examples/imgui_demo/
 
 The harness API exposes `harness_apply_synth_io()` as OPTIONAL because most feature smokes only `wait_for_widget` without driving input. Once you record one, it becomes mandatory.
 
-## Two-shell workflow
+## One-shell workflow
 
 `<daslang>` = path to a daslang build tree, `<dasimgui>` = path to this repo. Append `.exe` on Windows.
-
-Shell 1 (host) — cwd = the asset directory so the APNG lands next to its siblings:
-
-```bash
-cd <dasimgui>/doc/source/_static/tutorials
-<daslang>/bin/Release/daslang-live -project_root <dasimgui> \
-    <dasimgui>/examples/tutorial/with_id.das
-```
-
-Wait for `live_api: server started on port 9090` to print.
-
-Shell 2 (driver):
 
 ```bash
 <daslang>/bin/Release/daslang -project_root <dasimgui> \
     <dasimgui>/tests/integration/record_with_id.das
 ```
 
-Driver exits when `record_stop` returns. The APNG lands in shell 1's cwd (`doc/source/_static/tutorials/`).
+The driver spawns daslang-live, runs the body, posts `/shutdown`, drains stdout. Total wall time = `max_seconds` + ~3s (boot + drain headroom). The APNG lands at `<dasimgui>/doc/source/_static/tutorials/<basename>.apng` — `with_recording_app` resolves the path via `get_this_module_dir()` so cwd doesn't matter.
 
-**Always full-restart the host between recording iterations.** Any interactive probe (menu click, key press) you ran via `mcp__daslang__live_command` leaves state — open menus, scrolled positions, toggled widgets — that contaminates the next recording. Stop `daslang-live` / `imguiApp` processes; relaunch fresh.
+**Concurrent driver runs collide on port 9090** (same risk as the playwright tests). Recording is interactive, one-at-a-time anyway; just don't fan them out.
 
 ## Driver template
 
@@ -67,9 +55,6 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "scene_name.apng"
-
 let NARRATE_FRAMES = 240      //! 4.0s visible at 60 fps app
 let READ_MS    = 5000u        //! 5s read + 1s gap before next action
 let SETTLE_MS  = 1500u        //! 1.5s cursor settle before next narrate
@@ -80,46 +65,47 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL}")
+    with_recording_app("examples/tutorial/scene_name.das",
+                       "scene_name.apng", 45) $(app) {
+        var snap = wait_for_render(app, "ROOT_IDENT", 10.0f)
+        if (snap == null) { panic("ROOT_IDENT never rendered") }
+
+        //! Initial cursor placement -- flips synth_cursor_owned.
+        move_to(app, (360.0f, 240.0f), 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1 ----
+        move_to(app, p_target_1, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "...",
+            target = "ROOT_IDENT",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        var events : array<JsonValue?>
+        events |> click_at(0, p_target_1, 250)
+        post_command(app, "imgui_mouse_play", JV((events = events)))
+        sleep(RESULT_MS)
+        // ... etc
     }
-    var snap = wait_for_render(app, "ROOT_IDENT", 10.0f)
-    if (snap == null) { panic("ROOT_IDENT never rendered") }
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start",
-                 JV((file = OUTPUT, fps = 30, max_seconds = 45)))
-
-    //! Initial cursor placement -- flips synth_cursor_owned.
-    move_to(app, (360.0f, 240.0f), 600)
-    sleep(SETTLE_MS)
-
-    // ---- Stage 1 ----
-    move_to(app, p_target_1, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "...",
-        target = "ROOT_IDENT",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    var events : array<JsonValue?>
-    events |> click_at(0, p_target_1, 250)
-    post_command(app, "imgui_mouse_play", JV((events = events)))
-    sleep(RESULT_MS)
-    // ... etc
-
-    post_command(app, "record_stop", null)
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }
 ```
+
+The 3-arg form uses fps=30 (the common case). For long recordings where file size matters more than smoothness, use the 4-arg overload with explicit fps:
+
+```daslang
+with_recording_app("examples/tutorial/narrative_layout_tour.das",
+                   "narrative_layout_tour.apng", 75, 20) $(app) {
+    // ... narrate/click/drag ...
+}
+```
+
+Two drivers use fps=20: `record_boost_narrative_layout` (long progress-bar tour) and `record_edit_external` (slider drag + color picker pass that defeats APNG compression at 30 fps). Both stay under GitHub's 50 MB asset warning band.
+
+## Tour-specific overlays
+
+`with_recording_app` only toggles the `mouse_trail` + `cursor_sprite` pair that every recording uses. Drivers that need additional overlays (`imgui_key_hud`, `imgui_focus_rect`) enable/disable them **inside the body block**. See `record_visual_aids.das` — body posts `imgui_key_hud` / `imgui_focus_rect` enable at start, posts disable before returning.
 
 ## Reader pacing (LOCKED)
 
@@ -132,14 +118,17 @@ Recordings are for **readers**, not test assertions. Every stage gets explicit t
 | `SETTLE_MS` | `1500u` | After `move_to`: 1.5s for cursor to settle visually before next narrate |
 | `RESULT_MS` | `2000u` | After `click_at`/`imgui_mouse_play` of an interaction: 2s dwell so the reader sees the result |
 
-A recording that fits in 30s is usually too dense. Bump `record_start max_seconds` to 45-60 for multi-stage flows.
+A recording that fits in 30s is usually too dense. Bump the helper's `max_seconds` to 45-60 for multi-stage flows.
 
-Don't use the old `record_with_id.das` pacing (`frames = 180`, `sleep(3500u)`) for new recordings — Boris's feedback: it's too fast for readers. The `record_with_id.das` template predates the pacing audit; treat its constants as legacy, not canonical.
+Don't use the old `record_with_id.das` pacing (`frames = 180`, `sleep(3500u)`) for new recordings — Boris's feedback: it's too fast for readers. The older drivers predate the pacing audit; treat those constants as legacy, not canonical.
 
 ## `imgui_playwright` helpers
 
 The `widgets/imgui_playwright.das` module exposes:
 
+- `with_recording_app(feature_path, output_basename, max_seconds, body)` — 3-arg form (fps=30 default). Spawns daslang-live for `<dasimgui>/<feature_path>`, posts record_start/stop bracket around `body`, shuts down. APNG lands at `<dasimgui>/doc/source/_static/tutorials/<output_basename>`.
+- `with_recording_app(feature_path, output_basename, max_seconds, fps, body)` — 4-arg form for explicit fps (typically 20 for long captures).
+- `with_imgui_app(feature_path, body)` / `with_imgui_app_opt(...)` — the playwright-test cousin (for `[test] def …(t : T?)` files). Forwards `--headless` from the parent. Recording uses the `_recording_` variant instead because it needs the GL framebuffer.
 - `move_to(app, pos, duration_ms = 600)` — lerps cursor from last tracked position to `pos`; updates the tracked pos for the next call.
 - `click_at(var events, t_ms, pos, travel_ms = 500, button = 0)` — appends lerp + press + release + dwell to an events array. Call `post_command(app, "imgui_mouse_play", JV((events = events)))` to fire.
 - `drag_along(var events, t_ms, from_pos, to_pos, drag_ms, approach_ms = 400)` — lerp-to-start + press + drag + release.
@@ -172,6 +161,8 @@ Don't rely on eyeballs alone — instrument it. Two probes:
 
 ### Probe 1: live-process screenshot (state at *this moment*)
 
+Launch a host manually (not via the helper — you want it to stay alive after your probe), then drive it via MCP:
+
 ```
 mcp__daslang__live_command name="imgui_mouse_play" args='{"events":[
     {"t_ms":0,"kind":"move","x":50,"y":15},
@@ -196,7 +187,11 @@ Pick 5-6 N values spanning the recording (e.g. 60 / 200 / 400 / 600 / 800 / 950 
 
 ## Where APNGs land
 
-`doc/source/_static/tutorials/`. Each tutorial RST under `doc/source/tutorials/*.rst` cites its APNG via:
+`doc/source/_static/tutorials/`. The helper writes the absolute path via `dir_name(get_this_module_dir()) / RECORD_ASSET_REL` — same idiom `widgets/imgui_theme_daslang.das:155` uses for the bundled font. Caller cwd is irrelevant.
+
+When dasImgui is daspkg-installed under `daScript/modules/dasImgui/`, the APNG lands in that install copy. For source-repo workflows (preferred for committing), launch the driver with `-project_root <dasimgui-source>` so the loaded copy IS the source repo, and the APNG lands where you can `git add` it directly. The helper forwards `-project_root` from the driver's own argv to the spawned daslang-live.
+
+Each tutorial RST under `doc/source/tutorials/*.rst` cites its APNG via:
 
 ```rst
 .. image:: ../_static/tutorials/scene_name.apng
@@ -205,7 +200,7 @@ Pick 5-6 N values spanning the recording (e.g. 60 / 200 / 400 / 600 / 800 / 950 
 
 CI's sphinx step uses `-W` (warnings-as-errors), so an RST referencing a missing APNG fails the build. Pair every new tutorial commit with the APNG commit ahead of it (APNG-first, then RST). The APNG-only intermediate state is fine — only the RST cite trips `-W`.
 
-Existing APNG size range: 7.5 MB → 75 MB. Anything outside that is suspicious (too short = under-paced; too long = uncompressed/oversized).
+Existing APNG size range: 7.5 MB → 30 MB at logical 1x. Anything outside that is suspicious (too short = under-paced; too long = uncompressed/oversized).
 
 ## Commit structure for a new recording
 

--- a/tests/integration/record_boost_basics.das
+++ b/tests/integration/record_boost_basics.das
@@ -8,21 +8,15 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``boost_basics.apng`` against an
-//! **already-running** daslang-live.
+//! Driver script: record ``boost_basics.apng`` via :ref:`with_recording_app
+//! <function-imgui_playwright_with_recording_app>`. One shell:
 //!
-//! Workflow (two shells):
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_boost_basics.das
 //!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/boost_basics.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_boost_basics.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "boost_basics.apng"
+//! Helper spawns daslang-live with ``--imgui-content-scale=1.0`` so the APNG
+//! captures at logical 1x (small file, encoder keeps up). APNG lands at
+//! ``<dasImgui>/doc/source/_static/tutorials/boost_basics.apng``.
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,73 +35,54 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with boost_basics.das?")
+    with_recording_app("examples/tutorial/boost_basics.das",
+                       "boost_basics.apng", 30) $(app) {
+        //! Targets are path-qualified — the `window(BASICS_WIN, ...)` boost
+        //! container pushes its name onto the registry path.
+        let T_VOLUME = "BASICS_WIN/VOLUME"
+        let T_BUMP   = "BASICS_WIN/BUMP_BTN"
+
+        var snap = wait_for_render(app, T_BUMP, 10.0f)
+        if (snap == null) {
+            panic("{T_BUMP} never rendered — wrong app running?")
+        }
+        let p_bump = widget_center(snap, T_BUMP)
+
+        //! Slider drag: 10% to 75% along the slider's bbox width.
+        let vol_bb = widget_bbox(snap, T_VOLUME)
+        let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
+        let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.10f
+        let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.75f
+
+        //! Pacing rule (LOCKED): frames=180 = 3.0s; sleep=3500u = ~500ms gap.
+
+        // ---- Stage 1: slider drag ----
+        post_command(app, "imgui_narrate", JV((
+            text = "VOLUME is a daslang global emitted by the slider macro.",
+            target = T_VOLUME,
+            frames = 180
+        )))
+        sleep(3500u)
+        var slider_events : array<JsonValue?>
+        slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1400)
+        post_command(app, "imgui_mouse_play", JV((events = slider_events)))
+        sleep(2500u)
+
+        // ---- Stage 2: click the bump button ----
+        post_command(app, "imgui_narrate", JV((
+            text = "BUMP_BTN.click_count tracks the bumps.",
+            target = T_BUMP,
+            frames = 180
+        )))
+        move_to(app, p_bump)
+        sleep(3500u)
+        var bump_events : array<JsonValue?>
+        bump_events |> click_at(0, p_bump)
+        post_command(app, "imgui_mouse_play", JV((events = bump_events)))
+        sleep(1200u)
+        var bump_events2 : array<JsonValue?>
+        bump_events2 |> click_at(0, p_bump)
+        post_command(app, "imgui_mouse_play", JV((events = bump_events2)))
+        sleep(1500u)
     }
-
-    //! Targets are path-qualified — the `window(BASICS_WIN, ...)` boost
-    //! container pushes its name onto the registry path.
-    let T_VOLUME = "BASICS_WIN/VOLUME"
-    let T_BUMP   = "BASICS_WIN/BUMP_BTN"
-
-    var snap = wait_for_render(app, T_BUMP, 10.0f)
-    if (snap == null) {
-        panic("{T_BUMP} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_bump = widget_center(snap, T_BUMP)
-
-    //! Slider drag: 10% to 75% along the slider's bbox width.
-    let vol_bb = widget_bbox(snap, T_VOLUME)
-    let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
-    let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.10f
-    let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.75f
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 30)))
-
-    //! Pacing rule (LOCKED): frames=180 = 3.0s; sleep=3500u = ~500ms gap.
-
-    // ---- Stage 1: slider drag ----
-    post_command(app, "imgui_narrate", JV((
-        text = "VOLUME is a daslang global emitted by the slider macro.",
-        target = T_VOLUME,
-        frames = 180
-    )))
-    sleep(3500u)
-    var slider_events : array<JsonValue?>
-    slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1400)
-    post_command(app, "imgui_mouse_play", JV((events = slider_events)))
-    sleep(2500u)
-
-    // ---- Stage 2: click the bump button ----
-    post_command(app, "imgui_narrate", JV((
-        text = "BUMP_BTN.click_count tracks the bumps.",
-        target = T_BUMP,
-        frames = 180
-    )))
-    move_to(app, p_bump)
-    sleep(3500u)
-    var bump_events : array<JsonValue?>
-    bump_events |> click_at(0, p_bump)
-    post_command(app, "imgui_mouse_play", JV((events = bump_events)))
-    sleep(1200u)
-    var bump_events2 : array<JsonValue?>
-    bump_events2 |> click_at(0, p_bump)
-    post_command(app, "imgui_mouse_play", JV((events = bump_events2)))
-    sleep(1500u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_boost_narrative_layout.das
+++ b/tests/integration/record_boost_narrative_layout.das
@@ -8,9 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``narrative_layout_tour.apng`` against an
-//! **already-running** daslang-live hosting
-//! ``examples/tutorial/narrative_layout_tour.das``.
+//! Driver script: record ``narrative_layout_tour.apng``. One shell:
+//!
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_boost_narrative_layout.das
 //!
 //! Walks four boost-v2 families in one window:
 //!   1. Narrative widgets (text / text_wrapped / text_colored / text_disabled
@@ -19,18 +20,9 @@ require daslib/json_boost public
 //!   3. Display widgets (progress_bar)
 //!   4. Flat-form tooltips (set_item_tooltip)
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 -- host with cwd = the asset dir:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/narrative_layout_tour.das
-//!
-//!     # window 2 -- fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_boost_narrative_layout.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "narrative_layout_tour.apng"
+//! fps=20 keeps the long progress_bar recording under GitHub's 50 MB
+//! warning band — see :ref:`with_recording_app
+//! <function-imgui_playwright_with_recording_app>`.
 
 //! Reader pacing locked per skills/recording.md.
 let NARRATE_FRAMES = 240
@@ -55,126 +47,103 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} -- is it running with narrative_layout_tour.das?")
+    with_recording_app("examples/tutorial/narrative_layout_tour.das",
+                       "narrative_layout_tour.apng", 75, 20) $(app) {
+        var snap = wait_for_render(app, "TOUR_WIN/INTRO", 10.0f)
+        if (snap == null) {
+            panic("TOUR_WIN/INTRO never rendered -- wrong app?")
+        }
+
+        let p_intro    = widget_center(snap, "TOUR_WIN/INTRO")
+        let p_wrap     = widget_center(snap, "TOUR_WIN/WRAP")
+        let p_colored  = widget_center(snap, "TOUR_WIN/COLORED")
+        let p_bullet   = widget_center(snap, "TOUR_WIN/BULLET_LINE")
+        let p_label    = widget_center(snap, "TOUR_WIN/LABEL_VERSION")
+        let p_septitle = widget_center(snap, "TOUR_WIN/SEP_TITLE")
+        let p_progress = widget_center(snap, "TOUR_WIN/PROG_BAR")
+        let p_tooltip  = widget_center(snap, "TOUR_WIN/HOVER_TIP")
+
+        //! Initial cursor placement (synth IO flips `cursor_owned` on first move).
+        move_to(app, (450.0f, 360.0f), 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: plain text ----
+        move_to(app, p_intro, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "text() -- one line, telemetry-visible.",
+            target = "TOUR_WIN/INTRO",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: wrapped text ----
+        move_to(app, p_wrap, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "text_wrapped reflows to the window's right edge.",
+            target = "TOUR_WIN/WRAP",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: colored / disabled / bullet ----
+        move_to(app, p_colored, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "text_colored + text_disabled -- inline visual variants.",
+            target = "TOUR_WIN/COLORED",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        move_to(app, p_bullet, 700)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "bullet_text -- marker + text in one call.",
+            target = "TOUR_WIN/BULLET_LINE",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: label_text (two-string) ----
+        move_to(app, p_label, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "label_text -- label and value side-by-side.",
+            target = "TOUR_WIN/LABEL_VERSION",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 5: separator_text ----
+        move_to(app, p_septitle, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "separator_text -- inline section header.",
+            target = "TOUR_WIN/SEP_TITLE",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 6: progress_bar (driven by the host) ----
+        move_to(app, p_progress, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "progress_bar -- fraction driven from the host loop.",
+            target = "TOUR_WIN/PROG_BAR",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 7: flat tooltip on hover ----
+        move_to(app, p_tooltip, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "set_item_tooltip -- fires when hovering the previous item.",
+            target = "TOUR_WIN/HOVER_TIP",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        sleep(TAIL_MS)
     }
-
-    var snap = wait_for_render(app, "TOUR_WIN/INTRO", 10.0f)
-    if (snap == null) {
-        panic("TOUR_WIN/INTRO never rendered -- wrong app on {BASE_URL}?")
-    }
-
-    let p_intro    = widget_center(snap, "TOUR_WIN/INTRO")
-    let p_wrap     = widget_center(snap, "TOUR_WIN/WRAP")
-    let p_colored  = widget_center(snap, "TOUR_WIN/COLORED")
-    let p_bullet   = widget_center(snap, "TOUR_WIN/BULLET_LINE")
-    let p_label    = widget_center(snap, "TOUR_WIN/LABEL_VERSION")
-    let p_septitle = widget_center(snap, "TOUR_WIN/SEP_TITLE")
-    let p_progress = widget_center(snap, "TOUR_WIN/PROG_BAR")
-    let p_tooltip  = widget_center(snap, "TOUR_WIN/HOVER_TIP")
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    //! fps=20: the progress_bar animates every frame and the recording is
-    //! 55s long, so 30 fps blew past GitHub's 50 MB warning band. 20 fps
-    //! keeps the cursor-tracking smooth enough for readers while cutting
-    //! ~30% of file size.
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 20, max_seconds = 75)))
-
-    //! Initial cursor placement (synth IO flips `cursor_owned` on first move).
-    move_to(app, (450.0f, 360.0f), 600)
-    sleep(SETTLE_MS)
-
-    // ---- Stage 1: plain text ----
-    move_to(app, p_intro, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "text() -- one line, telemetry-visible.",
-        target = "TOUR_WIN/INTRO",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 2: wrapped text ----
-    move_to(app, p_wrap, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "text_wrapped reflows to the window's right edge.",
-        target = "TOUR_WIN/WRAP",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 3: colored / disabled / bullet ----
-    move_to(app, p_colored, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "text_colored + text_disabled -- inline visual variants.",
-        target = "TOUR_WIN/COLORED",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    move_to(app, p_bullet, 700)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "bullet_text -- marker + text in one call.",
-        target = "TOUR_WIN/BULLET_LINE",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 4: label_text (two-string) ----
-    move_to(app, p_label, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "label_text -- label and value side-by-side.",
-        target = "TOUR_WIN/LABEL_VERSION",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 5: separator_text ----
-    move_to(app, p_septitle, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "separator_text -- inline section header.",
-        target = "TOUR_WIN/SEP_TITLE",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 6: progress_bar (driven by the host) ----
-    move_to(app, p_progress, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "progress_bar -- fraction driven from the host loop.",
-        target = "TOUR_WIN/PROG_BAR",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 7: flat tooltip on hover ----
-    move_to(app, p_tooltip, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "set_item_tooltip -- fires when hovering the previous item.",
-        target = "TOUR_WIN/HOVER_TIP",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    sleep(TAIL_MS)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_containers.das
+++ b/tests/integration/record_containers.das
@@ -8,21 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``containers.apng`` against an
-//! **already-running** daslang-live.
+//! Driver script: record ``containers.apng``. One shell:
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/containers.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_containers.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "containers.apng"
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_containers.das
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,94 +30,75 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with containers.das?")
+    with_recording_app("examples/tutorial/containers.das",
+                       "containers.apng", 60) $(app) {
+        //! Targets are path-qualified — `window`, `menu_bar`, `tab_bar`, etc.
+        //! all push their identifier onto the registry path. Note that menu
+        //! and tab-item HEADER bboxes aren't registered (ImGui draws them as
+        //! chrome before the body block runs); we point narrates at child
+        //! widgets inside the active tab instead.
+        let T_WIRE        = "CONT_WIN/MAIN_TABS/GENERAL_TAB/WIRE"
+        let T_OPEN_POPUP  = "CONT_WIN/OPEN_POPUP_BTN"
+        let T_POPUP       = "CONT_WIN/OPTIONS_POPUP"
+        let T_HOVER       = "CONT_WIN/HOVER_BTN"
+
+        var snap = wait_for_render(app, T_OPEN_POPUP, 10.0f)
+        if (snap == null) {
+            panic("{T_OPEN_POPUP} never rendered — wrong app running?")
+        }
+        let p_open_popup = widget_center(snap, T_OPEN_POPUP)
+        let p_hover      = widget_center(snap, T_HOVER)
+        let p_wire       = widget_center(snap, T_WIRE)
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Stage 1: menu bar + tab bar — narrate the chrome ----
+        // The menu bar and tab headers are ImGui-drawn chrome above any
+        // registered widget. The cursor sits at the top of the General tab
+        // (WIRE) so the menu bar and tab strip are both in view.
+        post_command(app, "imgui_narrate", JV((
+            text = "menu_bar and tab_bar share the window chrome.",
+            target = T_WIRE,
+            frames = 200
+        )))
+        move_to(app, p_wire)
+        sleep(3500u)
+        post_command(app, "imgui_narrate", JV((
+            text = "Only the active tab's block runs each frame.",
+            target = T_WIRE,
+            frames = 200
+        )))
+        sleep(3500u)
+
+        // ---- Stage 2: popup via pending_open ----
+        post_command(app, "imgui_narrate", JV((
+            text = "popup — open via the button (pending_open).",
+            target = T_OPEN_POPUP,
+            frames = 200
+        )))
+        move_to(app, p_open_popup)
+        sleep(3500u)
+        var open_events : array<JsonValue?>
+        open_events |> click_at(0, p_open_popup)
+        post_command(app, "imgui_mouse_play", JV((events = open_events)))
+        sleep(2000u)
+        // Close it via the same channel imgui_close uses.
+        post_command(app, "imgui_close", JV((target = T_POPUP)))
+        sleep(1500u)
+
+        // ---- Stage 3: item_tooltip on hover ----
+        post_command(app, "imgui_narrate", JV((
+            text = "item_tooltip — auto-gated by IsItemHovered.",
+            target = T_HOVER,
+            frames = 200
+        )))
+        move_to(app, p_hover)
+        sleep(3500u)
+        // Dwell on the button so ImGui's hover delay fires the tooltip.
+        sleep(2500u)
     }
-
-    //! Targets are path-qualified — `window`, `menu_bar`, `tab_bar`, etc.
-    //! all push their identifier onto the registry path. Note that menu
-    //! and tab-item HEADER bboxes aren't registered (ImGui draws them as
-    //! chrome before the body block runs); we point narrates at child
-    //! widgets inside the active tab instead.
-    let T_WIRE        = "CONT_WIN/MAIN_TABS/GENERAL_TAB/WIRE"
-    let T_OPEN_POPUP  = "CONT_WIN/OPEN_POPUP_BTN"
-    let T_POPUP       = "CONT_WIN/OPTIONS_POPUP"
-    let T_HOVER       = "CONT_WIN/HOVER_BTN"
-
-    var snap = wait_for_render(app, T_OPEN_POPUP, 10.0f)
-    if (snap == null) {
-        panic("{T_OPEN_POPUP} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_open_popup = widget_center(snap, T_OPEN_POPUP)
-    let p_hover      = widget_center(snap, T_HOVER)
-    let p_wire       = widget_center(snap, T_WIRE)
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- Stage 1: menu bar + tab bar — narrate the chrome ----
-    // The menu bar and tab headers are ImGui-drawn chrome above any
-    // registered widget. The cursor sits at the top of the General tab
-    // (WIRE) so the menu bar and tab strip are both in view.
-    post_command(app, "imgui_narrate", JV((
-        text = "menu_bar and tab_bar share the window chrome.",
-        target = T_WIRE,
-        frames = 200
-    )))
-    move_to(app, p_wire)
-    sleep(3500u)
-    post_command(app, "imgui_narrate", JV((
-        text = "Only the active tab's block runs each frame.",
-        target = T_WIRE,
-        frames = 200
-    )))
-    sleep(3500u)
-
-    // ---- Stage 2: popup via pending_open ----
-    post_command(app, "imgui_narrate", JV((
-        text = "popup — open via the button (pending_open).",
-        target = T_OPEN_POPUP,
-        frames = 200
-    )))
-    move_to(app, p_open_popup)
-    sleep(3500u)
-    var open_events : array<JsonValue?>
-    open_events |> click_at(0, p_open_popup)
-    post_command(app, "imgui_mouse_play", JV((events = open_events)))
-    sleep(2000u)
-    // Close it via the same channel imgui_close uses.
-    post_command(app, "imgui_close", JV((target = T_POPUP)))
-    sleep(1500u)
-
-    // ---- Stage 3: item_tooltip on hover ----
-    post_command(app, "imgui_narrate", JV((
-        text = "item_tooltip — auto-gated by IsItemHovered.",
-        target = T_HOVER,
-        frames = 200
-    )))
-    move_to(app, p_hover)
-    sleep(3500u)
-    // Dwell on the button so ImGui's hover delay fires the tooltip.
-    sleep(2500u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_custom_widgets.das
+++ b/tests/integration/record_custom_widgets.das
@@ -8,21 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``custom_widgets.apng`` against an
-//! **already-running** daslang-live serving the custom_widgets tutorial.
+//! Driver script: record ``custom_widgets.apng``. One shell:
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/custom_widgets.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_custom_widgets.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "custom_widgets.apng"
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_custom_widgets.das
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     //! Pull (x_min, y_min, x_max, y_max) out of the snapshot for one widget.
@@ -42,120 +31,95 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    // ---- 1. Connect to the live host ----
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with custom_widgets.das?")
+    with_recording_app("examples/tutorial/custom_widgets.das",
+                       "custom_widgets.apng", 24) $(app) {
+        // ---- Resolve widget centers from a snapshot ----
+        let T_MASTER = "MIXER_WIN/MASTER"
+        let T_TREBLE = "MIXER_WIN/TREBLE"
+        let T_BASS   = "MIXER_WIN/BASS"
+        let T_RESET  = "MIXER_WIN/RESET_BTN"
+        var snap = wait_for_render(app, T_RESET, 10.0f)
+        if (snap == null) {
+            panic("{T_RESET} never rendered — wrong app running?")
+        }
+        let p_master = widget_center(snap, T_MASTER)
+        let p_treble = widget_center(snap, T_TREBLE)
+        let p_bass   = widget_center(snap, T_BASS)
+        let p_reset  = widget_center(snap, T_RESET)
+
+        // The knob is angular: atan2(mouse - center) drives value directly.
+        // Drag endpoints must stay in the active 270° arc (i.e. NOT in the
+        // 90° dead zone at the bottom). Straight lines through center are the
+        // hazard — pick endpoints with the same sign of dy (both above center).
+        //
+        // MASTER (bounds 0..1, starts at 0): drag from "7 o'clock" position
+        // (matches starting value, no press-jump) up and over to "12 o'clock".
+        // Value sweeps 0 → 0.5.
+        let r = 22.0f
+        let drag_start_master = (p_master._0 - r * 0.707f, p_master._1 + r * 0.707f)
+        let drag_end_master   = (p_master._0,              p_master._1 - r)
+
+        // TREBLE (bounds -1..1, starts at 0): drag from "12" to "2 o'clock".
+        // Value sweeps 0 → 0.33 — visible without crossing dead zone.
+        let drag_start_treble = (p_treble._0,              p_treble._1 - r)
+        let drag_end_treble   = (p_treble._0 + r * 0.707f, p_treble._1 - r * 0.707f)
+
+        // Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps under
+        // vsync), NOT the recorder's fps.
+        //     frames = 180   →  3.0s visible narrate
+        //     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //     sleep  = 1500u →  result dwell after action
+
+        // ---- Narrate then act — one beat per knob ----
+
+        // Beat 1: drag MASTER from 7 o'clock to 12 — value rises 0 → 0.5
+        post_command(app, "imgui_narrate", JV((
+            text = "ImGui ships no rotary widget. We add one with [widget].",
+            target = T_MASTER,
+            frames = 200
+        )))
+        move_to(app, p_master)
+        sleep(3500u)
+        var ev_master : array<JsonValue?>
+        ev_master |> drag_along(0, drag_start_master, drag_end_master, 1200)
+        post_command(app, "imgui_mouse_play", JV((events = ev_master)))
+        sleep(2000u)
+
+        // Beat 2: drag TREBLE from 12 to 2 o'clock — value rises 0 → ~0.33
+        post_command(app, "imgui_narrate", JV((
+            text = "State struct matches slider_float — pending_value_finalize Just Works.",
+            target = T_TREBLE,
+            frames = 200
+        )))
+        move_to(app, p_treble)
+        sleep(3500u)
+        var ev_treble : array<JsonValue?>
+        ev_treble |> drag_along(0, drag_start_treble, drag_end_treble, 1200)
+        post_command(app, "imgui_mouse_play", JV((events = ev_treble)))
+        sleep(2000u)
+
+        // Beat 3: imgui_set BASS — show that the live API path works on custom widgets too
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_set drives custom widgets the same way — no extra wiring.",
+            target = T_BASS,
+            frames = 200
+        )))
+        move_to(app, p_bass)
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_BASS, value = -0.5f)))
+        sleep(2000u)
+
+        // Beat 4: click RESET_BTN — ordinary built-in on the same panel
+        post_command(app, "imgui_narrate", JV((
+            text = "RESET_BTN is an ordinary built-in button — same registry.",
+            target = T_RESET,
+            frames = 200
+        )))
+        move_to(app, p_reset)
+        sleep(3500u)
+        var ev_reset : array<JsonValue?>
+        ev_reset |> click_at(0, p_reset)
+        post_command(app, "imgui_mouse_play", JV((events = ev_reset)))
+        sleep(1500u)
     }
-
-    // ---- 2. Resolve widget centers from a snapshot ----
-    let T_MASTER = "MIXER_WIN/MASTER"
-    let T_TREBLE = "MIXER_WIN/TREBLE"
-    let T_BASS   = "MIXER_WIN/BASS"
-    let T_RESET  = "MIXER_WIN/RESET_BTN"
-    var snap = wait_for_render(app, T_RESET, 10.0f)
-    if (snap == null) {
-        panic("{T_RESET} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_master = widget_center(snap, T_MASTER)
-    let p_treble = widget_center(snap, T_TREBLE)
-    let p_bass   = widget_center(snap, T_BASS)
-    let p_reset  = widget_center(snap, T_RESET)
-
-    // The knob is angular: atan2(mouse - center) drives value directly.
-    // Drag endpoints must stay in the active 270° arc (i.e. NOT in the
-    // 90° dead zone at the bottom). Straight lines through center are the
-    // hazard — pick endpoints with the same sign of dy (both above center).
-    //
-    // MASTER (bounds 0..1, starts at 0): drag from "7 o'clock" position
-    // (matches starting value, no press-jump) up and over to "12 o'clock".
-    // Value sweeps 0 → 0.5.
-    let r = 22.0f
-    let drag_start_master = (p_master._0 - r * 0.707f, p_master._1 + r * 0.707f)
-    let drag_end_master   = (p_master._0,              p_master._1 - r)
-
-    // TREBLE (bounds -1..1, starts at 0): drag from "12" to "2 o'clock".
-    // Value sweeps 0 → 0.33 — visible without crossing dead zone.
-    let drag_start_treble = (p_treble._0,              p_treble._1 - r)
-    let drag_end_treble   = (p_treble._0 + r * 0.707f, p_treble._1 - r * 0.707f)
-
-    // ---- 3. Enable visual aids BEFORE record_start ----
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-
-    // ---- 4. record_start: opens the APNG writer ----
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 24)))
-
-    // Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps under
-    // vsync), NOT the recorder's fps.
-    //     frames = 180   →  3.0s visible narrate
-    //     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //     sleep  = 1500u →  result dwell after action
-
-    // ---- 5. Narrate then act — one beat per knob ----
-
-    // Beat 1: drag MASTER from 7 o'clock to 12 — value rises 0 → 0.5
-    post_command(app, "imgui_narrate", JV((
-        text = "ImGui ships no rotary widget. We add one with [widget].",
-        target = T_MASTER,
-        frames = 200
-    )))
-    move_to(app, p_master)
-    sleep(3500u)
-    var ev_master : array<JsonValue?>
-    ev_master |> drag_along(0, drag_start_master, drag_end_master, 1200)
-    post_command(app, "imgui_mouse_play", JV((events = ev_master)))
-    sleep(2000u)
-
-    // Beat 2: drag TREBLE from 12 to 2 o'clock — value rises 0 → ~0.33
-    post_command(app, "imgui_narrate", JV((
-        text = "State struct matches slider_float — pending_value_finalize Just Works.",
-        target = T_TREBLE,
-        frames = 200
-    )))
-    move_to(app, p_treble)
-    sleep(3500u)
-    var ev_treble : array<JsonValue?>
-    ev_treble |> drag_along(0, drag_start_treble, drag_end_treble, 1200)
-    post_command(app, "imgui_mouse_play", JV((events = ev_treble)))
-    sleep(2000u)
-
-    // Beat 3: imgui_set BASS — show that the live API path works on custom widgets too
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_set drives custom widgets the same way — no extra wiring.",
-        target = T_BASS,
-        frames = 200
-    )))
-    move_to(app, p_bass)
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_BASS, value = -0.5f)))
-    sleep(2000u)
-
-    // Beat 4: click RESET_BTN — ordinary built-in on the same panel
-    post_command(app, "imgui_narrate", JV((
-        text = "RESET_BTN is an ordinary built-in button — same registry.",
-        target = T_RESET,
-        frames = 200
-    )))
-    move_to(app, p_reset)
-    sleep(3500u)
-    var ev_reset : array<JsonValue?>
-    ev_reset |> click_at(0, p_reset)
-    post_command(app, "imgui_mouse_play", JV((events = ev_reset)))
-    sleep(1500u)
-
-    // ---- 6. record_stop ----
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    // ---- 7. Disable visual aids ----
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_docking.das
+++ b/tests/integration/record_docking.das
@@ -8,21 +8,12 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``docking.apng`` against an **already-running**
-//! daslang-live. Mirrors record_layout.das.
+//! Driver script: record ``docking.apng``. One shell:
 //!
-//! Workflow (two shells):
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_docking.das
 //!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/docking.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_docking.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "docking.apng"
+//! Mirrors record_layout.das.
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,99 +32,80 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with docking.das?")
+    with_recording_app("examples/tutorial/docking.das",
+                       "docking.apng", 60) $(app) {
+        //! Targets are path-qualified — dockspace pushes onto the registry path.
+        let T_EXPLORER    = "DOCK_ROOT/EXPLORER"
+        let T_SOURCE      = "DOCK_ROOT/SOURCE"
+        let T_OUTPUT      = "DOCK_ROOT/OUTPUT"
+        let T_REFRESH_BTN = "DOCK_ROOT/EXPLORER/REFRESH_BTN"
+        let T_SAVE_BTN    = "DOCK_ROOT/SOURCE/SAVE_BTN"
+        let T_CLEAR_BTN   = "DOCK_ROOT/OUTPUT/CLEAR_BTN"
+
+        var snap = wait_for_render(app, T_REFRESH_BTN, 10.0f)
+        if (snap == null) {
+            panic("{T_REFRESH_BTN} never rendered — wrong app running?")
+        }
+        let p_refresh = widget_center(snap, T_REFRESH_BTN)
+        let p_save    = widget_center(snap, T_SAVE_BTN)
+        let p_clear   = widget_center(snap, T_CLEAR_BTN)
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms for the actual interaction (click / drag / dwell).
+
+        // ---- Stage 1: tour the docked panels ----
+        post_command(app, "imgui_narrate", JV((
+            text = "ImGui native docking — three dockable panels.",
+            target = T_EXPLORER,
+            frames = 180
+        )))
+        move_to(app, p_refresh)
+        sleep(3500u)
+
+        post_command(app, "imgui_narrate", JV((
+            text = "Each panel is a Begin/End window inside the dockspace.",
+            target = T_SOURCE,
+            frames = 180
+        )))
+        move_to(app, p_save)
+        sleep(3500u)
+
+        post_command(app, "imgui_narrate", JV((
+            text = "Tabs are draggable — layout persists via imgui.ini.",
+            target = T_OUTPUT,
+            frames = 180
+        )))
+        move_to(app, p_clear)
+        sleep(3500u)
+
+        // ---- Stage 2: drive from outside — imgui_undock pops OUTPUT out ----
+        // After undocking, ImGui places the floating window wherever imgui.ini
+        // remembered (or (0,0) on first run). Pin it to a visible location with
+        // imgui_set_window_pos so the demo clearly shows the panel detached.
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_undock + imgui_set_window_pos — panel floats free.",
+            target = T_OUTPUT,
+            frames = 200
+        )))
+        sleep(800u)
+        post_command(app, "imgui_undock", JV((target = T_OUTPUT)))
+        post_command(app, "imgui_set_window_pos", JV((
+            target = T_OUTPUT,
+            value = (x = 580.0f, y = 220.0f, w = 360.0f, h = 220.0f)
+        )))
+        sleep(3700u)
+
+        // ---- Stage 3: reset the dockspace ----
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_dock_reset rebuilds the default layout.",
+            target = T_EXPLORER,
+            frames = 180
+        )))
+        sleep(800u)
+        post_command(app, "imgui_dock_reset", JV((target = "DOCK_ROOT")))
+        sleep(3000u)
     }
-
-    //! Targets are path-qualified — dockspace pushes onto the registry path.
-    let T_EXPLORER    = "DOCK_ROOT/EXPLORER"
-    let T_SOURCE      = "DOCK_ROOT/SOURCE"
-    let T_OUTPUT      = "DOCK_ROOT/OUTPUT"
-    let T_REFRESH_BTN = "DOCK_ROOT/EXPLORER/REFRESH_BTN"
-    let T_SAVE_BTN    = "DOCK_ROOT/SOURCE/SAVE_BTN"
-    let T_CLEAR_BTN   = "DOCK_ROOT/OUTPUT/CLEAR_BTN"
-
-    var snap = wait_for_render(app, T_REFRESH_BTN, 10.0f)
-    if (snap == null) {
-        panic("{T_REFRESH_BTN} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_refresh = widget_center(snap, T_REFRESH_BTN)
-    let p_save    = widget_center(snap, T_SAVE_BTN)
-    let p_clear   = widget_center(snap, T_CLEAR_BTN)
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms for the actual interaction (click / drag / dwell).
-
-    // ---- Stage 1: tour the docked panels ----
-    post_command(app, "imgui_narrate", JV((
-        text = "ImGui native docking — three dockable panels.",
-        target = T_EXPLORER,
-        frames = 180
-    )))
-    move_to(app, p_refresh)
-    sleep(3500u)
-
-    post_command(app, "imgui_narrate", JV((
-        text = "Each panel is a Begin/End window inside the dockspace.",
-        target = T_SOURCE,
-        frames = 180
-    )))
-    move_to(app, p_save)
-    sleep(3500u)
-
-    post_command(app, "imgui_narrate", JV((
-        text = "Tabs are draggable — layout persists via imgui.ini.",
-        target = T_OUTPUT,
-        frames = 180
-    )))
-    move_to(app, p_clear)
-    sleep(3500u)
-
-    // ---- Stage 2: drive from outside — imgui_undock pops OUTPUT out ----
-    // After undocking, ImGui places the floating window wherever imgui.ini
-    // remembered (or (0,0) on first run). Pin it to a visible location with
-    // imgui_set_window_pos so the demo clearly shows the panel detached.
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_undock + imgui_set_window_pos — panel floats free.",
-        target = T_OUTPUT,
-        frames = 200
-    )))
-    sleep(800u)
-    post_command(app, "imgui_undock", JV((target = T_OUTPUT)))
-    post_command(app, "imgui_set_window_pos", JV((
-        target = T_OUTPUT,
-        value = (x = 580.0f, y = 220.0f, w = 360.0f, h = 220.0f)
-    )))
-    sleep(3700u)
-
-    // ---- Stage 3: reset the dockspace ----
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_dock_reset rebuilds the default layout.",
-        target = T_EXPLORER,
-        frames = 180
-    )))
-    sleep(800u)
-    post_command(app, "imgui_dock_reset", JV((target = "DOCK_ROOT")))
-    sleep(3000u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_drag_drop.das
+++ b/tests/integration/record_drag_drop.das
@@ -8,21 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``drag_drop.apng`` against an **already-running**
-//! daslang-live hosting ``examples/features/drag_drop.das``.
+//! Driver script: record ``drag_drop.apng``. One shell:
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 -- host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/features/drag_drop.das
-//!
-//!     # window 2 -- fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_drag_drop.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "drag_drop.apng"
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_drag_drop.das
 
 //! Reader pacing locked per skills/recording.md.
 let NARRATE_FRAMES = 240
@@ -48,80 +37,61 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} -- is it running with drag_drop.das?")
+    with_recording_app("examples/features/drag_drop.das",
+                       "drag_drop.apng", 45) $(app) {
+        let T_SOURCE = "MAIN_WIN/SOURCE_BTN"
+        let T_TARGET = "MAIN_WIN/TARGET_BTN"
+
+        var snap = wait_for_render(app, T_SOURCE, 10.0f)
+        if (snap == null) {
+            panic("{T_SOURCE} never rendered -- wrong app running?")
+        }
+        let p_source = widget_center(snap, T_SOURCE)
+        let p_target = widget_center(snap, T_TARGET)
+
+        //! Initial cursor placement (synth IO flips `cursor_owned` on first move).
+        move_to(app, (360.0f, 360.0f), 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: hover SOURCE + narrate ----
+        move_to(app, p_source, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "drag_drop_source attaches to the SOURCE button.",
+            target = T_SOURCE,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: hover TARGET + narrate ----
+        move_to(app, p_target, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "drag_drop_target accepts the typed payload.",
+            target = T_TARGET,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: perform the drag ----
+        //! Use drag_along + imgui_mouse_play (not drag_to). drag_to dispatches
+        //! the L1 drag coroutine which calls AddMouseButtonEvent / AddMousePosEvent
+        //! directly on io; that races against imgui_synth_tick's per-frame cursor
+        //! re-assertion and the press never appears to "hold." Building synth
+        //! events and posting via imgui_mouse_play routes through the synth
+        //! pipeline (synth_held_buttons + synth_cursor) which IS the drained path.
+        post_command(app, "imgui_narrate", JV((
+            text = "drag from SOURCE bbox to TARGET bbox -- payload travels with the cursor.",
+            target = T_SOURCE,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(RESULT_MS)
+        var drag_events : array<JsonValue?>
+        drag_events |> drag_along(0, p_source, p_target, 1200, 400)
+        post_command(app, "imgui_mouse_play", JV((events = drag_events)))
+        sleep(uint(2200))   //! approach(400) + 100 + drag(1200) + 200 + 300 = 2200ms wall time
+        sleep(RESULT_MS)
+        //! Settle on the target so the reader sees "Drops accepted: 1".
+        sleep(TAIL_MS)
     }
-
-    let T_SOURCE = "MAIN_WIN/SOURCE_BTN"
-    let T_TARGET = "MAIN_WIN/TARGET_BTN"
-
-    var snap = wait_for_render(app, T_SOURCE, 10.0f)
-    if (snap == null) {
-        panic("{T_SOURCE} never rendered -- wrong app running on {BASE_URL}?")
-    }
-    let p_source = widget_center(snap, T_SOURCE)
-    let p_target = widget_center(snap, T_TARGET)
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 45)))
-
-    //! Initial cursor placement (synth IO flips `cursor_owned` on first move).
-    move_to(app, (360.0f, 360.0f), 600)
-    sleep(SETTLE_MS)
-
-    // ---- Stage 1: hover SOURCE + narrate ----
-    move_to(app, p_source, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "drag_drop_source attaches to the SOURCE button.",
-        target = T_SOURCE,
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 2: hover TARGET + narrate ----
-    move_to(app, p_target, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "drag_drop_target accepts the typed payload.",
-        target = T_TARGET,
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-
-    // ---- Stage 3: perform the drag ----
-    //! Use drag_along + imgui_mouse_play (not drag_to). drag_to dispatches
-    //! the L1 drag coroutine which calls AddMouseButtonEvent / AddMousePosEvent
-    //! directly on io; that races against imgui_synth_tick's per-frame cursor
-    //! re-assertion and the press never appears to "hold." Building synth
-    //! events and posting via imgui_mouse_play routes through the synth
-    //! pipeline (synth_held_buttons + synth_cursor) which IS the drained path.
-    post_command(app, "imgui_narrate", JV((
-        text = "drag from SOURCE bbox to TARGET bbox -- payload travels with the cursor.",
-        target = T_SOURCE,
-        frames = NARRATE_FRAMES
-    )))
-    sleep(RESULT_MS)
-    var drag_events : array<JsonValue?>
-    drag_events |> drag_along(0, p_source, p_target, 1200, 400)
-    post_command(app, "imgui_mouse_play", JV((events = drag_events)))
-    sleep(uint(2200))   //! approach(400) + 100 + drag(1200) + 200 + 300 = 2200ms wall time
-    sleep(RESULT_MS)
-    //! Settle on the target so the reader sees "Drops accepted: 1".
-    sleep(TAIL_MS)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_driving_outside.das
+++ b/tests/integration/record_driving_outside.das
@@ -8,124 +8,92 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``driving_outside.apng`` against an
-//! **already-running** daslang-live. Every action is performed via
-//! live commands — no mouse moves into widget centers, since the
-//! whole point is to demonstrate the "no input device required"
-//! programming model.
+//! Driver script: record ``driving_outside.apng``. One shell:
 //!
-//! Workflow (two shells):
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_driving_outside.das
 //!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/driving_outside.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_driving_outside.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "driving_outside.apng"
-
-//! No mouse-driving helpers — this driver intentionally uses only the
-//! L2/L3 live-command surface (imgui_set / imgui_click / imgui_open /
-//! imgui_close), so there's no need to look up widget centers.
+//! Every action is performed via L2/L3 live commands (imgui_set /
+//! imgui_click / imgui_open / imgui_close) — no mouse moves into widget
+//! centers, since the whole point is to demonstrate the "no input device
+//! required" programming model.
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with driving_outside.das?")
+    with_recording_app("examples/tutorial/driving_outside.das",
+                       "driving_outside.apng", 60) $(app) {
+        //! Every target is path-qualified — the window pushes its name.
+        let T_USER   = "DRIVE_WIN/USER"
+        let T_SPEED  = "DRIVE_WIN/SPEED"
+        let T_PRESET = "DRIVE_WIN/PRESET"
+        let T_RUN    = "DRIVE_WIN/RUN_BTN"
+        let T_POPUP  = "DRIVE_WIN/STATUS_POPUP"
+
+        var snap = wait_for_render(app, T_USER, 10.0f)
+        if (snap == null) {
+            panic("{T_USER} never rendered — wrong app running?")
+        }
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Stage 1: imgui_set on a text input ----
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_set on USER — string value into the input.",
+            target = T_USER,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_USER, value = "Alice")))
+        sleep(1500u)
+
+        // ---- Stage 2: imgui_set on a slider (numeric) ----
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_set on SPEED — numeric value (queues pending_value).",
+            target = T_SPEED,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_SPEED, value = 7)))
+        sleep(1500u)
+
+        // ---- Stage 3: imgui_set on a combo (selected index) ----
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_set on PRESET — combo by selected index.",
+            target = T_PRESET,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_PRESET, value = 2)))
+        sleep(1500u)
+
+        // ---- Stage 4: imgui_click on a button ----
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_click on RUN_BTN — same path the chrome would fire.",
+            target = T_RUN,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_click", JV((target = T_RUN)))
+        sleep(800u)
+        post_command(app, "imgui_click", JV((target = T_RUN)))
+        sleep(800u)
+        post_command(app, "imgui_click", JV((target = T_RUN)))
+        sleep(1500u)
+
+        // ---- Stage 5: imgui_open / imgui_close on a popup ----
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_open / imgui_close — popup open/close from outside.",
+            target = T_RUN,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_open", JV((target = T_POPUP)))
+        sleep(1700u)
+        post_command(app, "imgui_close", JV((target = T_POPUP)))
+        sleep(1500u)
     }
-
-    //! Every target is path-qualified — the window pushes its name.
-    let T_USER   = "DRIVE_WIN/USER"
-    let T_SPEED  = "DRIVE_WIN/SPEED"
-    let T_PRESET = "DRIVE_WIN/PRESET"
-    let T_RUN    = "DRIVE_WIN/RUN_BTN"
-    let T_POPUP  = "DRIVE_WIN/STATUS_POPUP"
-
-    var snap = wait_for_render(app, T_USER, 10.0f)
-    if (snap == null) {
-        panic("{T_USER} never rendered — wrong app running on {BASE_URL}?")
-    }
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- Stage 1: imgui_set on a text input ----
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_set on USER — string value into the input.",
-        target = T_USER,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_USER, value = "Alice")))
-    sleep(1500u)
-
-    // ---- Stage 2: imgui_set on a slider (numeric) ----
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_set on SPEED — numeric value (queues pending_value).",
-        target = T_SPEED,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_SPEED, value = 7)))
-    sleep(1500u)
-
-    // ---- Stage 3: imgui_set on a combo (selected index) ----
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_set on PRESET — combo by selected index.",
-        target = T_PRESET,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_PRESET, value = 2)))
-    sleep(1500u)
-
-    // ---- Stage 4: imgui_click on a button ----
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_click on RUN_BTN — same path the chrome would fire.",
-        target = T_RUN,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_click", JV((target = T_RUN)))
-    sleep(800u)
-    post_command(app, "imgui_click", JV((target = T_RUN)))
-    sleep(800u)
-    post_command(app, "imgui_click", JV((target = T_RUN)))
-    sleep(1500u)
-
-    // ---- Stage 5: imgui_open / imgui_close on a popup ----
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_open / imgui_close — popup open/close from outside.",
-        target = T_RUN,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_open", JV((target = T_POPUP)))
-    sleep(1700u)
-    post_command(app, "imgui_close", JV((target = T_POPUP)))
-    sleep(1500u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_edit_external.das
+++ b/tests/integration/record_edit_external.das
@@ -8,9 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``edit_external_tour.apng`` against an
-//! **already-running** daslang-live hosting
-//! ``examples/tutorial/editing_external.das``.
+//! Driver script: record ``edit_external_tour.apng``. One shell:
+//!
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_edit_external.das
 //!
 //! Walks the boost-v2 external-pointer rail:
 //!   1. edit_slider_float -- drag along bbox
@@ -21,18 +22,8 @@ require daslib/json_boost public
 //!   6. edit_combo -- imgui_set int
 //!   7. edit_slider_angle -- imgui_set radians
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 -- host with cwd = the asset dir:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/editing_external.das
-//!
-//!     # window 2 -- fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_edit_external.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "edit_external_tour.apng"
+//! fps=20 keeps the slider drag + color picker (per-frame deltas defeat
+//! APNG compression at 30 fps) under GitHub's 50 MB asset warning band.
 
 //! Reader pacing locked per skills/recording.md.
 let NARRATE_FRAMES = 240
@@ -58,144 +49,122 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} -- is it running with editing_external.das?")
+    with_recording_app("examples/tutorial/editing_external.das",
+                       "edit_external_tour.apng", 75, 20) $(app) {
+        var snap = wait_for_render(app, "EDITOR_WIN/VOL_SLIDER", 10.0f)
+        if (snap == null) {
+            panic("EDITOR_WIN/VOL_SLIDER never rendered -- wrong app?")
+        }
+
+        let p_count   = widget_center(snap, "EDITOR_WIN/COUNT_INPUT")
+        let p_enabled = widget_center(snap, "EDITOR_WIN/ENABLED_CHECK")
+        let p_pos     = widget_center(snap, "EDITOR_WIN/POS_DRAG")
+        let p_color   = widget_center(snap, "EDITOR_WIN/ACCENT_COLOR")
+        let p_combo   = widget_center(snap, "EDITOR_WIN/QUALITY_COMBO")
+        let p_angle   = widget_center(snap, "EDITOR_WIN/ANGLE_SLIDER")
+
+        //! VOL_SLIDER: drag from 20% -> 75% along its bbox.
+        let vol_bb = widget_bbox(snap, "EDITOR_WIN/VOL_SLIDER")
+        let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
+        let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.20f
+        let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.75f
+
+        //! Initial cursor placement (flips synth_cursor_owned).
+        move_to(app, (400.0f, 360.0f), 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: edit_slider_float drag ----
+        move_to(app, (vol_x0, vol_y), 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "edit_slider_float -- drag updates the external float through safe_addr.",
+            target = "EDITOR_WIN/VOL_SLIDER",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        var slider_events : array<JsonValue?>
+        slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1200, 400)
+        post_command(app, "imgui_mouse_play", JV((events = slider_events)))
+        sleep(uint(2200))
+        sleep(RESULT_MS)
+
+        // ---- Stage 2: edit_input_int focus + type ----
+        move_to(app, p_count, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "edit_input_int -- focus and type into the external int.",
+            target = "EDITOR_WIN/COUNT_INPUT",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        post_command(app, "imgui_focus", JV((target = "EDITOR_WIN/COUNT_INPUT")))
+        sleep(400u)
+        post_command(app, "imgui_key_type", JV((text = "42", total_duration_s = 1.2f)))
+        sleep(RESULT_MS)
+
+        // ---- Stage 3: edit_checkbox click ----
+        move_to(app, p_enabled, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "edit_checkbox -- click toggles the external bool.",
+            target = "EDITOR_WIN/ENABLED_CHECK",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        var check_events : array<JsonValue?>
+        check_events |> click_at(0, p_enabled, 250)
+        post_command(app, "imgui_mouse_play", JV((events = check_events)))
+        sleep(RESULT_MS)
+
+        // ---- Stage 4: edit_drag_float3 via imgui_set ----
+        move_to(app, p_pos, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "edit_drag_float3 -- vector write via imgui_set + unsafe(reinterpret).",
+            target = "EDITOR_WIN/POS_DRAG",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        post_command(app, "imgui_set", JV((target = "EDITOR_WIN/POS_DRAG",
+                                           value = float3(1.5f, 2.5f, 3.5f))))
+        sleep(RESULT_MS)
+
+        // ---- Stage 5: edit_color_edit3 via imgui_set ----
+        move_to(app, p_color, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "edit_color_edit3 -- float3 round-trips into the swatch.",
+            target = "EDITOR_WIN/ACCENT_COLOR",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        post_command(app, "imgui_set", JV((target = "EDITOR_WIN/ACCENT_COLOR",
+                                           value = float3(0.35f, 0.70f, 0.90f))))
+        sleep(RESULT_MS)
+
+        // ---- Stage 6: edit_combo via imgui_set ----
+        move_to(app, p_combo, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "edit_combo -- pick a preset by index (popup item bboxes need a click first).",
+            target = "EDITOR_WIN/QUALITY_COMBO",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        post_command(app, "imgui_set", JV((target = "EDITOR_WIN/QUALITY_COMBO", value = 2)))
+        sleep(RESULT_MS)
+
+        // ---- Stage 7: edit_slider_angle via imgui_set ----
+        move_to(app, p_angle, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "edit_slider_angle -- radians under the hood; UI shows degrees.",
+            target = "EDITOR_WIN/ANGLE_SLIDER",
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        post_command(app, "imgui_set", JV((target = "EDITOR_WIN/ANGLE_SLIDER", value = 1.0f)))
+        sleep(RESULT_MS)
+        sleep(TAIL_MS)
     }
-
-    var snap = wait_for_render(app, "EDITOR_WIN/VOL_SLIDER", 10.0f)
-    if (snap == null) {
-        panic("EDITOR_WIN/VOL_SLIDER never rendered -- wrong app on {BASE_URL}?")
-    }
-
-    let p_count   = widget_center(snap, "EDITOR_WIN/COUNT_INPUT")
-    let p_enabled = widget_center(snap, "EDITOR_WIN/ENABLED_CHECK")
-    let p_pos     = widget_center(snap, "EDITOR_WIN/POS_DRAG")
-    let p_color   = widget_center(snap, "EDITOR_WIN/ACCENT_COLOR")
-    let p_combo   = widget_center(snap, "EDITOR_WIN/QUALITY_COMBO")
-    let p_angle   = widget_center(snap, "EDITOR_WIN/ANGLE_SLIDER")
-
-    //! VOL_SLIDER: drag from 20% -> 75% along its bbox.
-    let vol_bb = widget_bbox(snap, "EDITOR_WIN/VOL_SLIDER")
-    let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
-    let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.20f
-    let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.75f
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    //! fps=20 to keep the APNG under the 7.5-77 MB band -- the slider drag
-    //! + color picker produce per-frame pixel deltas that defeat APNG
-    //! compression at 30 fps.
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 20, max_seconds = 75)))
-
-    //! Initial cursor placement (flips synth_cursor_owned).
-    move_to(app, (400.0f, 360.0f), 600)
-    sleep(SETTLE_MS)
-
-    // ---- Stage 1: edit_slider_float drag ----
-    move_to(app, (vol_x0, vol_y), 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "edit_slider_float -- drag updates the external float through safe_addr.",
-        target = "EDITOR_WIN/VOL_SLIDER",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    var slider_events : array<JsonValue?>
-    slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1200, 400)
-    post_command(app, "imgui_mouse_play", JV((events = slider_events)))
-    sleep(uint(2200))
-    sleep(RESULT_MS)
-
-    // ---- Stage 2: edit_input_int focus + type ----
-    move_to(app, p_count, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "edit_input_int -- focus and type into the external int.",
-        target = "EDITOR_WIN/COUNT_INPUT",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    post_command(app, "imgui_focus", JV((target = "EDITOR_WIN/COUNT_INPUT")))
-    sleep(400u)
-    post_command(app, "imgui_key_type", JV((text = "42", total_duration_s = 1.2f)))
-    sleep(RESULT_MS)
-
-    // ---- Stage 3: edit_checkbox click ----
-    move_to(app, p_enabled, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "edit_checkbox -- click toggles the external bool.",
-        target = "EDITOR_WIN/ENABLED_CHECK",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    var check_events : array<JsonValue?>
-    check_events |> click_at(0, p_enabled, 250)
-    post_command(app, "imgui_mouse_play", JV((events = check_events)))
-    sleep(RESULT_MS)
-
-    // ---- Stage 4: edit_drag_float3 via imgui_set ----
-    move_to(app, p_pos, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "edit_drag_float3 -- vector write via imgui_set + unsafe(reinterpret).",
-        target = "EDITOR_WIN/POS_DRAG",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    post_command(app, "imgui_set", JV((target = "EDITOR_WIN/POS_DRAG",
-                                       value = float3(1.5f, 2.5f, 3.5f))))
-    sleep(RESULT_MS)
-
-    // ---- Stage 5: edit_color_edit3 via imgui_set ----
-    move_to(app, p_color, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "edit_color_edit3 -- float3 round-trips into the swatch.",
-        target = "EDITOR_WIN/ACCENT_COLOR",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    post_command(app, "imgui_set", JV((target = "EDITOR_WIN/ACCENT_COLOR",
-                                       value = float3(0.35f, 0.70f, 0.90f))))
-    sleep(RESULT_MS)
-
-    // ---- Stage 6: edit_combo via imgui_set ----
-    move_to(app, p_combo, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "edit_combo -- pick a preset by index (popup item bboxes need a click first).",
-        target = "EDITOR_WIN/QUALITY_COMBO",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    post_command(app, "imgui_set", JV((target = "EDITOR_WIN/QUALITY_COMBO", value = 2)))
-    sleep(RESULT_MS)
-
-    // ---- Stage 7: edit_slider_angle via imgui_set ----
-    move_to(app, p_angle, 900)
-    sleep(SETTLE_MS)
-    post_command(app, "imgui_narrate", JV((
-        text = "edit_slider_angle -- radians under the hood; UI shows degrees.",
-        target = "EDITOR_WIN/ANGLE_SLIDER",
-        frames = NARRATE_FRAMES
-    )))
-    sleep(READ_MS)
-    post_command(app, "imgui_set", JV((target = "EDITOR_WIN/ANGLE_SLIDER", value = 1.0f)))
-    sleep(RESULT_MS)
-    sleep(TAIL_MS)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_layout.das
+++ b/tests/integration/record_layout.das
@@ -8,21 +8,12 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``layout.apng`` against an **already-running**
-//! daslang-live. Mirrors record_widgets_tour.das.
+//! Driver script: record ``layout.apng``. One shell:
 //!
-//! Workflow (two shells):
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_layout.das
 //!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/layout.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_layout.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "layout.apng"
+//! Mirrors record_widgets_tour.das.
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,122 +32,103 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with layout.das?")
+    with_recording_app("examples/tutorial/layout.das",
+                       "layout.apng", 90) $(app) {
+        //! All boost widgets are nested under ``window(LAYOUT_WIN, ...)`` in
+        //! layout.das, so every registered key is path-prefixed. dock_left and
+        //! split_* helpers also appear in the registry but with bbox=(0,0,0,0)
+        //! (the splitter handle is an InvisibleButton not separately registered —
+        //! see test_layout_helpers.das:115-122 TODO). We narrate against and move
+        //! the cursor to a child button in each helper's pane instead.
+        let T_SIDEBAR     = "LAYOUT_WIN/SIDEBAR"
+        let T_SPLIT_MAIN  = "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN"
+        let T_SPLIT_VERT  = "LAYOUT_WIN/SPLIT_VERT"
+        let T_EXPLORE_BTN = "LAYOUT_WIN/SIDEBAR/EXPLORE_BTN"
+        let T_FILE_A_BTN  = "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN/FILE_A_BTN"
+        let T_CLEAR_BTN   = "LAYOUT_WIN/SPLIT_VERT/CLEAR_BTN"
+
+        var snap = wait_for_render(app, T_EXPLORE_BTN, 10.0f)
+        if (snap == null) {
+            panic("{T_EXPLORE_BTN} never rendered — wrong app running?")
+        }
+        let p_explore = widget_center(snap, T_EXPLORE_BTN)
+        let p_file_a  = widget_center(snap, T_FILE_A_BTN)
+        let p_clear   = widget_center(snap, T_CLEAR_BTN)
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Stage 1: sidebar (dock_left) ----
+        // Narrate against EXPLORE_BTN (a real bbox inside the sidebar) since
+        // dock_left itself has bbox=(0,0,0,0). Cursor moves into the sidebar.
+        post_command(app, "imgui_narrate", JV((
+            text = "dock_left fixes a sidebar to the left edge.",
+            target = T_EXPLORE_BTN,
+            frames = 200
+        )))
+        move_to(app, p_explore)
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_SIDEBAR, value = 260.0f)))
+        sleep(1500u)
+
+        // ---- Stage 2: horizontal splitter (split_h on top half) ----
+        // Re-resolve FILE_A_BTN bbox; SIDEBAR's resize reflowed the panes.
+        // Narrate against FILE_A_BTN (left split pane) — split_h has no bbox.
+        snap = wait_for_render(app, T_FILE_A_BTN, 3.0f)
+        let p_file_a_now = snap != null ? widget_center(snap, T_FILE_A_BTN) : p_file_a
+        post_command(app, "imgui_narrate", JV((
+            text = "split_h slices the top into left + right.",
+            target = T_FILE_A_BTN,
+            frames = 200
+        )))
+        move_to(app, p_file_a_now)
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_SPLIT_MAIN, value = 0.6f)))
+        sleep(1500u)
+
+        // ---- Stage 3: vertical splitter ----
+        // Narrate against CLEAR_BTN (bottom pane) — split_v has no bbox.
+        snap = wait_for_render(app, T_CLEAR_BTN, 3.0f)
+        let p_clear_now = snap != null ? widget_center(snap, T_CLEAR_BTN) : p_clear
+        post_command(app, "imgui_narrate", JV((
+            text = "split_v splits top from bottom.",
+            target = T_CLEAR_BTN,
+            frames = 200
+        )))
+        move_to(app, p_clear_now)
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_SPLIT_VERT, value = 0.45f)))
+        sleep(1500u)
+
+        // ---- Stage 4: click inside sidebar ----
+        snap = wait_for_render(app, T_EXPLORE_BTN, 3.0f)
+        let p_explore_now = snap != null ? widget_center(snap, T_EXPLORE_BTN) : p_explore
+        post_command(app, "imgui_narrate", JV((
+            text = "Each pane clips its widgets cleanly.",
+            target = T_EXPLORE_BTN,
+            frames = 180
+        )))
+        sleep(3500u)
+        var explore_events : array<JsonValue?>
+        explore_events |> click_at(0, p_explore_now)
+        post_command(app, "imgui_mouse_play", JV((events = explore_events)))
+        sleep(1500u)
+
+        // ---- Stage 5: click inside left-split pane (re-resolve bbox; layout shifted) ----
+        snap = wait_for_render(app, T_FILE_A_BTN, 5.0f)
+        let p_file_a_now2 = snap != null ? widget_center(snap, T_FILE_A_BTN) : p_file_a_now
+        post_command(app, "imgui_narrate", JV((
+            text = "Splitters re-flow the panes on every drag.",
+            target = T_FILE_A_BTN,
+            frames = 180
+        )))
+        sleep(3500u)
+        var file_events : array<JsonValue?>
+        file_events |> click_at(0, p_file_a_now2)
+        post_command(app, "imgui_mouse_play", JV((events = file_events)))
+        sleep(1700u)
     }
-
-    //! All boost widgets are nested under ``window(LAYOUT_WIN, ...)`` in
-    //! layout.das, so every registered key is path-prefixed. dock_left and
-    //! split_* helpers also appear in the registry but with bbox=(0,0,0,0)
-    //! (the splitter handle is an InvisibleButton not separately registered —
-    //! see test_layout_helpers.das:115-122 TODO). We narrate against and move
-    //! the cursor to a child button in each helper's pane instead.
-    let T_SIDEBAR     = "LAYOUT_WIN/SIDEBAR"
-    let T_SPLIT_MAIN  = "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN"
-    let T_SPLIT_VERT  = "LAYOUT_WIN/SPLIT_VERT"
-    let T_EXPLORE_BTN = "LAYOUT_WIN/SIDEBAR/EXPLORE_BTN"
-    let T_FILE_A_BTN  = "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN/FILE_A_BTN"
-    let T_CLEAR_BTN   = "LAYOUT_WIN/SPLIT_VERT/CLEAR_BTN"
-
-    var snap = wait_for_render(app, T_EXPLORE_BTN, 10.0f)
-    if (snap == null) {
-        panic("{T_EXPLORE_BTN} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_explore = widget_center(snap, T_EXPLORE_BTN)
-    let p_file_a  = widget_center(snap, T_FILE_A_BTN)
-    let p_clear   = widget_center(snap, T_CLEAR_BTN)
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 90)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- Stage 1: sidebar (dock_left) ----
-    // Narrate against EXPLORE_BTN (a real bbox inside the sidebar) since
-    // dock_left itself has bbox=(0,0,0,0). Cursor moves into the sidebar.
-    post_command(app, "imgui_narrate", JV((
-        text = "dock_left fixes a sidebar to the left edge.",
-        target = T_EXPLORE_BTN,
-        frames = 200
-    )))
-    move_to(app, p_explore)
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_SIDEBAR, value = 260.0f)))
-    sleep(1500u)
-
-    // ---- Stage 2: horizontal splitter (split_h on top half) ----
-    // Re-resolve FILE_A_BTN bbox; SIDEBAR's resize reflowed the panes.
-    // Narrate against FILE_A_BTN (left split pane) — split_h has no bbox.
-    snap = wait_for_render(app, T_FILE_A_BTN, 3.0f)
-    let p_file_a_now = snap != null ? widget_center(snap, T_FILE_A_BTN) : p_file_a
-    post_command(app, "imgui_narrate", JV((
-        text = "split_h slices the top into left + right.",
-        target = T_FILE_A_BTN,
-        frames = 200
-    )))
-    move_to(app, p_file_a_now)
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_SPLIT_MAIN, value = 0.6f)))
-    sleep(1500u)
-
-    // ---- Stage 3: vertical splitter ----
-    // Narrate against CLEAR_BTN (bottom pane) — split_v has no bbox.
-    snap = wait_for_render(app, T_CLEAR_BTN, 3.0f)
-    let p_clear_now = snap != null ? widget_center(snap, T_CLEAR_BTN) : p_clear
-    post_command(app, "imgui_narrate", JV((
-        text = "split_v splits top from bottom.",
-        target = T_CLEAR_BTN,
-        frames = 200
-    )))
-    move_to(app, p_clear_now)
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_SPLIT_VERT, value = 0.45f)))
-    sleep(1500u)
-
-    // ---- Stage 4: click inside sidebar ----
-    snap = wait_for_render(app, T_EXPLORE_BTN, 3.0f)
-    let p_explore_now = snap != null ? widget_center(snap, T_EXPLORE_BTN) : p_explore
-    post_command(app, "imgui_narrate", JV((
-        text = "Each pane clips its widgets cleanly.",
-        target = T_EXPLORE_BTN,
-        frames = 180
-    )))
-    sleep(3500u)
-    var explore_events : array<JsonValue?>
-    explore_events |> click_at(0, p_explore_now)
-    post_command(app, "imgui_mouse_play", JV((events = explore_events)))
-    sleep(1500u)
-
-    // ---- Stage 5: click inside left-split pane (re-resolve bbox; layout shifted) ----
-    snap = wait_for_render(app, T_FILE_A_BTN, 5.0f)
-    let p_file_a_now2 = snap != null ? widget_center(snap, T_FILE_A_BTN) : p_file_a_now
-    post_command(app, "imgui_narrate", JV((
-        text = "Splitters re-flow the panes on every drag.",
-        target = T_FILE_A_BTN,
-        frames = 180
-    )))
-    sleep(3500u)
-    var file_events : array<JsonValue?>
-    file_events |> click_at(0, p_file_a_now2)
-    post_command(app, "imgui_mouse_play", JV((events = file_events)))
-    sleep(1700u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_live_reload.das
+++ b/tests/integration/record_live_reload.das
@@ -8,21 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``live_reload.apng`` against an
-//! **already-running** daslang-live.
+//! Driver script: record ``live_reload.apng``. One shell:
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/live_reload.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_live_reload.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "live_reload.apng"
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_live_reload.das
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,93 +30,74 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with live_reload.das?")
+    with_recording_app("examples/tutorial/live_reload.das",
+                       "live_reload.apng", 60) $(app) {
+        let T_VOLUME = "LIVE_WIN/VOLUME"
+        let T_PING   = "LIVE_WIN/PING_BTN"
+
+        var snap = wait_for_render(app, T_VOLUME, 10.0f)
+        if (snap == null) {
+            panic("{T_VOLUME} never rendered — wrong app running?")
+        }
+        let p_ping   = widget_center(snap, T_PING)
+        let p_volume = widget_center(snap, T_VOLUME)
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Stage 1: VOLUME (@live slider, preserved across reload) ----
+        post_command(app, "imgui_narrate", JV((
+            text = "VOLUME is @live — value preserved across reload.",
+            target = T_VOLUME,
+            frames = 200
+        )))
+        move_to(app, p_volume)
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_VOLUME, value = 0.65f)))
+        sleep(1500u)
+
+        // ---- Stage 2: PING button — ClickState's @live click_count ----
+        post_command(app, "imgui_narrate", JV((
+            text = "PING_BTN.click_count is @live too.",
+            target = T_PING,
+            frames = 200
+        )))
+        move_to(app, p_ping)
+        sleep(3500u)
+        var ping_events : array<JsonValue?>
+        ping_events |> click_at(0, p_ping)
+        post_command(app, "imgui_mouse_play", JV((events = ping_events)))
+        sleep(1200u)
+        var ping_events2 : array<JsonValue?>
+        ping_events2 |> click_at(0, p_ping)
+        post_command(app, "imgui_mouse_play", JV((events = ping_events2)))
+        sleep(1500u)
+
+        // ---- Stage 3: custom [live_command] — bump_counter via curl ----
+        post_command(app, "imgui_narrate", JV((
+            text = "bump_counter is a user-defined [live_command].",
+            target = T_PING,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "bump_counter", JV((by = 1)))
+        sleep(800u)
+        post_command(app, "bump_counter", JV((by = 5)))
+        sleep(800u)
+        post_command(app, "bump_counter", JV((by = 1)))
+        sleep(1500u)
+
+        // ---- Stage 4: reset_counter — same surface, different handler ----
+        post_command(app, "imgui_narrate", JV((
+            text = "reset_counter — same surface, app-defined endpoint.",
+            target = T_PING,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "reset_counter", null)
+        sleep(1500u)
     }
-
-    let T_VOLUME = "LIVE_WIN/VOLUME"
-    let T_PING   = "LIVE_WIN/PING_BTN"
-
-    var snap = wait_for_render(app, T_VOLUME, 10.0f)
-    if (snap == null) {
-        panic("{T_VOLUME} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_ping   = widget_center(snap, T_PING)
-    let p_volume = widget_center(snap, T_VOLUME)
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- Stage 1: VOLUME (@live slider, preserved across reload) ----
-    post_command(app, "imgui_narrate", JV((
-        text = "VOLUME is @live — value preserved across reload.",
-        target = T_VOLUME,
-        frames = 200
-    )))
-    move_to(app, p_volume)
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_VOLUME, value = 0.65f)))
-    sleep(1500u)
-
-    // ---- Stage 2: PING button — ClickState's @live click_count ----
-    post_command(app, "imgui_narrate", JV((
-        text = "PING_BTN.click_count is @live too.",
-        target = T_PING,
-        frames = 200
-    )))
-    move_to(app, p_ping)
-    sleep(3500u)
-    var ping_events : array<JsonValue?>
-    ping_events |> click_at(0, p_ping)
-    post_command(app, "imgui_mouse_play", JV((events = ping_events)))
-    sleep(1200u)
-    var ping_events2 : array<JsonValue?>
-    ping_events2 |> click_at(0, p_ping)
-    post_command(app, "imgui_mouse_play", JV((events = ping_events2)))
-    sleep(1500u)
-
-    // ---- Stage 3: custom [live_command] — bump_counter via curl ----
-    post_command(app, "imgui_narrate", JV((
-        text = "bump_counter is a user-defined [live_command].",
-        target = T_PING,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "bump_counter", JV((by = 1)))
-    sleep(800u)
-    post_command(app, "bump_counter", JV((by = 5)))
-    sleep(800u)
-    post_command(app, "bump_counter", JV((by = 1)))
-    sleep(1500u)
-
-    // ---- Stage 4: reset_counter — same surface, different handler ----
-    post_command(app, "imgui_narrate", JV((
-        text = "reset_counter — same surface, app-defined endpoint.",
-        target = T_PING,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "reset_counter", null)
-    sleep(1500u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_recording.das
+++ b/tests/integration/record_recording.das
@@ -8,22 +8,18 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``recording.apng`` against an
-//! **already-running** daslang-live. This driver is also the tutorial
-//! topic — the RST walks through every line below.
+//! Driver script: record ``recording.apng`` — also the tutorial topic,
+//! the RST walks every line below. One shell:
 //!
-//! Workflow (two shells):
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_recording.das
 //!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/recording.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_recording.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "recording.apng"
+//! :ref:`with_recording_app <function-imgui_playwright_with_recording_app>`
+//! spawns daslang-live on the tutorial, passes ``--imgui-content-scale=1.0``
+//! and ``--no-hdpi-framebuffer`` so capture stays at logical 1x even on
+//! retina, toggles visual aids around the body, posts ``record_start`` /
+//! ``record_stop``, drives shutdown. APNG lands at
+//! ``<dasImgui>/doc/source/_static/tutorials/recording.apng``.
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     //! Pull (x_min, y_min, x_max, y_max) out of the snapshot for one
@@ -48,99 +44,59 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    // ---- 1. Connect to the live host ----
-    // ImguiApp bundles the HTTP transport + base URL into a value the
-    // playwright helpers (post_command, move_to, click_at, ...) all
-    // take as their first arg.
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with recording.das?")
+    with_recording_app("examples/tutorial/recording.das",
+                       "recording.apng", 30) $(app) {
+        // ---- Resolve widget centers from a snapshot ----
+        // wait_for_render polls imgui_snapshot until the named widget
+        // appears (covers the cold-start gap where the subject is up but
+        // the first frame hasn't rendered). 10s timeout is generous.
+        let T_VOLUME = "REC_WIN/VOLUME"
+        let T_SAVE   = "REC_WIN/SAVE_BTN"
+        var snap = wait_for_render(app, T_SAVE, 10.0f)
+        if (snap == null) {
+            panic("{T_SAVE} never rendered — wrong app running?")
+        }
+        let p_volume = widget_center(snap, T_VOLUME)
+        let p_save   = widget_center(snap, T_SAVE)
+
+        // Volume drag: 15% to 80% along the slider's bbox width.
+        let vol_bb = widget_bbox(snap, T_VOLUME)
+        let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
+        let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.15f
+        let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.80f
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Narrate then act — repeat ----
+
+        // Stage 1: slider drag
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_narrate posts a sticky-note over a target.",
+            target = T_VOLUME,
+            frames = 200
+        )))
+        move_to(app, p_volume)
+        sleep(3500u)
+        var slider_events : array<JsonValue?>
+        slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1400)
+        post_command(app, "imgui_mouse_play", JV((events = slider_events)))
+        sleep(2500u)
+
+        // Stage 2: click the button
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_mouse_play feeds a scripted timeline of events.",
+            target = T_SAVE,
+            frames = 200
+        )))
+        move_to(app, p_save)
+        sleep(3500u)
+        var save_events : array<JsonValue?>
+        save_events |> click_at(0, p_save)
+        post_command(app, "imgui_mouse_play", JV((events = save_events)))
+        sleep(1500u)
     }
-
-    // ---- 2. Resolve widget centers from a snapshot ----
-    // wait_for_render polls imgui_snapshot until the named widget
-    // appears (covers the cold-start gap where the subject is up but
-    // first frame hasn't rendered). 10s timeout is generous.
-    let T_VOLUME = "REC_WIN/VOLUME"
-    let T_SAVE   = "REC_WIN/SAVE_BTN"
-    var snap = wait_for_render(app, T_SAVE, 10.0f)
-    if (snap == null) {
-        panic("{T_SAVE} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_volume = widget_center(snap, T_VOLUME)
-    let p_save   = widget_center(snap, T_SAVE)
-
-    // Volume drag: 15% to 80% along the slider's bbox width.
-    let vol_bb = widget_bbox(snap, T_VOLUME)
-    let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
-    let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.15f
-    let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.80f
-
-    // ---- 3. Enable visual aids BEFORE record_start ----
-    // mouse_trail draws the fading line behind the synth cursor;
-    // cursor_sprite draws a visible pointer at io.MousePos so the
-    // recording shows what's clicking what. Enable both first so the
-    // very first frame of the APNG already has the cursor visible.
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-
-    // ---- 4. record_start: opens the APNG writer ----
-    // file lands next to daslang-live's cwd (we set that to
-    // doc/source/_static/tutorials/ in shell 1). max_seconds caps the
-    // recording so a runaway driver doesn't churn disk forever.
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 30)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- 5. Narrate then act — repeat ----
-
-    // Stage 1: slider drag
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_narrate posts a sticky-note over a target.",
-        target = T_VOLUME,
-        frames = 200
-    )))
-    move_to(app, p_volume)
-    sleep(3500u)
-    var slider_events : array<JsonValue?>
-    slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1400)
-    post_command(app, "imgui_mouse_play", JV((events = slider_events)))
-    sleep(2500u)
-
-    // Stage 2: click the button
-    post_command(app, "imgui_narrate", JV((
-        text = "imgui_mouse_play feeds a scripted timeline of events.",
-        target = T_SAVE,
-        frames = 200
-    )))
-    move_to(app, p_save)
-    sleep(3500u)
-    var save_events : array<JsonValue?>
-    save_events |> click_at(0, p_save)
-    post_command(app, "imgui_mouse_play", JV((events = save_events)))
-    sleep(1500u)
-
-    // ---- 6. record_stop: flushes the APNG writer, prints stats ----
-    // The response carries (frames, duration_s, dropped, saved) — a quick
-    // sanity check for the driver author.
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    // ---- 7. Disable visual aids ----
-    // The host stays alive after the driver exits; clean up so the next
-    // driver (or a developer poking at the live host manually) starts
-    // from a clean state.
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_state_telemetry.das
+++ b/tests/integration/record_state_telemetry.das
@@ -8,21 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``state_telemetry.apng`` against an
-//! **already-running** daslang-live.
+//! Driver script: record ``state_telemetry.apng``. One shell:
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/state_telemetry.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_state_telemetry.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "state_telemetry.apng"
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_state_telemetry.das
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,100 +30,81 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with state_telemetry.das?")
+    with_recording_app("examples/tutorial/state_telemetry.das",
+                       "state_telemetry.apng", 60) $(app) {
+        //! Targets are path-qualified — the `window(STATE_WIN, ...)` boost
+        //! container pushes its name onto the registry path.
+        let T_SAVE     = "STATE_WIN/SAVE_BTN"
+        let T_SPEED    = "STATE_WIN/SPEED"
+        let T_VOLUME   = "STATE_WIN/VOLUME"
+        let T_STATUS   = "STATE_WIN/STATUS_TEXT"
+        let T_BUMP     = "STATE_WIN/BUMP_STATUS"
+
+        var snap = wait_for_render(app, T_SAVE, 10.0f)
+        if (snap == null) {
+            panic("{T_SAVE} never rendered — wrong app running?")
+        }
+        let p_save   = widget_center(snap, T_SAVE)
+        let p_bump   = widget_center(snap, T_BUMP)
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Stage 1: auto-emit + click_count ----
+        post_command(app, "imgui_narrate", JV((
+            text = "button(SAVE_BTN, ...) auto-emits the SAVE_BTN global.",
+            target = T_SAVE,
+            frames = 200
+        )))
+        move_to(app, p_save)
+        sleep(3500u)
+        var save_events : array<JsonValue?>
+        save_events |> click_at(0, p_save)
+        post_command(app, "imgui_mouse_play", JV((events = save_events)))
+        sleep(1500u)
+        // second click to make click_count tick visibly
+        var save_events2 : array<JsonValue?>
+        save_events2 |> click_at(0, p_save)
+        post_command(app, "imgui_mouse_play", JV((events = save_events2)))
+        sleep(1500u)
+
+        // ---- Stage 2: dotted flags steer the emitted global ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Dotted flags: SPEED.PUBLIC, VOLUME.NOTLIVE.",
+            target = T_SPEED,
+            frames = 200
+        )))
+        sleep(3500u)
+        // imgui_set drives the slider values without simulating a drag.
+        post_command(app, "imgui_set", JV((target = T_SPEED, value = 7)))
+        sleep(900u)
+        post_command(app, "imgui_set", JV((target = T_VOLUME, value = 0.65f)))
+        sleep(1500u)
+
+        // ---- Stage 3: text_show + imgui_set drives the value from outside ----
+        post_command(app, "imgui_narrate", JV((
+            text = "text_show — app-side value mirrored into the snapshot.",
+            target = T_STATUS,
+            frames = 200
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = T_STATUS, value = "set from outside")))
+        sleep(1500u)
+
+        // ---- Stage 4: bump rewrites STATUS from inside the app ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Bump rewrites STATUS_TEXT.value from inside the app.",
+            target = T_BUMP,
+            frames = 200
+        )))
+        move_to(app, p_bump)
+        sleep(3500u)
+        var bump_events : array<JsonValue?>
+        bump_events |> click_at(0, p_bump)
+        post_command(app, "imgui_mouse_play", JV((events = bump_events)))
+        sleep(2000u)
     }
-
-    //! Targets are path-qualified — the `window(STATE_WIN, ...)` boost
-    //! container pushes its name onto the registry path.
-    let T_SAVE     = "STATE_WIN/SAVE_BTN"
-    let T_SPEED    = "STATE_WIN/SPEED"
-    let T_VOLUME   = "STATE_WIN/VOLUME"
-    let T_STATUS   = "STATE_WIN/STATUS_TEXT"
-    let T_BUMP     = "STATE_WIN/BUMP_STATUS"
-
-    var snap = wait_for_render(app, T_SAVE, 10.0f)
-    if (snap == null) {
-        panic("{T_SAVE} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_save   = widget_center(snap, T_SAVE)
-    let p_bump   = widget_center(snap, T_BUMP)
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- Stage 1: auto-emit + click_count ----
-    post_command(app, "imgui_narrate", JV((
-        text = "button(SAVE_BTN, ...) auto-emits the SAVE_BTN global.",
-        target = T_SAVE,
-        frames = 200
-    )))
-    move_to(app, p_save)
-    sleep(3500u)
-    var save_events : array<JsonValue?>
-    save_events |> click_at(0, p_save)
-    post_command(app, "imgui_mouse_play", JV((events = save_events)))
-    sleep(1500u)
-    // second click to make click_count tick visibly
-    var save_events2 : array<JsonValue?>
-    save_events2 |> click_at(0, p_save)
-    post_command(app, "imgui_mouse_play", JV((events = save_events2)))
-    sleep(1500u)
-
-    // ---- Stage 2: dotted flags steer the emitted global ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Dotted flags: SPEED.PUBLIC, VOLUME.NOTLIVE.",
-        target = T_SPEED,
-        frames = 200
-    )))
-    sleep(3500u)
-    // imgui_set drives the slider values without simulating a drag.
-    post_command(app, "imgui_set", JV((target = T_SPEED, value = 7)))
-    sleep(900u)
-    post_command(app, "imgui_set", JV((target = T_VOLUME, value = 0.65f)))
-    sleep(1500u)
-
-    // ---- Stage 3: text_show + imgui_set drives the value from outside ----
-    post_command(app, "imgui_narrate", JV((
-        text = "text_show — app-side value mirrored into the snapshot.",
-        target = T_STATUS,
-        frames = 200
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = T_STATUS, value = "set from outside")))
-    sleep(1500u)
-
-    // ---- Stage 4: bump rewrites STATUS from inside the app ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Bump rewrites STATUS_TEXT.value from inside the app.",
-        target = T_BUMP,
-        frames = 200
-    )))
-    move_to(app, p_bump)
-    sleep(3500u)
-    var bump_events : array<JsonValue?>
-    bump_events |> click_at(0, p_bump)
-    post_command(app, "imgui_mouse_play", JV((events = bump_events)))
-    sleep(2000u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_visual_aids.das
+++ b/tests/integration/record_visual_aids.das
@@ -8,25 +8,16 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``visual_aids_tour.apng`` against an
-//! **already-running** daslang-live.
+//! Driver script: record ``visual_aids_tour.apng``. One shell:
 //!
-//! Workflow (two shells):
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_visual_aids.das
 //!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/visual_aids_tour.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_visual_aids.das
-//!
-//! The driver enables mouse trail + cursor sprite, sweeps through every
-//! widget's snapshot bbox with a synth click at each, then calls record_stop
-//! to flush the writer cleanly.
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "visual_aids_tour.apng"
+//! Sweeps through every widget's snapshot bbox with a synth click at each,
+//! then runs the keyboard half (key_hud + focus_rect overlays). Body
+//! manages key_hud + focus_rect inline — :ref:`with_recording_app
+//! <function-imgui_playwright_with_recording_app>` only toggles the
+//! mouse_trail + cursor_sprite pair that every driver shares.
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     //! Read globals[ident].bbox (float4 serialized as {x,y,z,w}). float4 below
@@ -77,126 +68,107 @@ def drag_along_local(var events : array<JsonValue?>;
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with visual_aids_tour.das?")
+    with_recording_app("examples/tutorial/visual_aids_tour.das",
+                       "visual_aids_tour.apng", 60) $(app) {
+        // Resolve widget centers from the running app's snapshot — tolerant to
+        // layout drift. SAVE_BTN is the gate: if we can see it we're on the tour.
+        var snap = wait_for_render(app, "SUBJECT_WIN/SAVE_BTN", 10.0f)
+        if (snap == null) {
+            panic("SAVE_BTN never rendered — wrong app running?")
+        }
+        let p_hi_status   = widget_center(snap, "CONTROLS_WIN/BTN_HIGHLIGHT_STATUS")
+        let p_hi_volume   = widget_center(snap, "CONTROLS_WIN/BTN_HIGHLIGHT_VOLUME")
+        let p_hi_save     = widget_center(snap, "CONTROLS_WIN/BTN_HIGHLIGHT_SAVE")
+        let p_narrate_vol  = widget_center(snap, "CONTROLS_WIN/BTN_NARRATE_VOLUME")
+        let p_narrate_save = widget_center(snap, "CONTROLS_WIN/BTN_NARRATE_SAVE")
+        let p_name_input   = widget_center(snap, "SUBJECT_WIN/NAME_INPUT")
+        // Slider drag: from ~20% along VOLUME's bbox to ~85%, vertically centered.
+        let vol_bb = widget_bbox(snap, "SUBJECT_WIN/VOLUME")
+        let vol_y   = (vol_bb.y + vol_bb.w) * 0.5f
+        let vol_x0  = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.20f
+        let vol_x1  = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.85f
+
+        // key_hud + focus_rect are tour-specific overlays for the keyboard half.
+        // The helper already enabled mouse_trail + cursor_sprite for us.
+        post_command(app, "imgui_key_hud",       JV((enabled = true, show_modifiers = true)))
+        post_command(app, "imgui_focus_rect",    JV((enabled = true)))
+
+        // --- Mouse tour ---
+        //   - Click each highlight button (yellow rect appears around target).
+        //   - Drag the VOLUME slider (press → move-while-pressed → release).
+        //   - Click each narrate button (callout box + connector line appears).
+        // Highlights last ~2s by default so a prior highlight is still visible
+        // while we tour the next widget.
+        var events : array<JsonValue?>
+        events |> push(JV((t_ms = 0, kind = "move", x = 40.0f, y = 380.0f)))
+        events |> stop_at(700,  p_hi_status)
+        events |> stop_at(1500, p_hi_volume)
+        events |> stop_at(2300, p_hi_save)
+        events |> drag_along_local(3100, (vol_x0, vol_y), (vol_x1, vol_y), 1000)
+        events |> stop_at(5500, p_narrate_vol)
+        events |> stop_at(6400, p_narrate_save)
+        events |> push(JV((t_ms = 7400, kind = "move", x = 500.0f, y = 300.0f)))
+        post_command(app, "imgui_mouse_play", JV((events = events)))
+
+        // Sleep through the mouse tour. Polling status in a tight loop while the
+        // recorder is grabbing every frame thrashes the host's HTTP handler —
+        // sleep through it instead. Mouse tour ends at ~7.4s + extra buffer so
+        // the last narrate callout / click flash play out fully and the viewer
+        // has a beat to take it in before keyboard tour starts.
+        sleep(9000u)
+
+        // --- Keyboard tour ---
+        // Move cursor visually to NAME_INPUT, then activate via imgui_focus. The
+        // cursor motion gives a visible cue; the SetKeyboardFocusHere path
+        // lights up the focus rect AND establishes the nav state Shortcut() keys
+        // off, so Ctrl+A / Ctrl+Backspace route into the InputText afterward.
+        // (Under the legacy glfw_live driver, synth mouse-clicks dropped the
+        // shortcut-routing path; imgui_live's full bypass + g.InputEventsQueue
+        // purge fixes that, but a focus-via-API activation is still cleaner than
+        // a synth click for tour purposes.)
+        var move_events <- [
+            JV((t_ms = 0,   kind = "move", x = p_name_input._0, y = p_name_input._1)),
+            JV((t_ms = 400, kind = "move", x = p_name_input._0, y = p_name_input._1))
+        ]
+        post_command(app, "imgui_mouse_play", JV((events = move_events)))
+        sleep(800u)
+        post_command(app, "imgui_focus", JV((target = "SUBJECT_WIN/NAME_INPUT")))
+        sleep(400u)
+
+        // Narrate the keyboard half so the viewer knows what's coming.
+        post_command(app, "imgui_narrate", JV((
+            text = "Watch the keycap HUD as we type.",
+            target = "SUBJECT_WIN/NAME_INPUT",
+            frames = 180
+        )))
+        sleep(2200u)
+
+        // Type "Hello, World!" over 4 seconds. Mixed caps + comma + space + bang
+        // exercise auto-Shift around capitals and shifted punctuation, so the
+        // modifier strip should flash amber on H, W, and ! while the keycaps
+        // pop at bottom-center.
+        post_command(app, "imgui_key_type", JV((text = "Hello, World!", total_duration_s = 4.0f)))
+        sleep(4800u)
+
+        // Demonstrate a chord: Ctrl+A. Both Ctrl pill and the "A" keycap pop.
+        post_command(app, "imgui_narrate", JV((
+            text = "Ctrl+A selects all.",
+            target = "SUBJECT_WIN/NAME_INPUT",
+            frames = 150
+        )))
+        sleep(1600u)
+        post_command(app, "imgui_key_chord", JV((mods = ["Ctrl"], key = "A")))
+        sleep(1400u)
+
+        // Clear the field — Backspace once (selection is active, so one press
+        // empties the buffer). "Bksp" appears in the keycap row.
+        let backspace_key = int(ImGuiKey.Backspace)
+        post_command(app, "imgui_key_press",   JV((key = backspace_key)))
+        post_command(app, "imgui_key_release", JV((key = backspace_key)))
+        sleep(1800u)
+
+        // Disable tour-specific overlays — the helper handles trail + sprite.
+        post_command(app, "imgui_key_hud",       JV((enabled = false)))
+        post_command(app, "imgui_focus_rect",    JV((enabled = false)))
     }
-
-    // Resolve widget centers from the running app's snapshot — tolerant to
-    // layout drift. SAVE_BTN is the gate: if we can see it we're on the tour.
-    var snap = wait_for_render(app, "SUBJECT_WIN/SAVE_BTN", 10.0f)
-    if (snap == null) {
-        panic("SAVE_BTN never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_hi_status   = widget_center(snap, "CONTROLS_WIN/BTN_HIGHLIGHT_STATUS")
-    let p_hi_volume   = widget_center(snap, "CONTROLS_WIN/BTN_HIGHLIGHT_VOLUME")
-    let p_hi_save     = widget_center(snap, "CONTROLS_WIN/BTN_HIGHLIGHT_SAVE")
-    let p_narrate_vol  = widget_center(snap, "CONTROLS_WIN/BTN_NARRATE_VOLUME")
-    let p_narrate_save = widget_center(snap, "CONTROLS_WIN/BTN_NARRATE_SAVE")
-    let p_name_input   = widget_center(snap, "SUBJECT_WIN/NAME_INPUT")
-    // Slider drag: from ~20% along VOLUME's bbox to ~85%, vertically centered.
-    let vol_bb = widget_bbox(snap, "SUBJECT_WIN/VOLUME")
-    let vol_y   = (vol_bb.y + vol_bb.w) * 0.5f
-    let vol_x0  = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.20f
-    let vol_x1  = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.85f
-
-    // Visual aids on. mouse_trail draws the synth path; cursor_sprite is the
-    // in-frame cursor pointer; click flash fires on every synth press (button
-    // events live in glfw_live, painter in imgui_visual_aids). key_hud +
-    // focus_rect are new for the keyboard half of the tour.
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "imgui_key_hud",       JV((enabled = true, show_modifiers = true)))
-    post_command(app, "imgui_focus_rect",    JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    // --- Mouse tour ---
-    //   - Click each highlight button (yellow rect appears around target).
-    //   - Drag the VOLUME slider (press → move-while-pressed → release).
-    //   - Click each narrate button (callout box + connector line appears).
-    // Highlights last ~2s by default so a prior highlight is still visible
-    // while we tour the next widget.
-    var events : array<JsonValue?>
-    events |> push(JV((t_ms = 0, kind = "move", x = 40.0f, y = 380.0f)))
-    events |> stop_at(700,  p_hi_status)
-    events |> stop_at(1500, p_hi_volume)
-    events |> stop_at(2300, p_hi_save)
-    events |> drag_along_local(3100, (vol_x0, vol_y), (vol_x1, vol_y), 1000)
-    events |> stop_at(5500, p_narrate_vol)
-    events |> stop_at(6400, p_narrate_save)
-    events |> push(JV((t_ms = 7400, kind = "move", x = 500.0f, y = 300.0f)))
-    post_command(app, "imgui_mouse_play", JV((events = events)))
-
-    // Sleep through the mouse tour. Polling status in a tight loop while the
-    // recorder is grabbing every frame thrashes the host's HTTP handler —
-    // sleep through it instead. Mouse tour ends at ~7.4s + extra buffer so
-    // the last narrate callout / click flash play out fully and the viewer
-    // has a beat to take it in before keyboard tour starts.
-    sleep(9000u)
-
-    // --- Keyboard tour ---
-    // Move cursor visually to NAME_INPUT, then activate via imgui_focus. The
-    // cursor motion gives a visible cue; the SetKeyboardFocusHere path
-    // lights up the focus rect AND establishes the nav state Shortcut() keys
-    // off, so Ctrl+A / Ctrl+Backspace route into the InputText afterward.
-    // (Under the legacy glfw_live driver, synth mouse-clicks dropped the
-    // shortcut-routing path; imgui_live's full bypass + g.InputEventsQueue
-    // purge fixes that, but a focus-via-API activation is still cleaner than
-    // a synth click for tour purposes.)
-    var move_events <- [
-        JV((t_ms = 0,   kind = "move", x = p_name_input._0, y = p_name_input._1)),
-        JV((t_ms = 400, kind = "move", x = p_name_input._0, y = p_name_input._1))
-    ]
-    post_command(app, "imgui_mouse_play", JV((events = move_events)))
-    sleep(800u)
-    post_command(app, "imgui_focus", JV((target = "SUBJECT_WIN/NAME_INPUT")))
-    sleep(400u)
-
-    // Narrate the keyboard half so the viewer knows what's coming.
-    post_command(app, "imgui_narrate", JV((
-        text = "Watch the keycap HUD as we type.",
-        target = "SUBJECT_WIN/NAME_INPUT",
-        frames = 180
-    )))
-    sleep(2200u)
-
-    // Type "Hello, World!" over 4 seconds. Mixed caps + comma + space + bang
-    // exercise auto-Shift around capitals and shifted punctuation, so the
-    // modifier strip should flash amber on H, W, and ! while the keycaps
-    // pop at bottom-center.
-    post_command(app, "imgui_key_type", JV((text = "Hello, World!", total_duration_s = 4.0f)))
-    sleep(4800u)
-
-    // Demonstrate a chord: Ctrl+A. Both Ctrl pill and the "A" keycap pop.
-    post_command(app, "imgui_narrate", JV((
-        text = "Ctrl+A selects all.",
-        target = "SUBJECT_WIN/NAME_INPUT",
-        frames = 150
-    )))
-    sleep(1600u)
-    post_command(app, "imgui_key_chord", JV((mods = ["Ctrl"], key = "A")))
-    sleep(1400u)
-
-    // Clear the field — Backspace once (selection is active, so one press
-    // empties the buffer). "Bksp" appears in the keycap row.
-    let backspace_key = int(ImGuiKey.Backspace)
-    post_command(app, "imgui_key_press",   JV((key = backspace_key)))
-    post_command(app, "imgui_key_release", JV((key = backspace_key)))
-    sleep(1800u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    // Disable overlays so a follow-up session doesn't inherit them.
-    post_command(app, "imgui_key_hud",       JV((enabled = false)))
-    post_command(app, "imgui_focus_rect",    JV((enabled = false)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_widgets_tour.das
+++ b/tests/integration/record_widgets_tour.das
@@ -8,25 +8,13 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``widgets_tour.apng`` against an **already-running**
-//! daslang-live.
+//! Driver script: record ``widgets_tour.apng``. One shell:
 //!
-//! Workflow (two shells):
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_widgets_tour.das
 //!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/widgets_tour.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_widgets_tour.das
-//!
-//! The driver enables mouse trail + cursor sprite, posts a narrate post-it
-//! before each widget, performs a representative interaction, then calls
-//! record_stop to flush the writer cleanly.
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "widgets_tour.apng"
+//! Posts a narrate post-it before each widget, performs a representative
+//! interaction, then exits.
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -45,118 +33,99 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with widgets_tour.das?")
+    with_recording_app("examples/tutorial/widgets_tour.das",
+                       "widgets_tour.apng", 90) $(app) {
+        var snap = wait_for_render(app, "AUDIO_WIN/SAVE_BTN", 10.0f)
+        if (snap == null) {
+            panic("SAVE_BTN never rendered — wrong app running?")
+        }
+        let p_user_name = widget_center(snap, "AUDIO_WIN/USER_NAME")
+        let p_muted     = widget_center(snap, "AUDIO_WIN/MUTED")
+        let p_save      = widget_center(snap, "AUDIO_WIN/SAVE_BTN")
+
+        // VOLUME slider: drag from 15% to 80% along its bbox.
+        let vol_bb = widget_bbox(snap, "AUDIO_WIN/VOLUME")
+        let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
+        let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.15f
+        let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.80f
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Stage 1: text input ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Type your name into the field.",
+            target = "AUDIO_WIN/USER_NAME",
+            frames = 180
+        )))
+        move_to(app, p_user_name)
+        sleep(3500u)
+        post_command(app, "imgui_focus", JV((target = "AUDIO_WIN/USER_NAME")))
+        sleep(400u)
+        post_command(app, "imgui_key_type", JV((text = "Alice", total_duration_s = 2.5f)))
+        sleep(3000u)
+
+        // ---- Stage 2: slider drag ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Drag the slider to set the volume.",
+            target = "AUDIO_WIN/VOLUME",
+            frames = 180
+        )))
+        sleep(3500u)
+        var slider_events : array<JsonValue?>
+        slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1400)
+        post_command(app, "imgui_mouse_play", JV((events = slider_events)))
+        sleep(2500u)
+
+        // ---- Stage 3: checkbox click ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Click to mute.",
+            target = "AUDIO_WIN/MUTED",
+            frames = 180
+        )))
+        sleep(3500u)
+        var muted_events : array<JsonValue?>
+        muted_events |> click_at(0, p_muted)
+        post_command(app, "imgui_mouse_play", JV((events = muted_events)))
+        sleep(1500u)
+
+        // ---- Stage 4: combo via imgui_set ----
+        // Opening a combo + clicking a popup item requires the popup to render
+        // before its bboxes appear in the snapshot. For a tutorial recording the
+        // simpler path is to imgui_set the value while the narrate post-it
+        // explains what just happened.
+        post_command(app, "imgui_narrate", JV((
+            text = "Pick a quality preset.",
+            target = "AUDIO_WIN/QUALITY",
+            frames = 180
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = "AUDIO_WIN/QUALITY", value = 2)))
+        sleep(1500u)
+
+        // ---- Stage 5: color editor via imgui_set ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Tune the accent color.",
+            target = "AUDIO_WIN/TINT",
+            frames = 180
+        )))
+        sleep(3500u)
+        post_command(app, "imgui_set", JV((target = "AUDIO_WIN/TINT", value = float3(0.25f, 0.75f, 0.45f))))
+        sleep(1500u)
+
+        // ---- Stage 6: button click ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Save the settings.",
+            target = "AUDIO_WIN/SAVE_BTN",
+            frames = 180
+        )))
+        sleep(3500u)
+        var save_events : array<JsonValue?>
+        save_events |> click_at(0, p_save)
+        post_command(app, "imgui_mouse_play", JV((events = save_events)))
+        sleep(1800u)
     }
-
-    var snap = wait_for_render(app, "AUDIO_WIN/SAVE_BTN", 10.0f)
-    if (snap == null) {
-        panic("SAVE_BTN never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_user_name = widget_center(snap, "AUDIO_WIN/USER_NAME")
-    let p_muted     = widget_center(snap, "AUDIO_WIN/MUTED")
-    let p_save      = widget_center(snap, "AUDIO_WIN/SAVE_BTN")
-
-    // VOLUME slider: drag from 15% to 80% along its bbox.
-    let vol_bb = widget_bbox(snap, "AUDIO_WIN/VOLUME")
-    let vol_y  = (vol_bb.y + vol_bb.w) * 0.5f
-    let vol_x0 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.15f
-    let vol_x1 = vol_bb.x + (vol_bb.z - vol_bb.x) * 0.80f
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 90)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- Stage 1: text input ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Type your name into the field.",
-        target = "AUDIO_WIN/USER_NAME",
-        frames = 180
-    )))
-    move_to(app, p_user_name)
-    sleep(3500u)
-    post_command(app, "imgui_focus", JV((target = "AUDIO_WIN/USER_NAME")))
-    sleep(400u)
-    post_command(app, "imgui_key_type", JV((text = "Alice", total_duration_s = 2.5f)))
-    sleep(3000u)
-
-    // ---- Stage 2: slider drag ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Drag the slider to set the volume.",
-        target = "AUDIO_WIN/VOLUME",
-        frames = 180
-    )))
-    sleep(3500u)
-    var slider_events : array<JsonValue?>
-    slider_events |> drag_along(0, (vol_x0, vol_y), (vol_x1, vol_y), 1400)
-    post_command(app, "imgui_mouse_play", JV((events = slider_events)))
-    sleep(2500u)
-
-    // ---- Stage 3: checkbox click ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Click to mute.",
-        target = "AUDIO_WIN/MUTED",
-        frames = 180
-    )))
-    sleep(3500u)
-    var muted_events : array<JsonValue?>
-    muted_events |> click_at(0, p_muted)
-    post_command(app, "imgui_mouse_play", JV((events = muted_events)))
-    sleep(1500u)
-
-    // ---- Stage 4: combo via imgui_set ----
-    // Opening a combo + clicking a popup item requires the popup to render
-    // before its bboxes appear in the snapshot. For a tutorial recording the
-    // simpler path is to imgui_set the value while the narrate post-it
-    // explains what just happened.
-    post_command(app, "imgui_narrate", JV((
-        text = "Pick a quality preset.",
-        target = "AUDIO_WIN/QUALITY",
-        frames = 180
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = "AUDIO_WIN/QUALITY", value = 2)))
-    sleep(1500u)
-
-    // ---- Stage 5: color editor via imgui_set ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Tune the accent color.",
-        target = "AUDIO_WIN/TINT",
-        frames = 180
-    )))
-    sleep(3500u)
-    post_command(app, "imgui_set", JV((target = "AUDIO_WIN/TINT", value = float3(0.25f, 0.75f, 0.45f))))
-    sleep(1500u)
-
-    // ---- Stage 6: button click ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Save the settings.",
-        target = "AUDIO_WIN/SAVE_BTN",
-        frames = 180
-    )))
-    sleep(3500u)
-    var save_events : array<JsonValue?>
-    save_events |> click_at(0, p_save)
-    post_command(app, "imgui_mouse_play", JV((events = save_events)))
-    sleep(1800u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_with_id.das
+++ b/tests/integration/record_with_id.das
@@ -8,21 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``with_id.apng`` against an **already-running**
-//! daslang-live.
+//! Driver script: record ``with_id.apng``. One shell:
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/with_id.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_with_id.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "with_id.apng"
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_with_id.das
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,119 +30,100 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with with_id.das?")
+    with_recording_app("examples/tutorial/with_id.das",
+                       "with_id.apng", 60) $(app) {
+        //! Targets are path-qualified — the `window(ID_WIN, ...)` boost
+        //! container pushes its name, and `with_id("…")` adds further segments.
+        let T_SAVE_A      = "ID_WIN/section_a/SAVE_BTN"
+        let T_SAVE_B      = "ID_WIN/section_b/SAVE_BTN"
+        let T_NESTED      = "ID_WIN/outer/inner/NESTED_BTN"
+        let T_HASHED      = "ID_WIN/HASHED_BTN"
+        let T_RPS_PATH    = "ID_WIN/rps_stable"
+
+        var snap = wait_for_render(app, T_SAVE_A, 10.0f)
+        if (snap == null) {
+            panic("{T_SAVE_A} never rendered — wrong app running?")
+        }
+        let p_save_a  = widget_center(snap, T_SAVE_A)
+        let p_save_b  = widget_center(snap, T_SAVE_B)
+        let p_nested  = widget_center(snap, T_NESTED)
+        let p_hashed  = widget_center(snap, T_HASHED)
+        let p_rps     = widget_center(snap, T_RPS_PATH)
+
+        //! Slider drag (path= demo): drag from 15% to 75% along the slider bbox.
+        let rps_bb = widget_bbox(snap, T_RPS_PATH)
+        let rps_y  = (rps_bb.y + rps_bb.w) * 0.5f
+        let rps_x0 = rps_bb.x + (rps_bb.z - rps_bb.x) * 0.15f
+        let rps_x1 = rps_bb.x + (rps_bb.z - rps_bb.x) * 0.75f
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms result dwell after the action.
+
+        // ---- Stage 1: two scopes, same widget identifier ----
+        post_command(app, "imgui_narrate", JV((
+            text = "with_id scopes a render — same SAVE_BTN, two paths.",
+            target = T_SAVE_A,
+            frames = 180
+        )))
+        move_to(app, p_save_a)
+        sleep(3500u)
+        var save_a_events : array<JsonValue?>
+        save_a_events |> click_at(0, p_save_a)
+        post_command(app, "imgui_mouse_play", JV((events = save_a_events)))
+        sleep(1500u)
+
+        post_command(app, "imgui_narrate", JV((
+            text = "section_b path → distinct ImGui hash + own click count slot.",
+            target = T_SAVE_B,
+            frames = 180
+        )))
+        move_to(app, p_save_b)
+        sleep(3500u)
+        var save_b_events : array<JsonValue?>
+        save_b_events |> click_at(0, p_save_b)
+        post_command(app, "imgui_mouse_play", JV((events = save_b_events)))
+        sleep(1500u)
+
+        // ---- Stage 2: nested with_id chain ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Nested with_id — segments join with /.",
+            target = T_NESTED,
+            frames = 200
+        )))
+        move_to(app, p_nested)
+        sleep(3500u)
+        var nested_events : array<JsonValue?>
+        nested_events |> click_at(0, p_nested)
+        post_command(app, "imgui_mouse_play", JV((events = nested_events)))
+        sleep(1500u)
+
+        // ---- Stage 3: id= per-call sugar ----
+        post_command(app, "imgui_narrate", JV((
+            text = "id= mangles the ImGui hash; telemetry path unchanged.",
+            target = T_HASHED,
+            frames = 200
+        )))
+        move_to(app, p_hashed)
+        sleep(3500u)
+        var hashed_events : array<JsonValue?>
+        hashed_events |> click_at(0, p_hashed)
+        post_command(app, "imgui_mouse_play", JV((events = hashed_events)))
+        sleep(1500u)
+
+        // ---- Stage 4: path= per-call sugar ----
+        post_command(app, "imgui_narrate", JV((
+            text = "path= replaces the registry path leaf.",
+            target = T_RPS_PATH,
+            frames = 200
+        )))
+        move_to(app, p_rps)
+        sleep(3500u)
+        var rps_events : array<JsonValue?>
+        rps_events |> drag_along(0, (rps_x0, rps_y), (rps_x1, rps_y), 1400)
+        post_command(app, "imgui_mouse_play", JV((events = rps_events)))
+        sleep(2000u)
     }
-
-    //! Targets are path-qualified — the `window(ID_WIN, ...)` boost
-    //! container pushes its name, and `with_id("…")` adds further segments.
-    let T_SAVE_A      = "ID_WIN/section_a/SAVE_BTN"
-    let T_SAVE_B      = "ID_WIN/section_b/SAVE_BTN"
-    let T_NESTED      = "ID_WIN/outer/inner/NESTED_BTN"
-    let T_HASHED      = "ID_WIN/HASHED_BTN"
-    let T_RPS_PATH    = "ID_WIN/rps_stable"
-
-    var snap = wait_for_render(app, T_SAVE_A, 10.0f)
-    if (snap == null) {
-        panic("{T_SAVE_A} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_save_a  = widget_center(snap, T_SAVE_A)
-    let p_save_b  = widget_center(snap, T_SAVE_B)
-    let p_nested  = widget_center(snap, T_NESTED)
-    let p_hashed  = widget_center(snap, T_HASHED)
-    let p_rps     = widget_center(snap, T_RPS_PATH)
-
-    //! Slider drag (path= demo): drag from 15% to 75% along the slider bbox.
-    let rps_bb = widget_bbox(snap, T_RPS_PATH)
-    let rps_y  = (rps_bb.y + rps_bb.w) * 0.5f
-    let rps_x0 = rps_bb.x + (rps_bb.z - rps_bb.x) * 0.15f
-    let rps_x1 = rps_bb.x + (rps_bb.z - rps_bb.x) * 0.75f
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms result dwell after the action.
-
-    // ---- Stage 1: two scopes, same widget identifier ----
-    post_command(app, "imgui_narrate", JV((
-        text = "with_id scopes a render — same SAVE_BTN, two paths.",
-        target = T_SAVE_A,
-        frames = 180
-    )))
-    move_to(app, p_save_a)
-    sleep(3500u)
-    var save_a_events : array<JsonValue?>
-    save_a_events |> click_at(0, p_save_a)
-    post_command(app, "imgui_mouse_play", JV((events = save_a_events)))
-    sleep(1500u)
-
-    post_command(app, "imgui_narrate", JV((
-        text = "section_b path → distinct ImGui hash + own click count slot.",
-        target = T_SAVE_B,
-        frames = 180
-    )))
-    move_to(app, p_save_b)
-    sleep(3500u)
-    var save_b_events : array<JsonValue?>
-    save_b_events |> click_at(0, p_save_b)
-    post_command(app, "imgui_mouse_play", JV((events = save_b_events)))
-    sleep(1500u)
-
-    // ---- Stage 2: nested with_id chain ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Nested with_id — segments join with /.",
-        target = T_NESTED,
-        frames = 200
-    )))
-    move_to(app, p_nested)
-    sleep(3500u)
-    var nested_events : array<JsonValue?>
-    nested_events |> click_at(0, p_nested)
-    post_command(app, "imgui_mouse_play", JV((events = nested_events)))
-    sleep(1500u)
-
-    // ---- Stage 3: id= per-call sugar ----
-    post_command(app, "imgui_narrate", JV((
-        text = "id= mangles the ImGui hash; telemetry path unchanged.",
-        target = T_HASHED,
-        frames = 200
-    )))
-    move_to(app, p_hashed)
-    sleep(3500u)
-    var hashed_events : array<JsonValue?>
-    hashed_events |> click_at(0, p_hashed)
-    post_command(app, "imgui_mouse_play", JV((events = hashed_events)))
-    sleep(1500u)
-
-    // ---- Stage 4: path= per-call sugar ----
-    post_command(app, "imgui_narrate", JV((
-        text = "path= replaces the registry path leaf.",
-        target = T_RPS_PATH,
-        frames = 200
-    )))
-    move_to(app, p_rps)
-    sleep(3500u)
-    var rps_events : array<JsonValue?>
-    rps_events |> drag_along(0, (rps_x0, rps_y), (rps_x1, rps_y), 1400)
-    post_command(app, "imgui_mouse_play", JV((events = rps_events)))
-    sleep(2000u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/tests/integration/record_with_style.das
+++ b/tests/integration/record_with_style.das
@@ -8,21 +8,10 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Driver script: record ``with_style.apng`` against an **already-running**
-//! daslang-live.
+//! Driver script: record ``with_style.apng``. One shell:
 //!
-//! Workflow (two shells):
-//!
-//!     # window 1 — host with cwd = the asset dir so the APNG lands there:
-//!     cd modules/dasImgui/doc/source/_static/tutorials
-//!     ../../../../../../bin/Release/daslang-live.exe \
-//!         ../../../../examples/tutorial/with_style.das
-//!
-//!     # window 2 — fire the driver, exits when done:
-//!     bin/Release/daslang.exe modules/dasImgui/tests/integration/record_with_style.das
-
-let BASE_URL = "http://127.0.0.1:9090"
-let OUTPUT   = "with_style.apng"
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_with_style.das
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -41,84 +30,65 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 
 [export]
 def main {
-    let app = ImguiApp(
-        base_url = BASE_URL,
-        feature_path = "",
-        transport <- live_api_transport(BASE_URL)
-    )
-    print("[record] connecting to {BASE_URL}\n")
-    if (!wait_until_ready(app, 5.0f)) {
-        panic("daslang-live not responding on {BASE_URL} — is it running with with_style.das?")
+    with_recording_app("examples/tutorial/with_style.das",
+                       "with_style.apng", 60) $(app) {
+        //! Targets are path-qualified — the `window(STYLE_WIN, ...)` boost
+        //! container pushes its name onto the registry path.
+        let T_STYLED        = "STYLE_WIN/STYLED_BTN"
+        let T_NESTED_STYLED = "STYLE_WIN/NESTED_STYLED_BTN"
+        let T_UNSTYLED      = "STYLE_WIN/UNSTYLED_BTN"
+
+        var snap = wait_for_render(app, T_STYLED, 10.0f)
+        if (snap == null) {
+            panic("{T_STYLED} never rendered — wrong app running?")
+        }
+        let p_styled        = widget_center(snap, T_STYLED)
+        let p_nested_styled = widget_center(snap, T_NESTED_STYLED)
+        let p_unstyled      = widget_center(snap, T_UNSTYLED)
+
+        //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
+        //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
+        //!     frames = 180   →  3.0s visible
+        //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
+        //! Then ~1500ms for the actual interaction (click / drag / dwell).
+
+        // ---- Stage 1: mixed color + var in one block ----
+        post_command(app, "imgui_narrate", JV((
+            text = "with_style pushes color + style-var as one block.",
+            target = T_STYLED,
+            frames = 180
+        )))
+        move_to(app, p_styled)
+        sleep(3500u)
+        var styled_events : array<JsonValue?>
+        styled_events |> click_at(0, p_styled)
+        post_command(app, "imgui_mouse_play", JV((events = styled_events)))
+        sleep(1500u)
+
+        // ---- Stage 2: nested with_style — inner stacks on outer ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Nested with_style — inner additions stack on outer.",
+            target = T_NESTED_STYLED,
+            frames = 180
+        )))
+        move_to(app, p_nested_styled)
+        sleep(3500u)
+        var nested_events : array<JsonValue?>
+        nested_events |> click_at(0, p_nested_styled)
+        post_command(app, "imgui_mouse_play", JV((events = nested_events)))
+        sleep(1500u)
+
+        // ---- Stage 3: pop balance — baseline restored ----
+        post_command(app, "imgui_narrate", JV((
+            text = "After the block — baseline style is restored.",
+            target = T_UNSTYLED,
+            frames = 180
+        )))
+        move_to(app, p_unstyled)
+        sleep(3500u)
+        var unstyled_events : array<JsonValue?>
+        unstyled_events |> click_at(0, p_unstyled)
+        post_command(app, "imgui_mouse_play", JV((events = unstyled_events)))
+        sleep(1700u)
     }
-
-    //! Targets are path-qualified — the `window(STYLE_WIN, ...)` boost
-    //! container pushes its name onto the registry path.
-    let T_STYLED        = "STYLE_WIN/STYLED_BTN"
-    let T_NESTED_STYLED = "STYLE_WIN/NESTED_STYLED_BTN"
-    let T_UNSTYLED      = "STYLE_WIN/UNSTYLED_BTN"
-
-    var snap = wait_for_render(app, T_STYLED, 10.0f)
-    if (snap == null) {
-        panic("{T_STYLED} never rendered — wrong app running on {BASE_URL}?")
-    }
-    let p_styled        = widget_center(snap, T_STYLED)
-    let p_nested_styled = widget_center(snap, T_NESTED_STYLED)
-    let p_unstyled      = widget_center(snap, T_UNSTYLED)
-
-    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
-    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
-    post_command(app, "record_start", JV((file = OUTPUT, fps = 30, max_seconds = 60)))
-
-    //! Pacing rule (LOCKED): `frames` is the app's frame counter (60 fps
-    //! under vsync), NOT the recorder's fps. For ~3s readable narrate:
-    //!     frames = 180   →  3.0s visible
-    //!     sleep  = 3500u →  narrate disappears with ~500ms gap before next
-    //! Then ~1500ms for the actual interaction (click / drag / dwell).
-
-    // ---- Stage 1: mixed color + var in one block ----
-    post_command(app, "imgui_narrate", JV((
-        text = "with_style pushes color + style-var as one block.",
-        target = T_STYLED,
-        frames = 180
-    )))
-    move_to(app, p_styled)
-    sleep(3500u)
-    var styled_events : array<JsonValue?>
-    styled_events |> click_at(0, p_styled)
-    post_command(app, "imgui_mouse_play", JV((events = styled_events)))
-    sleep(1500u)
-
-    // ---- Stage 2: nested with_style — inner stacks on outer ----
-    post_command(app, "imgui_narrate", JV((
-        text = "Nested with_style — inner additions stack on outer.",
-        target = T_NESTED_STYLED,
-        frames = 180
-    )))
-    move_to(app, p_nested_styled)
-    sleep(3500u)
-    var nested_events : array<JsonValue?>
-    nested_events |> click_at(0, p_nested_styled)
-    post_command(app, "imgui_mouse_play", JV((events = nested_events)))
-    sleep(1500u)
-
-    // ---- Stage 3: pop balance — baseline restored ----
-    post_command(app, "imgui_narrate", JV((
-        text = "After the block — baseline style is restored.",
-        target = T_UNSTYLED,
-        frames = 180
-    )))
-    move_to(app, p_unstyled)
-    sleep(3500u)
-    var unstyled_events : array<JsonValue?>
-    unstyled_events |> click_at(0, p_unstyled)
-    post_command(app, "imgui_mouse_play", JV((events = unstyled_events)))
-    sleep(1700u)
-
-    let stopped = post_command(app, "record_stop", null)
-    let stop_dump = stopped != null ? write_json(stopped) : "<null>"
-    print("[record] record_stop -> {stop_dump}\n")
-    print("[record] APNG saved to {OUTPUT} (next to daslang-live's CWD)\n")
-
-    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
-    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
 }

--- a/widgets/imgui_live.das
+++ b/widgets/imgui_live.das
@@ -13,10 +13,12 @@ require imgui public
 require imgui_app
 require glfw/glfw_boost
 require daslib/archive
+require daslib/clargs
 require daslib/safe_addr
 require live/live_commands
 require live_host
 require math
+require strings
 require imgui/imgui_live_core public
 require imgui/imgui_theme_daslang
 
@@ -29,19 +31,43 @@ var public live_imgui_ctx : ImGuiContext?
 //! Set once inside :ref:`live_imgui_init <function-imgui_live_live_imgui_init>`
 //! (windowed path); stays at 1.0 in headless mode. User code can read this
 //! to scale custom drawing — line widths, viewport math, etc.
+//!
+//! Override at init by passing ``--imgui-content-scale=<float>`` after the
+//! daslang ``--`` separator. Used by :ref:`with_recording_app
+//! <function-imgui_playwright_with_recording_app>` to force 1x so APNG
+//! captures stay small and encoder-friendly even on retina.
 var public live_imgui_content_scale : float = 1.0f
+
+// Lazy CLI-flag cache. `--imgui-content-scale=<float>` after `--` overrides
+// the GLFW content-scale query in live_imgui_init. Mirrors the pattern in
+// widgets/imgui_harness.das:86-101 (ensure_parsed for --headless family).
+var private g_scale_parsed   : bool  = false
+var private g_scale_override : float = 0.0f
+
+def private ensure_scale_parsed() {
+    return if (g_scale_parsed)
+    g_scale_parsed = true
+    let args <- get_user_args()
+    let raw = find_flag_raw_value(args, "--imgui-content-scale")
+    g_scale_override = to_float(raw |> unwrap_or("0"))
+}
 
 def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#version 330") : ImGuiContext? {
     //! Idempotent ImGui context create + backend init; safe across reload (reuses preserved ctx).
-    //! Reads the window's content scale, loads JetBrains Mono at ``14 * scale`` px,
-    //! applies the daslang theme, and calls ``ScaleAllSizes(scale)`` so paddings/
-    //! spacings/rounding match the display. Call from your script's ``init()``.
+    //! Picks content scale: ``--imgui-content-scale=<float>`` override wins;
+    //! otherwise queries ``glfwGetWindowContentScale``. Loads JetBrains Mono at
+    //! ``14 * scale`` px, applies the daslang theme, and calls
+    //! ``ScaleAllSizes(scale)`` so paddings/spacings/rounding match the display.
+    //! Call from your script's ``init()``.
     if (live_imgui_ctx != null) {
         SetCurrentContext(live_imgui_ctx)
         return live_imgui_ctx
     }
     live_imgui_ctx = CreateContext(null)
-    if (window != null) {
+    ensure_scale_parsed()
+    if (g_scale_override > 0.0f) {
+        live_imgui_content_scale = max(g_scale_override, 1.0f)
+    } elif (window != null) {
         var xs = 1.0f
         var ys = 1.0f
         glfwGetWindowContentScale(window, safe_addr(xs), safe_addr(ys))

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -12,6 +12,7 @@ require daslib/json_boost public
 require daslib/fio public
 require daslib/command_line
 require daslib/clargs
+require daslib/module_path
 require daslib/strings_boost
 require strings
 
@@ -570,6 +571,100 @@ def public with_imgui_app_opt(feature_path : string;
     }))
     if (unready) {
         panic("daslang-live not ready after {ready_timeout_sec}s.\nstdout/stderr:\n{captured}")
+    }
+    if (exit_code == popen_timed_out) {
+        panic("daslang-live timed out (>{test_timeout_sec}s).\nstdout/stderr:\n{captured}")
+    }
+    if (exit_code != 0) {
+        panic("daslang-live exited non-zero ({exit_code}).\nstdout/stderr:\n{captured}")
+    }
+}
+
+// ===== Recording helper =====
+
+let private RECORD_ASSET_REL = "doc/source/_static/tutorials"
+let private RECORD_FPS = 30
+
+def public with_recording_app(feature_path : string;
+                              output_apng_basename : string;
+                              max_seconds : int;
+                              body : block<(app : ImguiApp) : void>) {
+    //! Spawn ``daslang-live <feature_path>`` at logical 1x (passes
+    //! ``--imgui-content-scale=1.0`` after ``--`` so APNGs stay
+    //! encoder-friendly even on retina), toggle visual aids, post
+    //! ``record_start``, run ``body`` for the narrate/click/drag timeline,
+    //! then ``record_stop`` / ``/shutdown`` / drain. APNG lands at
+    //! ``<dasImgui>/doc/source/_static/tutorials/<output_apng_basename>``
+    //! regardless of caller cwd. Forwards ``-project_root`` from the
+    //! driver's own argv so the source-repo recording workflow survives
+    //! (``skills/recording.md``). Panics on non-zero exit / readiness or
+    //! test timeout so the recording driver fails loudly.
+    let exe = daslang_live_exe()
+    // Resolve feature_path against dasImgui root (where examples/tutorial/
+    // and examples/features/ actually live), NOT the daScript root that
+    // resolve_feature_path uses. Same idiom as
+    // widgets/imgui_theme_daslang.das:155 (font path resolution).
+    let dasimgui_root = dir_name(get_this_module_dir())
+    var app_path = feature_path
+    if (!is_absolute(app_path)) {
+        app_path = path_join(dasimgui_root, app_path)
+    }
+    let asset_dir = path_join(dasimgui_root, RECORD_ASSET_REL)
+    let output_apng_path = path_join(asset_dir, output_apng_basename)
+
+    var argv <- [exe]
+    // Forward -project_root if the driver received it (source-repo
+    // workflow: APNGs land under the source repo's asset dir, not the
+    // daspkg-installed copy under daScript/modules/).
+    let user_args <- get_user_args()
+    let pr = find_flag_raw_value(user_args, "-project_root") |> unwrap_or("")
+    if (!empty(pr)) {
+        argv |> push("-project_root")
+        argv |> push(pr)
+    }
+    argv |> push(app_path)
+    argv |> push("--")
+    argv |> push("--imgui-content-scale=1.0")
+    // Ask glfw_live to skip the HDPI backing on retina / Windows DPI so the
+    // framebuffer (and the APNG capture that reads it via glReadPixels) match
+    // the requested logical size. Without this, captures stay at physical 2x
+    // even when the style is 1x — UI is small inside a big frame.
+    argv |> push("--no-hdpi-framebuffer")
+
+    let base_url = "http://127.0.0.1:{DEFAULT_LIVE_PORT}"
+    var app = ImguiApp(base_url = base_url,
+                       feature_path = app_path,
+                       transport <- live_api_transport(base_url))
+    var captured : string
+    var unready  = false
+    // Body must complete within max_seconds + ready/shutdown headroom.
+    let test_timeout_sec = float(max_seconds) + 30.0f
+    let exit_code = unsafe(popen_argv(argv, test_timeout_sec, $(f) {
+        return if (f == null)
+        if (!wait_until_ready(app, DEFAULT_READY_TIMEOUT_SEC)) {
+            unready = true
+            captured = unsafe(fread_to_eof(f))
+            return
+        }
+        post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
+        post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
+        post_command(app, "record_start", JV((
+            file = output_apng_path,
+            fps = RECORD_FPS,
+            max_seconds = max_seconds
+        )))
+        invoke(body, app)
+        let stopped = post_command(app, "record_stop", null)
+        let dump = stopped != null ? write_json(stopped) : "<null>"
+        print("[record] record_stop -> {dump}\n")
+        print("[record] APNG saved to {output_apng_path}\n")
+        post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
+        post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
+        post_signal(app, "/shutdown")
+        captured = unsafe(fread_to_eof(f))
+    }))
+    if (unready) {
+        panic("daslang-live not ready after {DEFAULT_READY_TIMEOUT_SEC}s.\nstdout/stderr:\n{captured}")
     }
     if (exit_code == popen_timed_out) {
         panic("daslang-live timed out (>{test_timeout_sec}s).\nstdout/stderr:\n{captured}")

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -583,22 +583,40 @@ def public with_imgui_app_opt(feature_path : string;
 // ===== Recording helper =====
 
 let private RECORD_ASSET_REL = "doc/source/_static/tutorials"
-let private RECORD_FPS = 30
+let private RECORD_FPS_DEFAULT = 30
 
 def public with_recording_app(feature_path : string;
                               output_apng_basename : string;
                               max_seconds : int;
                               body : block<(app : ImguiApp) : void>) {
+    //! 30 fps form (the common case). Delegates to the 4-arg overload —
+    //! daslang's gen2 trailing-block sugar can't see through a default
+    //! parameter sitting between the last positional and the block, so
+    //! the overload pair keeps the common call site clean.
+    with_recording_app(feature_path, output_apng_basename, max_seconds, RECORD_FPS_DEFAULT, body)
+}
+
+def public with_recording_app(feature_path : string;
+                              output_apng_basename : string;
+                              max_seconds : int;
+                              fps : int;
+                              body : block<(app : ImguiApp) : void>) {
     //! Spawn ``daslang-live <feature_path>`` at logical 1x (passes
-    //! ``--imgui-content-scale=1.0`` after ``--`` so APNGs stay
-    //! encoder-friendly even on retina), toggle visual aids, post
-    //! ``record_start``, run ``body`` for the narrate/click/drag timeline,
-    //! then ``record_stop`` / ``/shutdown`` / drain. APNG lands at
+    //! ``--imgui-content-scale=1.0`` + ``--no-hdpi-framebuffer`` after
+    //! ``--`` so the framebuffer + ImGui style both stay at logical
+    //! resolution, keeping APNGs encoder-friendly even on retina), toggle
+    //! visual aids, post ``record_start``, run ``body`` for the
+    //! narrate/click/drag timeline, then ``record_stop`` / ``/shutdown`` /
+    //! drain. APNG lands at
     //! ``<dasImgui>/doc/source/_static/tutorials/<output_apng_basename>``
     //! regardless of caller cwd. Forwards ``-project_root`` from the
     //! driver's own argv so the source-repo recording workflow survives
-    //! (``skills/recording.md``). Panics on non-zero exit / readiness or
-    //! test timeout so the recording driver fails loudly.
+    //! (``skills/recording.md``). ``fps`` defaults to 30; pass a smaller
+    //! value for long-running recordings where file size matters more
+    //! than smoothness (the narrative_layout / edit_external tours run
+    //! at 20 to stay under GitHub's 50 MB asset warning). Panics on
+    //! non-zero exit / readiness or test timeout so the recording
+    //! driver fails loudly.
     let exe = daslang_live_exe()
     // Resolve feature_path against dasImgui root (where examples/tutorial/
     // and examples/features/ actually live), NOT the daScript root that
@@ -650,7 +668,7 @@ def public with_recording_app(feature_path : string;
         post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
         post_command(app, "record_start", JV((
             file = output_apng_path,
-            fps = RECORD_FPS,
+            fps = fps,
             max_seconds = max_seconds
         )))
         invoke(body, app)


### PR DESCRIPTION
## Summary

Collapses the two-shell APNG recording workflow (`shell 1: daslang-live tutorial.das` + `shell 2: daslang record_xxx.das`) into one shell. The driver spawns its own daslang-live host via a new `with_recording_app` helper modeled on the existing `with_imgui_app_opt`. The helper passes two flags after the daslang `--` separator so the recording host renders at logical 1x even on retina (small APNGs, encoder keeps up):

- `--imgui-content-scale=1.0` — `live_imgui_init` styles ImGui at 1x
- `--no-hdpi-framebuffer` — `live_create_window` opens window at 1:1 framebuffer (consumed by daScript-side `glfw_live`, see companion PR GaijinEntertainment/daScript#TBD)

Tutorials run by users directly (no driver, no flags) keep native HDPI.

5 commits:

1. **`49dca95` imgui_live: --imgui-content-scale CLI flag** — lazy-parsed `get_user_args()` check in `live_imgui_init`; flag wins over GLFW content-scale query.
2. **`40c4459` with_recording_app helper + Batch A driver** — `widgets/imgui_playwright.das` gains the helper; `record_boost_basics.das` refactored as shakedown.
3. **`f7d08ea` Batch B (7 drivers) + fps overload** — `record_recording`, `record_boost_narrative_layout` (PR #41 body preserved), `record_containers`, `record_docking`, `record_drag_drop` (PR #41 body preserved), `record_layout`, `record_state_telemetry`. The helper gains a 4-arg fps overload (default 30; two drivers use 20 to stay under GitHub's 50 MB asset warning band).
4. **`ad5e996` Batch C (8 drivers) — outliers + standard** — `record_visual_aids` (keeps local `stop_at` / `drag_along_local`; body inline-manages `key_hud` + `focus_rect`), `record_driving_outside` (no widget bbox lookups, L2/L3 commands only), `record_edit_external` (PR #41 body preserved, fps=20), `record_custom_widgets`, `record_live_reload`, `record_widgets_tour`, `record_with_id`, `record_with_style`.
5. **`fa9f50e` docs** — `skills/recording.md`, the `recording.das` tutorial header docstring, and `doc/source/tutorials/recording.rst` rewritten for the one-shell flow.

Net: 16 drivers refactored, helper added, ~1100 LoC of boilerplate removed (16 × ~30 LoC avg + duplicated `widget_bbox` / `widget_center` retained per-driver since some bodies use them locally).

## API

```daslang
// 3-arg form (fps=30 default — the common case)
def public with_recording_app(feature_path : string;
                              output_apng_basename : string;
                              max_seconds : int;
                              body : block<(app : ImguiApp) : void>)

// 4-arg form (explicit fps)
def public with_recording_app(feature_path : string;
                              output_apng_basename : string;
                              max_seconds : int;
                              fps : int;
                              body : block<(app : ImguiApp) : void>)
```

The two-overload shape exists because gen2's trailing-block sugar `$(app) { ... }` can't see through a default parameter sitting between the last positional and the block. The 3-arg form delegates to the 4-arg with default fps.

## Driver shape — before / after

```daslang
// BEFORE — manual ImguiApp + boilerplate
[export]
def main {
    let app = ImguiApp(base_url = BASE_URL, feature_path = "",
                       transport <- live_api_transport(BASE_URL))
    if (!wait_until_ready(app, 5.0f)) panic(...)
    post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
    post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
    post_command(app, "record_start", JV((file=OUTPUT, fps=30, max_seconds=30)))
    // ... body ...
    post_command(app, "record_stop", null)
    post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
    post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
}

// AFTER
[export]
def main {
    with_recording_app("examples/tutorial/X.das", "X.apng", 30) $(app) {
        // ... body ...
    }
}
```

## Verification

- [x] Compile + lint clean on all 16 refactored drivers + helper (`mcp__daslang__compile_check` / `mcp__daslang__lint`)
- [x] `record_boost_basics.das` end-to-end on retina mac: 640×320 APNG (~7.8 MB), 0 frames dropped, vs pre-fix 1280×640 / 28 MB
- [x] `-project_root` forwarding works (source-repo workflow per `skills/recording.md`)
- [x] APNG lands at absolute path `<dasimgui>/doc/source/_static/tutorials/<basename>` — caller cwd no longer matters
- [ ] CI: tests.yml matrix green
- [ ] Boris re-records ~3 representative APNGs to confirm visual quality matches at 1x (deferred — existing committed APNGs are still valid references)

## Companion PRs

- **GaijinEntertainment/daScript#TBD** — the daslang side of `--no-hdpi-framebuffer`. The dasImgui flag is harmless until that side ships; once it does, framebuffer-size-shrink kicks in automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)