### PR TITLE
imgui_playwright: -project_root forwarding fix + attach mode

### DIFF
--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -23,6 +23,7 @@ require strings
 let DEFAULT_LIVE_PORT : int = 9090                   // daslang-live's live_api default port
 let DEFAULT_DEADLOCK_SANITY_SEC : float = 120.0f     // backstop for the frame-counter-never-advances case (crash / true deadlock); never trips on slow-but-progressing
 let DEFAULT_READY_TIMEOUT_SEC : float = 30.0f        // /status must turn 200 OK within this — covers daslang-live boot + GLFW + ImGui ctx
+let ATTACH_PROBE_SEC : float = 0.3f                  // with_recording_app's attach-vs-spawn detection — short enough to feel instant when nothing's listening
 let DEFAULT_TEST_TIMEOUT_SEC : float = 120.0f        // upper bound on the entire popen lifetime, including body + drain
 let DEFAULT_RELOAD_TIMEOUT_SEC : float = 30.0f       // POST /reload to /status.has_error == false convergence
 let DEFAULT_FRAME_WAIT_SEC : float = 10.0f           // upper bound on "first frame to render the named widget"
@@ -601,23 +602,34 @@ def public with_recording_app(feature_path : string;
                               max_seconds : int;
                               fps : int;
                               body : block<(app : ImguiApp) : void>) {
-    //! Spawn ``daslang-live <feature_path>`` at logical 1x (passes
-    //! ``--imgui-content-scale=1.0`` + ``--no-hdpi-framebuffer`` after
-    //! ``--`` so the framebuffer + ImGui style both stay at logical
-    //! resolution, keeping APNGs encoder-friendly even on retina), toggle
-    //! visual aids, post ``record_start``, run ``body`` for the
-    //! narrate/click/drag timeline, then ``record_stop`` / ``/shutdown`` /
-    //! drain. APNG lands at
+    //! Run a recording session against ``feature_path``. If a daslang-live
+    //! host is already serving at the live-API port, **attach** to it (the
+    //! running host's current HDPI/style — dev workflow: iterate live, then
+    //! flip the recorder on without restarting). Otherwise **spawn** a new
+    //! host at logical 1x (passes ``--imgui-content-scale=1.0`` +
+    //! ``--no-hdpi-framebuffer`` after ``--`` so framebuffer + ImGui style
+    //! both stay at logical resolution; APNGs stay encoder-friendly even on
+    //! retina — canonical-recording workflow). Toggles visual aids, posts
+    //! ``record_start``, runs ``body`` for the narrate/click/drag timeline,
+    //! then ``record_stop``. Spawned host gets ``/shutdown`` + drain;
+    //! attached host is left running.
+    //!
+    //! In attach mode the caller owns whatever feature is loaded — the
+    //! helper does NOT post a switch-feature command. If the running host
+    //! has a different feature loaded, the driver body's
+    //! ``wait_for_render`` call will time out and the driver panics with
+    //! the standard "{ident} never rendered — wrong app running?" message.
+    //!
+    //! APNG lands at
     //! ``<dasImgui>/doc/source/_static/tutorials/<output_apng_basename>``
     //! regardless of caller cwd. Forwards ``-project_root`` from the
-    //! driver's own argv so the source-repo recording workflow survives
-    //! (``skills/recording.md``). ``fps`` defaults to 30; pass a smaller
-    //! value for long-running recordings where file size matters more
-    //! than smoothness (the narrative_layout / edit_external tours run
-    //! at 20 to stay under GitHub's 50 MB asset warning). Panics on
-    //! non-zero exit / readiness or test timeout so the recording
-    //! driver fails loudly.
-    let exe = daslang_live_exe()
+    //! driver's own argv (spawn mode only) so the source-repo recording
+    //! workflow survives (``skills/recording.md``). ``fps`` defaults to
+    //! 30; pass a smaller value for long-running recordings where file
+    //! size matters more than smoothness (the narrative_layout /
+    //! edit_external tours run at 20 to stay under GitHub's 50 MB asset
+    //! warning). Panics on non-zero exit / readiness or test timeout so
+    //! the recording driver fails loudly.
     // Resolve feature_path against dasImgui root (where examples/tutorial/
     // and examples/features/ actually live), NOT the daScript root that
     // resolve_feature_path uses. Same idiom as
@@ -630,12 +642,42 @@ def public with_recording_app(feature_path : string;
     let asset_dir = path_join(dasimgui_root, RECORD_ASSET_REL)
     let output_apng_path = path_join(asset_dir, output_apng_basename)
 
+    let base_url = "http://127.0.0.1:{DEFAULT_LIVE_PORT}"
+    var app = ImguiApp(base_url = base_url,
+                       feature_path = app_path,
+                       transport <- live_api_transport(base_url))
+
+    // Attach-mode probe: 0.3 s is enough for three /status polls (instant
+    // on a healthy listener, fast TCP-refused if no one's there).
+    if (wait_until_ready(app, ATTACH_PROBE_SEC)) {
+        print("[record] attaching to existing daslang-live at {base_url}\n")
+        post_command(app, "imgui_mouse_trail",   JV((enabled = true)))
+        post_command(app, "imgui_cursor_sprite", JV((enabled = true)))
+        post_command(app, "record_start", JV((
+            file = output_apng_path,
+            fps = fps,
+            max_seconds = max_seconds
+        )))
+        invoke(body, app)
+        let stopped = post_command(app, "record_stop", null)
+        let dump = stopped != null ? write_json(stopped) : "<null>"
+        print("[record] record_stop -> {dump}\n")
+        print("[record] APNG saved to {output_apng_path}\n")
+        post_command(app, "imgui_cursor_sprite", JV((enabled = false)))
+        post_command(app, "imgui_mouse_trail",   JV((enabled = false)))
+        return
+    }
+
+    let exe = daslang_live_exe()
     var argv <- [exe]
     // Forward -project_root if the driver received it (source-repo
     // workflow: APNGs land under the source repo's asset dir, not the
-    // daspkg-installed copy under daScript/modules/).
-    let user_args <- get_user_args()
-    let pr = find_flag_raw_value(user_args, "-project_root") |> unwrap_or("")
+    // daspkg-installed copy under daScript/modules/).  -project_root
+    // is a daslang.exe flag (pre-`--`), so scan the full argv via
+    // get_command_line_arguments() — get_user_args() only sees the
+    // post-`--` slice in interpreted mode.
+    let argv_all <- get_command_line_arguments()
+    let pr = find_flag_raw_value(argv_all, "-project_root") |> unwrap_or("")
     if (!empty(pr)) {
         argv |> push("-project_root")
         argv |> push(pr)
@@ -649,10 +691,6 @@ def public with_recording_app(feature_path : string;
     // even when the style is 1x — UI is small inside a big frame.
     argv |> push("--no-hdpi-framebuffer")
 
-    let base_url = "http://127.0.0.1:{DEFAULT_LIVE_PORT}"
-    var app = ImguiApp(base_url = base_url,
-                       feature_path = app_path,
-                       transport <- live_api_transport(base_url))
     var captured : string
     var unready  = false
     // Body must complete within max_seconds + ready/shutdown headroom.


### PR DESCRIPTION
## Summary

Two fixes to `with_recording_app`, both surfaced while testing the one-shell recording flow (PR #43) on Windows.

### 1) `-project_root` forwarding

The helper forwards `-project_root` from the driver's argv to the spawned `daslang-live` so the source-repo recording workflow lands APNGs under the dev clone's asset dir (not the daspkg copy under `daScript/modules/`).

The forwarding scanned `get_user_args()`, which in **interpreted mode** only returns the slice AFTER `--`. But `-project_root` is a `daslang.exe` flag and lives BEFORE `--`. So the documented single-flag invocation

```
daslang.exe -project_root <dasimgui> tests/integration/record_X.das
```

silently dropped the flag, and the spawned `daslang-live` died on the very first `require imgui` in the feature file:

```
error[20605]: missing prerequisite 'imgui'; file not found
```

Workaround until now was to pass `-project_root` **twice**.

**Fix:** scan `get_command_line_arguments()` instead. The daslang builtin returns the full original argv (set via `setCommandLineArguments(argc, argv)` at [daScript/utils/daScript/main.cpp:140](https://github.com/GaijinEntertainment/daScript/blob/master/utils/daScript/main.cpp#L140) before any flag parsing), so the flag is visible regardless of pre-/post-`--`.

### 2) Attach-to-running-host

Probe `GET /status` before spawning. If a `daslang-live` is already serving at the live-API port, skip the spawn + `/shutdown` lifecycle and run the recording body directly against the running host.

**Use case:** dev keeps `daslang-live` open while iterating on a tutorial, then triggers the recorder without restarting the host. Before: spawn would collide on port 9090, the recorder would panic with non-zero exit, and you had to kill the host first.

**Probe:** `wait_until_ready(app, 0.3 s)` — three `/status` polls at the existing 100 ms cadence. Instant when something's listening, fast TCP-refused when not.

**Contract:**
- Caller owns whatever feature is loaded in the attached host — the helper does NOT post a switch-feature command. If it's the wrong feature, the body's `wait_for_render` panics with the standard `"{ident} never rendered — wrong app running?"` message.
- Attached captures run at the host's current HDPI/style. The logical-1x mode (`--imgui-content-scale=1.0` + `--no-hdpi-framebuffer`) is spawn-only — the dev host stays at native HDPI.

## Verification on Windows

| Mode | Invocation | Result |
|---|---|---|
| Spawn | `daslang.exe -project_root D:/DASPKG/dasImgui D:/DASPKG/dasImgui/tests/integration/record_boost_basics.das` | `boost_basics.apng` 640×320 / 7.84 MB / 334 frames / 0 dropped — matches committed retina-mac reference (640×320 / 7.83 MB) within encoder noise |
| Attach | same invocation, with `daslang-live` pre-launched on :9090 | `[record] attaching to existing daslang-live at http://127.0.0.1:9090` — host PID stays alive after the recorder exits; APNG 640×320 (same on this 100%-scale monitor) |

Also confirms `--no-hdpi-framebuffer` (daslang PR #2704) correctly engages `GLFW_SCALE_TO_MONITOR=0` on Windows.

## Test plan

- [x] Compile clean (`-dry-run` passes)
- [x] Format-clean (`mcp__daslang__format_file` reports `already_formatted`)
- [x] Spawn mode: single-flag invocation produces 640×320 APNG
- [x] Attach mode: detects pre-running host, reuses it, leaves it alive
- [x] APNG diff vs committed reference within encoder noise
- [ ] CI green (no required gate, eyeball)

🤖 Generated with [Claude Code](https://claude.com/claude-code)