### PR TITLE
PR-C: imgui_demo 3-apps mega-PR — custom_rendering + dockspace + documents + drawlist primitives + PR-50 follow-ups

### DIFF
--- a/doc/source/tutorials/docking.rst
+++ b/doc/source/tutorials/docking.rst
@@ -7,10 +7,12 @@ Docking
 ImGui's native docking lets the user grab a window's tab and drop it into a
 side pane, the bottom pane, or even pop it out to a free-floating window —
 all preserved across runs through ``imgui.ini``. The dasImgui boost layer
-wraps the C++ surface in two macros: ``dockspace`` (the full-viewport
-dockable region) and ``dock_window`` (each dockable panel inside it). A
-small ``DockBuilder`` helper seeds a 3-pane initial layout so first-run
-users see something meaningful before they start dragging tabs around.
+wraps the C++ surface in three macros: ``dockspace`` (the full-viewport
+dockable region), the sibling ``dockspace_in_window`` (an explicit
+``DockSpace`` nested inside a host ``window(HOST, …)``), and
+``dock_window`` (each dockable panel inside either dockspace). A small
+``DockBuilder`` helper seeds an initial layout so first-run users see
+something meaningful before they start dragging tabs around.
 
 Source: ``examples/tutorial/docking.das``.
 
@@ -31,9 +33,9 @@ Requires
 Same backend + boost layer as :ref:`tutorial_layout`, but layout helpers are
 replaced by the docking module:
 
-* ``imgui/imgui_docking_builtin`` — the ``dockspace`` and ``dock_window``
-  macros, plus the ``DockBuilder*`` bindings cherry-picked from ImGui's
-  internal API.
+* ``imgui/imgui_docking_builtin`` — the ``dockspace``,
+  ``dockspace_in_window``, and ``dock_window`` macros, plus the
+  ``DockBuilder*`` bindings cherry-picked from ImGui's internal API.
 
 The flag that lights it up
 ==========================

--- a/doc/source/tutorials/docking.rst
+++ b/doc/source/tutorials/docking.rst
@@ -76,6 +76,50 @@ explicit.
 The setup is gated on ``state.has_initial_layout`` so it runs once per
 session — or after ``imgui_dock_reset`` flips the flag back to false.
 
+Variant: dockspace inside a host window
+=======================================
+
+``dockspace`` wraps ``DockSpaceOverViewport`` — the dock region claims the
+entire OS window. The sibling ``dockspace_in_window`` wraps the explicit
+``DockSpace(id, size, flags, null)`` call so the dock node lives INSIDE
+an enclosing ``window(HOST, ...)`` rather than over the viewport. Use
+this when the host window needs its own menu bar, decorations, or a
+floating / moveable frame around the dockable area.
+
+.. code-block:: das
+
+   SetNextWindowSize(ImVec2(680.0f, 440.0f), ImGuiCond.FirstUseEver)
+   window(HOST, (text = "Editor",
+                 closable = false,
+                 flags = ImGuiWindowFlags.MenuBar |
+                         ImGuiWindowFlags.NoDocking)) {
+       menu_bar(HOST_MENU) {
+           menu(FILE_MENU, (text = "File", enabled = true)) {
+               menu_item(SAVE_ITEM, (text = "Save"))
+           }
+       }
+       dockspace_in_window(DS, (size = float2(0.0f, 0.0f),
+                                flags = ImGuiDockNodeFlags.None)) {
+           dock_window(FILES, (text = "Files", closable = false,
+                               flags = ImGuiWindowFlags.None)) { ... }
+           dock_window(OUTPUT, (text = "Output", closable = false,
+                                flags = ImGuiWindowFlags.None)) { ... }
+       }
+   }
+
+The host's ``ImGuiWindowFlags.MenuBar`` / ``NoDocking`` live on the
+``window`` call, not on ``dockspace_in_window`` — the dockspace container
+only manages the dock node. ``size = (0,0)`` (typical) fills the host's
+available content region after the menu bar.
+
+``DS.dock_id`` is captured for ``DockBuilder*`` layout calls the same way
+as ``dockspace`` — the choice between the two is purely about whether
+you want the host frame around the dock area.
+
+See :download:`examples/features/dockspace_in_window.das
+<../../../examples/features/dockspace_in_window.das>` for the full
+scene.
+
 The frame loop
 ==============
 

--- a/doc/source/tutorials/drawlist.rst
+++ b/doc/source/tutorials/drawlist.rst
@@ -7,7 +7,10 @@ Drawlist rail
 ImGui exposes three viewport-level draw lists — window, foreground, background —
 plus a family of low-level ``Add*`` primitives that paint directly to them
 (``AddLine``, ``AddRect``, ``AddCircle``, etc.). The boost layer wraps them
-behind three scope wrappers and eight primitive functions:
+behind three scope wrappers and a primitive set covering the geometric basics
+(line / rect / circle / triangle / text) plus the v2 extras
+(rect_filled_multi_color / ellipse / ngon / polyline / bezier) plus
+path-building, channel-splitting, and clip-rect rails:
 
 .. code-block:: das
 
@@ -75,6 +78,77 @@ Eight ``[drawlist_prim]``-tagged painters cover the geometric basics:
 or ``GetColorU32(ImGuiCol.*)`` for style-colour references. Positions are
 screen-space pixels; widget-relative drawing typically anchors on
 ``GetCursorScreenPos`` / ``GetItemRectMin`` / ``GetItemRectMax``.
+
+Shape extras (v2 additions)
+===========================
+
+Eight additional ``[drawlist_prim]`` painters round out the shape set:
+
+* ``add_rect_filled_multi_color(dl, a, b, col_ul, col_ur, col_br, col_bl)`` —
+  per-corner gradient (4 colours, bilinearly interpolated).
+* ``add_ellipse(dl, center, radii, col, rot = 0.0f, num_segments = 0, thickness = 1.0f)``
+  / ``add_ellipse_filled(dl, center, radii, col, rot = 0.0f, num_segments = 0)``
+  — ``radii`` = ``(rx, ry)`` half-axes; ``rot`` rotates the ellipse about
+  ``center`` (radians).
+* ``add_ngon(dl, center, radius, col, num_segments, thickness = 1.0f)``
+  / ``add_ngon_filled(dl, center, radius, col, num_segments)`` —
+  regular N-gons; ``num_segments`` required (no adaptive default).
+* ``add_polyline(dl, points : array<float2>, col, flags = ImDrawFlags.None, thickness = 1.0f)``
+  — open or closed polyline through ``points`` (use
+  ``ImDrawFlags.Closed`` to close).
+* ``add_bezier_cubic(dl, p1, p2, p3, p4, col, thickness = 1.0f, num_segments = 0)``
+  / ``add_bezier_quadratic(dl, p1, p2, p3, col, thickness = 1.0f, num_segments = 0)``
+  — bezier curves through anchor + control points.
+
+Path building
+=============
+
+For complex one-off shapes (rounded rects assembled from arcs, custom
+polygons, etc.) the path family lets the caller build a vertex stack
+incrementally then terminate with one of ``path_stroke`` /
+``path_fill_convex`` / ``path_fill_concave``:
+
+* ``path_clear(dl)`` — discard pending path vertices.
+* ``path_line_to(dl, pos)`` — append a straight-line segment.
+* ``path_arc_to(dl, center, radius, a_min, a_max, num_segments = 0)`` —
+  append a circular arc.
+* ``path_bezier_quadratic_curve_to(dl, p2, p3, num_segments = 0)`` —
+  append a quadratic bezier curve from the path's current endpoint.
+* ``path_fill_convex(dl, col)`` / ``path_fill_concave(dl, col)`` —
+  close + fill (convex is faster; concave handles non-convex polygons).
+* ``path_stroke(dl, col, flags = ImDrawFlags.None, thickness = 1.0f)`` —
+  close + stroke; ``ImDrawFlags.Closed`` joins last vertex to first.
+
+See :download:`examples/features/drawlist_path.das
+<../../../examples/features/drawlist_path.das>` for a stroked rounded
+rect, filled convex pentagon, and filled concave arrow built path-style.
+
+Channel splitting
+=================
+
+ImGui drawlists are append-only — once a vertex lands, later draws sit
+on top. ``channels_split`` defers ordering: split the drawlist into N
+channels, submit each layer in convenient order, then ``channels_merge``
+flattens them in channel-index order (channel 0 first, channel N-1 last).
+
+* ``channels_split(dl, count)`` — push ``count`` channels.
+* ``channels_set_current(dl, idx)`` — switch the active channel.
+* ``channels_merge(dl)`` — flatten back to the main draw stream.
+
+Typical use: draw a card's foreground content first to measure its
+bounding box, then go back to channel 0 to paint the background card
+behind it. See :download:`examples/features/drawlist_channels.das
+<../../../examples/features/drawlist_channels.das>`.
+
+Clip rect scope
+===============
+
+``with_clip_rect(min, max, intersect_with_current) { ... }`` (lives in
+``imgui_scope_builtin``) restricts every widget and drawlist primitive
+submitted inside the block to the given screen-space rect. Set
+``intersect_with_current=true`` (typical) to intersect with the existing
+clip; ``false`` replaces it. See :download:`examples/features/clip_rect.das
+<../../../examples/features/clip_rect.das>`.
 
 Path-key telemetry
 ==================

--- a/doc/source/tutorials/drawlist.rst
+++ b/doc/source/tutorials/drawlist.rst
@@ -117,7 +117,8 @@ incrementally then terminate with one of ``path_stroke`` /
 * ``path_fill_convex(dl, col)`` / ``path_fill_concave(dl, col)`` —
   close + fill (convex is faster; concave handles non-convex polygons).
 * ``path_stroke(dl, col, flags = ImDrawFlags.None, thickness = 1.0f)`` —
-  close + stroke; ``ImDrawFlags.Closed`` joins last vertex to first.
+  stroke the pending path (open by default). Pass
+  ``ImDrawFlags.Closed`` to join the last vertex back to the first.
 
 See :download:`examples/features/drawlist_path.das
 <../../../examples/features/drawlist_path.das>` for a stroked rounded

--- a/doc/source/tutorials/drawlist.rst
+++ b/doc/source/tutorials/drawlist.rst
@@ -9,8 +9,11 @@ plus a family of low-level ``Add*`` primitives that paint directly to them
 (``AddLine``, ``AddRect``, ``AddCircle``, etc.). The boost layer wraps them
 behind three scope wrappers and a primitive set covering the geometric basics
 (line / rect / circle / triangle / text) plus the v2 extras
-(rect_filled_multi_color / ellipse / ngon / polyline / bezier) plus
-path-building, channel-splitting, and clip-rect rails:
+(rect_filled_multi_color / ellipse / ngon / polyline / bezier). The
+path-building (``path_*``), channel-splitting (``channels_*``), and
+clip-rect rails are control-flow helpers, not registered ``[drawlist_prim]``
+entries — they shape what the primitives render but do not themselves
+create snapshot rows:
 
 .. code-block:: das
 

--- a/examples/features/align_text_to_frame_padding.das
+++ b/examples/features/align_text_to_frame_padding.das
@@ -1,0 +1,60 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: align_text_to_frame_padding — vertically align next text to a
+//                                        framed item's baseline.
+// SHOWS:   The standard pattern for pairing a label with an inline framed
+//          widget (button, input, slider) on the same line. Without the
+//          prefix, the bare `text()` sits at the top of the line and looks
+//          mis-aligned against the framed widget's vertical centre. Compare
+//          row A (no align) against row B (with align).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/align_text_to_frame_padding.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/align_text_to_frame_padding.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/align_text_to_frame_padding.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("align_text_to_frame_padding", 520, 240)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 200.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "align_text_to_frame_padding", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Row A vs Row B — same widgets, only difference is the align prefix."))
+
+        // Row A — bare label, looks top-aligned against the framed button.
+        text(LABEL_A, (text = "Row A:"))
+        same_line()
+        if (button(BTN_A, (text = "framed widget"))) {}
+
+        // Row B — align prefix lifts the label baseline to the frame's centre.
+        align_text_to_frame_padding(ALIGN_B)
+        text(LABEL_B, (text = "Row B:"))
+        same_line()
+        if (button(BTN_B, (text = "framed widget"))) {}
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/child_scroll_reenter.das
+++ b/examples/features/child_scroll_reenter.das
@@ -1,0 +1,82 @@
+options gen2
+
+require imgui/imgui_harness
+
+var private SCROLL_ROW : table<int; NarrativeState>
+
+// =============================================================================
+// FEATURE: child_scroll_reenter — re-enter an existing child window from
+//          outside its body to nudge its scroll position via SetScrollX/Y.
+// SHOWS:   `child(SCROLLY, (text = "lines", ...)) { ... 50 rows ... }` paints
+//          a scrollable child. Two repeat-fire buttons below it call
+//          `child_scroll_reenter("SCROLLY", "lines") { SetScrollY(...) }` to
+//          scroll up/down. The wrapper replicates the original `child(IDENT)`
+//          container's `PushID(IDENT)` frame so `BeginChild("lines", ...)`
+//          hashes to the SAME window. Drop the PushID and ImGui hashes to a
+//          phantom sibling — scroll observably does nothing.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/child_scroll_reenter.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/child_scroll_reenter.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/child_scroll_reenter.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("child_scroll_reenter — boost v2", 520, 520)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 480.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "child_scroll_reenter", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Hold the buttons to nudge SCROLLY's scroll position."))
+
+        child(SCROLLY, (text = "lines", size = float2(440.0f, 320.0f),
+                        child_flags = ImGuiChildFlags.Border,
+                        window_flags = ImGuiWindowFlags.None)) {
+            for (i in range(50)) {
+                text(SCROLL_ROW[i], (text = "row {i}"))
+            }
+        }
+
+        // Repeat-fire buttons so a single hold scrolls continuously.
+        with_button_repeat(true) {
+            if (button(BTN_UP, (text = "scroll up"))) {}
+            same_line()
+            if (button(BTN_DOWN, (text = "scroll down"))) {}
+        }
+        same_line()
+        text(STATUS, (text = "scroll.y: {int(SCROLLY.scroll.y)} / {int(SCROLLY.scroll_max.y)}"))
+
+        let delta = 8.0f
+        if (BTN_UP.click_count > 0 && BTN_UP.clicked) {
+            child_scroll_reenter("SCROLLY", "lines") {
+                SetScrollY(GetScrollY() - delta)
+            }
+        }
+        if (BTN_DOWN.click_count > 0 && BTN_DOWN.clicked) {
+            child_scroll_reenter("SCROLLY", "lines") {
+                SetScrollY(GetScrollY() + delta)
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/clip_rect.das
+++ b/examples/features/clip_rect.das
@@ -1,16 +1,16 @@
 options gen2
-// Demos the low-level ImDrawList API (GetWindowDrawList + AddCircleFilled).
-// No v2 wrappers exist for direct drawlist primitives; opt out of the
-// default-on lint so the demo compiles cleanly.
-options _allow_imgui_legacy = true
 
 require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: with_clip_rect — Push/PopClipRect scope wrapper.
-// SHOWS:   `with_clip_rect(min, max, intersect) { ... }` restricts every draw
-//          inside to the given rectangle. Typical use: rendering DrawList
-//          shapes that should not bleed outside a widget box.
+// SHOWS:   `with_clip_rect(min, max, intersect_with_current) { ... }`
+//          restricts every widget and drawlist primitive submitted inside
+//          the block to the given screen-space rect. Typical use: rendering
+//          DrawList shapes that should not bleed outside a widget box.
+//          Compare the left circle (no clip — spills past the band) vs the
+//          right circle (inside with_clip_rect — cleanly cut at the band
+//          edge).
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/clip_rect.das
 // HEADLESS:   daslang.exe modules/dasImgui/examples/features/clip_rect.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/clip_rect.das
@@ -18,7 +18,7 @@ require imgui/imgui_harness
 
 [export]
 def init() {
-    harness_init("with_clip_rect — boost v2 §3.6", 720, 480)
+    harness_init("with_clip_rect — clip scope", 520, 320)
 }
 
 [export]
@@ -26,31 +26,41 @@ def update() {
     if (!harness_begin_frame()) return
     harness_new_frame()
 
-    SetNextWindowSize(ImVec2(680.0, 420.0), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(480.0, 280.0), ImGuiCond.Always)
     window(MAIN_WIN, (text = "with_clip_rect", closable = false,
                       flags = ImGuiWindowFlags.None)) {
-        text(LEAD, (text = "Clip rect confines the draw-list shapes below to a 200×80 box."))
+        text(LEAD, (text = "Left circle: no clip. Right circle: clipped to its band."))
 
-        let topleft = GetCursorScreenPos()
-        let clip_min = ImVec2(topleft.x, topleft.y)
-        let clip_max = ImVec2(topleft.x + 200.0, topleft.y + 80.0)
+        let origin = GetCursorScreenPos()
+        let blue = rgba(70u, 130u, 240u, 240u)
+        let band = rgba(60u, 60u, 90u, 200u)
 
-        with_clip_rect(float2(clip_min.x, clip_min.y),
-                       float2(clip_max.x, clip_max.y), true) {
-            var dl & = unsafe(*GetWindowDrawList())
-            // Two overlapping circles — both extend beyond the clip box; the
-            // wrapper crops them to the rectangle.
-            unsafe {
-                dl.AddCircleFilled(ImVec2(clip_min.x + 80.0, clip_min.y + 40.0),
-                                   80.0, 0xFFAA4400u, 0)
-                dl.AddCircleFilled(ImVec2(clip_min.x + 160.0, clip_min.y + 40.0),
-                                   80.0, 0xFF0099FFu, 0)
-            }
-            dummy(GUARD, (size = float2(200.0f, 80.0f)))
+        with_window_drawlist() $(var dl) {
+            // Left half — band painted, circle NOT clipped, spills out.
+            dl |> add_rect_filled(
+                float2(origin.x + 16.0f, origin.y + 24.0f),
+                float2(origin.x + 200.0f, origin.y + 64.0f),
+                band)
+            dl |> add_circle_filled(
+                float2(origin.x + 200.0f, origin.y + 44.0f),
+                30.0f, blue, 0)
         }
 
-        separator(SEP)
-        text(NOTE, (text = "Below the clip block — uncropped Text renders normally."))
+        // Right half — same circle, clipped to its band by with_clip_rect.
+        let r_x0 = origin.x + 240.0f
+        let r_y0 = origin.y + 24.0f
+        let r_x1 = origin.x + 424.0f
+        let r_y1 = origin.y + 64.0f
+        with_clip_rect(float2(r_x0, r_y0), float2(r_x1, r_y1), true) {
+            with_window_drawlist() $(var dl2) {
+                dl2 |> add_rect_filled(float2(r_x0, r_y0), float2(r_x1, r_y1), band)
+                dl2 |> add_circle_filled(float2(r_x1, r_y0 + 20.0f),
+                                         30.0f, blue, 0)
+            }
+        }
+
+        dummy(BAND_SLOT, (size = float2(460.0f, 100.0f)))
+        text(NOTE, (text = "(The right circle's overflow is clipped at the band edge — the left one spills past.)"))
     }
 
     harness_end_frame()

--- a/examples/features/clip_rect.das
+++ b/examples/features/clip_rect.das
@@ -57,6 +57,9 @@ def update() {
                 dl2 |> add_circle_filled(float2(r_x1, r_y0 + 20.0f),
                                          30.0f, blue, 0)
             }
+            // GUARD dummy inside the clip block — proves widget registration
+            // works normally inside with_clip_rect (no scope-leak).
+            dummy(GUARD, (size = float2(r_x1 - r_x0, r_y1 - r_y0)))
         }
 
         dummy(BAND_SLOT, (size = float2(460.0f, 100.0f)))

--- a/examples/features/data_table.das
+++ b/examples/features/data_table.das
@@ -27,6 +27,15 @@ var private GRID_ROW_NAME : table<int; NarrativeState>
 var private GRID_ROW_QTY : table<int; NarrativeState>
 var private GRID_ROW_PRICE : table<int; NarrativeState>
 
+// Module-scope inventory rows — hoisted out of update() so the three
+// dynamic arrays allocate once at module init instead of leaking a fresh
+// allocation every frame (local `var array<T>` in a hot path doesn't
+// finalize on scope exit).
+let private GRID_NAMES <- ["Widget", "Sprocket", "Gizmo", "Doohickey", "Thingamajig",
+                           "Whatsit", "Doodad", "Gadget"]
+let private GRID_QTY <- [12, 4, 7, 33, 1, 9, 22, 5]
+let private GRID_PRICE <- [1.50, 9.99, 4.25, 0.75, 19.00, 3.10, 2.80, 6.45]
+
 [export]
 def init() {
     harness_init("data_table — boost v2 table rail", 640, 420)
@@ -55,21 +64,16 @@ def update() {
             table_setup_scroll_freeze(1, 1)
             table_headers_row()
 
-            let names <- ["Widget", "Sprocket", "Gizmo", "Doohickey", "Thingamajig",
-                          "Whatsit", "Doodad", "Gadget"]
-            let qty <- [12, 4, 7, 33, 1, 9, 22, 5]
-            let price <- [1.50, 9.99, 4.25, 0.75, 19.00, 3.10, 2.80, 6.45]
-
-            for (i in range(length(names))) {
+            for (i in range(length(GRID_NAMES))) {
                 table_next_row()
                 if (table_set_column_index(0)) {
-                    text(GRID_ROW_NAME[i], (text = "{names[i]}"))
+                    text(GRID_ROW_NAME[i], (text = "{GRID_NAMES[i]}"))
                 }
                 if (table_next_column()) {
-                    text(GRID_ROW_QTY[i], (text = "{qty[i]}"))
+                    text(GRID_ROW_QTY[i], (text = "{GRID_QTY[i]}"))
                 }
                 if (table_next_column()) {
-                    text(GRID_ROW_PRICE[i], (text = "${price[i]}"))
+                    text(GRID_ROW_PRICE[i], (text = "${GRID_PRICE[i]}"))
                 }
             }
         }

--- a/examples/features/data_table.das
+++ b/examples/features/data_table.das
@@ -1,0 +1,93 @@
+options gen2
+
+require imgui/imgui_harness
+require imgui/imgui_table_builtin
+
+// =============================================================================
+// FEATURE: data_table — Phase 0b.3 table container + cursor primitives.
+// SHOWS:   - `data_table(TBL, (columns=3, text="grid", flags=Resizable|Borders,
+//            outer_size=(0,0), inner_width=0.0))` — BeginTable/EndTable
+//            only-on-true paired container.
+//          - `table_setup_column(label, flags?, init_width?, user_id?)` — one
+//            call per column directly after BeginTable, before headers.
+//          - `table_setup_scroll_freeze(cols, rows)` — pin the first column +
+//            header row during scroll.
+//          - `table_headers_row()` — submit header row using setup labels.
+//          - `table_next_row(flags?, min_row_height?)` — append row.
+//          - `table_next_column() : bool` — advance one column; returns true
+//            when the cell is visible.
+//          - `table_set_column_index(col) : bool` — jump to a specific column
+//            index in the current row.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/data_table.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/data_table.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/data_table.das
+// =============================================================================
+
+var private GRID_ROW_NAME : table<int; NarrativeState>
+var private GRID_ROW_QTY : table<int; NarrativeState>
+var private GRID_ROW_PRICE : table<int; NarrativeState>
+
+[export]
+def init() {
+    harness_init("data_table — boost v2 table rail", 640, 420)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(600.0, 380.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "data_table", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Three-column inventory grid; first column + headers are scroll-frozen."))
+
+        data_table(INVENTORY, (text = "inventory", columns = 3,
+                               flags = ImGuiTableFlags.Resizable |
+                                       ImGuiTableFlags.Borders |
+                                       ImGuiTableFlags.ScrollY |
+                                       ImGuiTableFlags.RowBg,
+                               outer_size = float2(0.0f, 240.0f),
+                               inner_width = 0.0f)) {
+            table_setup_column("Name", ImGuiTableColumnFlags.WidthStretch)
+            table_setup_column("Qty",  ImGuiTableColumnFlags.WidthFixed, 60.0f)
+            table_setup_column("$",    ImGuiTableColumnFlags.WidthFixed, 80.0f)
+            table_setup_scroll_freeze(1, 1)
+            table_headers_row()
+
+            let names <- ["Widget", "Sprocket", "Gizmo", "Doohickey", "Thingamajig",
+                          "Whatsit", "Doodad", "Gadget"]
+            let qty <- [12, 4, 7, 33, 1, 9, 22, 5]
+            let price <- [1.50, 9.99, 4.25, 0.75, 19.00, 3.10, 2.80, 6.45]
+
+            for (i in range(length(names))) {
+                table_next_row()
+                if (table_set_column_index(0)) {
+                    text(GRID_ROW_NAME[i], (text = "{names[i]}"))
+                }
+                if (table_next_column()) {
+                    text(GRID_ROW_QTY[i], (text = "{qty[i]}"))
+                }
+                if (table_next_column()) {
+                    text(GRID_ROW_PRICE[i], (text = "${price[i]}"))
+                }
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/dockspace_in_window.das
+++ b/examples/features/dockspace_in_window.das
@@ -1,0 +1,105 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: dockspace_in_window — explicit-host dockspace nested inside a
+//                                Begin/End window (compare dock_basic.das
+//                                which uses DockSpaceOverViewport for the
+//                                full-viewport variant).
+// SHOWS:   - window(HOST, (flags = MenuBar | NoDocking | NoCollapse)) — the
+//            host window owns its own MenuBar; dockspace_in_window does NOT
+//            manage host-window flags.
+//          - menu_bar(HOST_MENU) inside the host: regular menu/menu_item.
+//          - dockspace_in_window(DS, (size = (0,0), flags = None)) —
+//            DockSpace(GetID(widget_ident), size, flags, null). size=(0,0)
+//            fills the host's available content region (post-menu-bar).
+//            state.dock_id is captured for DockBuilder* layout calls.
+//          - DockBuilder seeded layout (1 horizontal split: Files | Output)
+//            gated by state.has_initial_layout (one-shot per session, or
+//            after imgui_dock_reset).
+//          - dock_window(FILES) / dock_window(OUTPUT) — dockable panels
+//            INSIDE the host window via the captured DS.dock_id.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/dockspace_in_window.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/dockspace_in_window.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/dockspace_in_window.das
+// =============================================================================
+
+def setup_default_layout(dock_id : uint) {
+    //! 2-panel horizontal split: Files (left 40%) | Output (right 60%).
+    DockBuilderRemoveNode(dock_id)
+    DockBuilderAddDockSpaceNode(dock_id, ImGuiDockNodeFlags.None)
+    var left_id : uint = 0u
+    var right_id : uint = 0u
+    DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.40f, left_id, right_id)
+    DockBuilderDockWindow("Files", left_id)
+    DockBuilderDockWindow("Output", right_id)
+    DockBuilderFinish(dock_id)
+}
+
+[export]
+def init() {
+    harness_init("dockspace_in_window — boost v2", 720, 480)
+    var io & = unsafe(GetIO())
+    io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.FirstUseEver)
+    SetNextWindowSize(ImVec2(680.0f, 440.0f), ImGuiCond.FirstUseEver)
+    window(HOST, (text = "Host window with embedded dockspace",
+                  closable = false,
+                  flags = ImGuiWindowFlags.MenuBar |
+                          ImGuiWindowFlags.NoDocking |
+                          ImGuiWindowFlags.NoCollapse)) {
+        menu_bar(HOST_MENU) {
+            menu(FILE_MENU, (text = "File", enabled = true)) {
+                menu_item(SAVE_ITEM, (text = "Save"))
+                menu_item(QUIT_ITEM, (text = "Quit"))
+            }
+        }
+
+        dockspace_in_window(DS, (size = float2(0.0f, 0.0f),
+                                 flags = ImGuiDockNodeFlags.None)) {
+            // Seed layout once after the first frame (DS.dock_id is captured
+            // by the dockspace_in_window body before this block fires).
+            if (!DS.has_initial_layout && DS.dock_id != 0u) {
+                setup_default_layout(DS.dock_id)
+                DS.has_initial_layout = true
+            }
+            dock_window(FILES, (text = "Files", closable = false,
+                                flags = ImGuiWindowFlags.None)) {
+                text(FILES_LINE_1, (text = "file_a.das"))
+                text(FILES_LINE_2, (text = "file_b.das"))
+                text(FILES_LINE_3, (text = "file_c.das"))
+            }
+            dock_window(OUTPUT, (text = "Output", closable = false,
+                                 flags = ImGuiWindowFlags.None)) {
+                text(OUTPUT_HEADER, (text = "Build output:"))
+                text(OUTPUT_LINE_1, (text = "[INFO] compiled file_a.das"))
+                text(OUTPUT_LINE_2, (text = "[INFO] compiled file_b.das"))
+                text(OUTPUT_LINE_3, (text = "[INFO] done in 142ms"))
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/dockspace_in_window.das
+++ b/examples/features/dockspace_in_window.das
@@ -27,8 +27,12 @@ require imgui/imgui_harness
 
 def setup_default_layout(dock_id : uint) {
     //! 2-panel horizontal split: Files (left 40%) | Output (right 60%).
+    //! SetNodeSize before SplitNode — without it the 40/60 ratio is
+    //! computed from a zero-sized node (matches dock_basic.das order).
     DockBuilderRemoveNode(dock_id)
     DockBuilderAddDockSpaceNode(dock_id, ImGuiDockNodeFlags.None)
+    let vp = GetMainViewport()
+    DockBuilderSetNodeSize(dock_id, ImVec2(vp.Size.x, vp.Size.y))
     var left_id : uint = 0u
     var right_id : uint = 0u
     DockBuilderSplitNode(dock_id, ImGuiDir.Left, 0.40f, left_id, right_id)

--- a/examples/features/drawlist.das
+++ b/examples/features/drawlist.das
@@ -17,7 +17,7 @@ require imgui/imgui_harness
 
 [export]
 def init() {
-    harness_init("drawlist — rail tour", 520, 420)
+    harness_init("drawlist — rail tour", 520, 540)
 }
 
 [export]
@@ -25,15 +25,15 @@ def update() {
     if (!harness_begin_frame()) return
     harness_new_frame()
 
-    SetNextWindowSize(ImVec2(480.0, 360.0), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(480.0, 480.0), ImGuiCond.Always)
     window(DRAW_WIN, (text = "drawlist", closable = false,
                       flags = ImGuiWindowFlags.None)) {
         text(DRAW_INTRO, (text = "Drawlist primitives below — bboxes are mouse-cards targetable by path."))
         separator()
 
         let origin = GetCursorScreenPos()
-        let green  = rgba( 60u, 220u, 100u, 255u)
-        let blue   = rgba( 70u, 130u, 240u, 255u)
+        let green  = rgba(60u, 220u, 100u, 255u)
+        let blue   = rgba(70u, 130u, 240u, 255u)
         let yellow = rgba(240u, 220u,  60u, 255u)
         let gray   = rgba(200u, 200u, 210u, 255u)
 
@@ -52,7 +52,7 @@ def update() {
                            yellow, 2.0f)
             // Circles.
             dl |> add_circle_filled(float2(origin.x +  60.0f, origin.y + 130.0f), 28.0f, blue, 0)
-            dl |> add_circle(       float2(origin.x + 130.0f, origin.y + 130.0f), 28.0f, blue, 0, 2.0f)
+            dl |> add_circle(float2(origin.x + 130.0f, origin.y + 130.0f), 28.0f, blue, 0, 2.0f)
             // Triangles.
             dl |> add_triangle_filled(float2(origin.x + 220.0f, origin.y + 102.0f),
                                       float2(origin.x + 192.0f, origin.y + 158.0f),
@@ -63,11 +63,51 @@ def update() {
             // Text label.
             dl |> add_text(float2(origin.x +  16.0f, origin.y + 180.0f), gray,
                            "add_text — window drawlist")
+            // Multi-color gradient rect.
+            dl |> add_rect_filled_multi_color(
+                float2(origin.x +  16.0f, origin.y + 200.0f),
+                float2(origin.x + 220.0f, origin.y + 218.0f),
+                rgba(255u, 0u, 0u, 220u),    // upper-left
+                rgba(0u, 255u, 0u, 220u),    // upper-right
+                rgba(0u, 0u, 255u, 220u),    // bottom-right
+                rgba(255u, 255u, 0u, 220u))  // bottom-left
+            // Stroked + filled ellipse.
+            dl |> add_ellipse(float2(origin.x + 270.0f, origin.y + 209.0f),
+                              float2(28.0f, 14.0f), yellow, 0.0f, 0, 1.5f)
+            dl |> add_ellipse_filled(float2(origin.x + 340.0f, origin.y + 209.0f),
+                                     float2(28.0f, 14.0f), blue, 0.0f, 0)
+            // Stroked + filled N-gon (hexagon).
+            dl |> add_ngon(float2(origin.x +  40.0f, origin.y + 250.0f),
+                           22.0f, green, 6, 2.0f)
+            dl |> add_ngon_filled(float2(origin.x + 100.0f, origin.y + 250.0f),
+                                  22.0f, green, 6)
+            // Cubic + quadratic bezier curves.
+            dl |> add_bezier_cubic(
+                float2(origin.x + 150.0f, origin.y + 270.0f),
+                float2(origin.x + 200.0f, origin.y + 220.0f),
+                float2(origin.x + 260.0f, origin.y + 280.0f),
+                float2(origin.x + 310.0f, origin.y + 230.0f),
+                yellow, 2.0f, 0)
+            dl |> add_bezier_quadratic(
+                float2(origin.x + 320.0f, origin.y + 270.0f),
+                float2(origin.x + 380.0f, origin.y + 230.0f),
+                float2(origin.x + 440.0f, origin.y + 270.0f),
+                blue, 2.0f, 0)
+            // Polyline (open M-shape).
+            var poly <- [
+                float2(origin.x +  20.0f, origin.y + 300.0f),
+                float2(origin.x +  40.0f, origin.y + 280.0f),
+                float2(origin.x +  60.0f, origin.y + 295.0f),
+                float2(origin.x +  80.0f, origin.y + 280.0f),
+                float2(origin.x + 100.0f, origin.y + 300.0f)
+            ]
+            dl |> add_polyline(poly, gray, ImDrawFlags.None, 1.5f)
+            delete poly
         }
 
         // Reserve layout space for the band painted above so subsequent
         // ImGui widgets land below.
-        dummy(DRAW_BAND_SLOT, (size = float2(460.0f, 220.0f)))
+        dummy(DRAW_BAND_SLOT, (size = float2(460.0f, 340.0f)))
 
         text(DRAW_FG_LABEL, (text = "foreground swatch (overlays window):"))
     }

--- a/examples/features/drawlist.das
+++ b/examples/features/drawlist.das
@@ -4,13 +4,17 @@ require imgui/imgui_harness
 
 // =============================================================================
 // FEATURE: drawlist — window/foreground/background drawlist rail.
-//          INSIDE window(DRAW_WIN, ...): `with_window_drawlist` exercises all
-//          8 primitives (line/rect/rect_filled/circle/circle_filled/triangle/
-//          triangle_filled/text) nested under DRAW_WIN/.
+//          INSIDE window(DRAW_WIN, ...): `with_window_drawlist` exercises
+//          the full shape set — 8 originals (line / rect / rect_filled /
+//          circle / circle_filled / triangle / triangle_filled / text)
+//          plus 8 v2 extras (rect_filled_multi_color / ellipse /
+//          ellipse_filled / ngon / ngon_filled / polyline / bezier_cubic /
+//          bezier_quadratic) nested under DRAW_WIN/.
 //          OUTSIDE the window block: `with_foreground_drawlist` +
 //          `with_background_drawlist` each call `add_rect_filled` at the
 //          viewport level — those path keys have no container prefix.
-// SHOWS:   3 scope wrappers + 8 primitives; nested-vs-unnested telemetry.
+// SHOWS:   3 scope wrappers + 16 shape primitives (originals + v2 extras);
+//          nested-vs-unnested telemetry.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/drawlist.das
 // HEADLESS:   daslang.exe modules/dasImgui/examples/features/drawlist.das -- --headless --headless-frames=60
 // =============================================================================

--- a/examples/features/drawlist_channels.das
+++ b/examples/features/drawlist_channels.das
@@ -1,0 +1,76 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: drawlist channels family — channels_split / channels_set_current /
+//          channels_merge.
+// SHOWS:   Split the window drawlist into 2 channels; submit the foreground
+//          content first (channel 1), then go BACK and paint the background
+//          card behind it (channel 0). After channels_merge, channel 0
+//          renders first (under) and channel 1 on top. Without channels you
+//          would need to know all bbox sizes UPFRONT to paint the
+//          background before the content.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/drawlist_channels.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/drawlist_channels.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/drawlist_channels.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("drawlist channels — split / merge", 520, 300)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 260.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "drawlist_channels", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Yellow card painted on channel 0 (background) AFTER the white text on channel 1 (foreground)."))
+
+        let origin = GetCursorScreenPos()
+        let card_bg = rgba(220u, 220u, 100u, 220u)
+        let white   = rgba(255u, 255u, 255u, 255u)
+
+        with_window_drawlist() $(var dl) {
+            dl |> channels_split(2)
+
+            // ---- Channel 1 (foreground): submit content first to measure ----
+            dl |> channels_set_current(1)
+            let text_pos = float2(origin.x + 24.0f, origin.y + 20.0f)
+            dl |> add_text(text_pos, white, "FOREGROUND TEXT — painted before the bg")
+            let txt_sz = CalcTextSize("FOREGROUND TEXT — painted before the bg")
+
+            // ---- Channel 0 (background): paint the card behind ----
+            dl |> channels_set_current(0)
+            dl |> add_rect_filled(
+                float2(text_pos.x - 12.0f, text_pos.y - 8.0f),
+                float2(text_pos.x + txt_sz.x + 12.0f, text_pos.y + txt_sz.y + 8.0f),
+                card_bg, 4.0f, ImDrawFlags.None)
+
+            dl |> channels_merge()
+        }
+
+        dummy(CARD_SLOT, (size = float2(460.0f, 80.0f)))
+        text(NOTE, (text = "(Without channels_split, the foreground text would render BENEATH the later card_bg rect — wrong z-order.)"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/drawlist_path.das
+++ b/examples/features/drawlist_path.das
@@ -1,0 +1,98 @@
+options gen2
+
+require imgui/imgui_harness
+require math
+
+// =============================================================================
+// FEATURE: drawlist path family — path_clear / path_line_to / path_arc_to /
+//          path_bezier_quadratic_curve_to / path_fill_convex /
+//          path_fill_concave / path_stroke.
+// SHOWS:   Build a complex shape on the drawlist's internal path stack, then
+//          render it in one go via the path_stroke / path_fill_convex /
+//          path_fill_concave terminator. Cheaper than a polyline for
+//          dynamic shapes because intermediate vertex counts can vary and
+//          ImGui only allocates one draw command.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/drawlist_path.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/drawlist_path.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/drawlist_path.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("drawlist path family", 520, 420)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 380.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "drawlist_path", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Three path-built shapes: stroked rounded rect, filled convex pentagon, filled concave arrow."))
+
+        let origin = GetCursorScreenPos()
+        let blue   = rgba(70u, 130u, 240u, 255u)
+        let green  = rgba(60u, 220u, 100u, 230u)
+        let orange = rgba(240u, 150u,  60u, 230u)
+
+        with_window_drawlist() $(var dl) {
+            // 1) Stroked rounded-rect built from 4 arcs.
+            let r = 16.0f
+            let x0 = origin.x +  16.0f
+            let y0 = origin.y +  16.0f
+            let x1 = origin.x + 180.0f
+            let y1 = origin.y +  72.0f
+            dl |> path_clear()
+            dl |> path_arc_to(float2(x0 + r, y0 + r), r, PI, 1.5f * PI, 16)
+            dl |> path_arc_to(float2(x1 - r, y0 + r), r, 1.5f * PI, 2.0f * PI, 16)
+            dl |> path_arc_to(float2(x1 - r, y1 - r), r, 0.0f, 0.5f * PI, 16)
+            dl |> path_arc_to(float2(x0 + r, y1 - r), r, 0.5f * PI, PI, 16)
+            dl |> path_stroke(blue, ImDrawFlags.Closed, 2.0f)
+
+            // 2) Filled convex pentagon built from 5 line-tos.
+            let cx = origin.x + 260.0f
+            let cy = origin.y +  48.0f
+            dl |> path_clear()
+            for (i in range(5)) {
+                let theta = float(i) * (2.0f * PI / 5.0f) - 0.5f * PI
+                dl |> path_line_to(float2(cx + cos(theta) * 32.0f,
+                                          cy + sin(theta) * 32.0f))
+            }
+            dl |> path_fill_convex(green)
+
+            // 3) Filled concave arrow built from line-tos + a quadratic curve.
+            let ax = origin.x +  16.0f
+            let ay = origin.y + 120.0f
+            dl |> path_clear()
+            dl |> path_line_to(float2(ax +   0.0f, ay +  16.0f))
+            dl |> path_line_to(float2(ax +  60.0f, ay +  16.0f))
+            dl |> path_line_to(float2(ax +  60.0f, ay +   0.0f))
+            dl |> path_bezier_quadratic_curve_to(
+                float2(ax + 120.0f, ay +  16.0f),
+                float2(ax +  60.0f, ay +  32.0f), 8)
+            dl |> path_line_to(float2(ax +  60.0f, ay +  16.0f))
+            dl |> path_fill_concave(orange)
+        }
+
+        // Reserve layout space.
+        dummy(PATH_SLOT, (size = float2(460.0f, 240.0f)))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/edit_collapsing_header.das
+++ b/examples/features/edit_collapsing_header.das
@@ -1,0 +1,74 @@
+options gen2
+
+require imgui/imgui_harness
+require daslib/safe_addr
+
+// =============================================================================
+// FEATURE: edit_collapsing_header — closable CollapsingHeader on a caller-
+//                                   owned bool? p_open.
+// SHOWS:   `edit_collapsing_header(safe_addr(visible), (text = "label"))` —
+//          while `*ptr == false` the header (and its body) is hidden
+//          entirely. While `*ptr == true` the X close-button on the header
+//          writes `*ptr = false` when clicked. Body of the conditional
+//          runs only when the section is BOTH visible AND expanded.
+//          Container-form sibling: `collapsing_header(closable=true)`.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_collapsing_header.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_collapsing_header.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/edit_collapsing_header.das
+// =============================================================================
+
+var private VISIBLE_A = true
+var private VISIBLE_B = true
+
+[export]
+def init() {
+    harness_init("edit_collapsing_header — closable", 480, 360)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(440.0, 320.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "edit_collapsing_header", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Click the X on either header to hide it; use the buttons to restore."))
+
+        if (edit_collapsing_header(safe_addr(VISIBLE_A), (id = "HDR_A", text = "Header A"))) {
+            text(BODY_A_1, (text = "  body A — first line"))
+            text(BODY_A_2, (text = "  body A — second line"))
+        }
+
+        if (edit_collapsing_header(safe_addr(VISIBLE_B), (id = "HDR_B", text = "Header B"))) {
+            text(BODY_B_1, (text = "  body B — first line"))
+            text(BODY_B_2, (text = "  body B — second line"))
+        }
+
+        separator(SEP)
+        if (button(RESTORE_A, (text = "show A"))) {
+            VISIBLE_A = true
+        }
+        same_line()
+        if (button(RESTORE_B, (text = "show B"))) {
+            VISIBLE_B = true
+        }
+        text(STATUS, (text = "A visible: {VISIBLE_A} | B visible: {VISIBLE_B}"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/input_text_callback.das
+++ b/examples/features/input_text_callback.das
@@ -29,6 +29,10 @@ def private completion_cb(var data : ImGuiInputTextCallbackData) : int {
             data |> DeleteChars(0, data.BufTextLen)
             data |> InsertChars(0, matches[0])
         }
+        // Local arrays don't finalize on scope exit; without an explicit
+        // delete each TAB-completion leaks the candidate buffer. Matches
+        // app_console.das's completion callback pattern.
+        delete matches
     }
     return 0
 }

--- a/examples/features/input_text_callback.das
+++ b/examples/features/input_text_callback.das
@@ -1,0 +1,75 @@
+options gen2
+
+require imgui/imgui_harness
+require strings
+
+// =============================================================================
+// FEATURE: input_text_callback — InputText with user-supplied event callback.
+// SHOWS:   `input_text_callback(STATE, text, flags, cb)` — the lambda fires
+//          synchronously from ImGui::InputText whenever a callback-event flag
+//          (CallbackCompletion = TAB, CallbackHistory = Up/Down, etc.) is
+//          tripped. The `data` pointer is valid only inside the call. This
+//          demo wires CallbackCompletion to a tiny dictionary: pressing TAB
+//          while typing prefix-completes the longest unique match.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/input_text_callback.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/input_text_callback.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/input_text_callback.das
+// =============================================================================
+
+let private COMMANDS <- ["help", "history", "clear", "classify", "echo", "exit"]
+
+def private completion_cb(var data : ImGuiInputTextCallbackData) : int {
+    if (data.EventFlag == ImGuiInputTextFlags.CallbackCompletion) {
+        let prefix = clone_string(data.Buf)
+        var matches : array<string>
+        for (c in COMMANDS) {
+            if (c |> starts_with(prefix)) matches |> push(c)
+        }
+        if (length(matches) == 1) {
+            data |> DeleteChars(0, data.BufTextLen)
+            data |> InsertChars(0, matches[0])
+        }
+    }
+    return 0
+}
+
+[export]
+def init() {
+    harness_init("input_text_callback — TAB-complete", 520, 240)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 200.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "input_text_callback", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Type a prefix (e.g. 'he') and press TAB."))
+
+        if (input_text_callback(CMD, "command",
+                                ImGuiInputTextFlags.CallbackCompletion,
+                                @(var data : ImGuiInputTextCallbackData) =>
+                                    completion_cb(data))) {}
+
+        separator(SEP)
+        text(STATIC, (text = "Dictionary: help / history / clear / classify / echo / exit"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/list_clipper.das
+++ b/examples/features/list_clipper.das
@@ -1,0 +1,61 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: list_clipper — virtual-list culling rail.
+// SHOWS:   `list_clipper(items_count) $(start, end_) { ... }` — block fires
+//          once per visible chunk with `[start, end_)` row indices. Render
+//          exactly those rows inside the block; rows outside the visible
+//          region are SKIPPED entirely (no widget submission). The host
+//          window must be scrollable so the clipper has something to cull.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/list_clipper.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/list_clipper.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/list_clipper.das
+// =============================================================================
+
+var private CLIPPED_ROW : table<int; NarrativeState>
+let private ITEM_COUNT = 1000
+
+[export]
+def init() {
+    harness_init("list_clipper — 1000-row virtual list", 480, 480)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(440.0, 440.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "list_clipper", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "1000-row virtual list — only the visible chunk is rendered each frame."))
+
+        child(SCROLL_AREA, (text = "scroll", size = float2(400.0f, 360.0f),
+                            child_flags = ImGuiChildFlags.Border,
+                            window_flags = ImGuiWindowFlags.None)) {
+            list_clipper(ITEM_COUNT) $(start; end_) {
+                for (i in range(start, end_)) {
+                    text(CLIPPED_ROW[i], (text = "row {i}"))
+                }
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/list_clipper.das
+++ b/examples/features/list_clipper.das
@@ -7,8 +7,9 @@ require imgui/imgui_harness
 // SHOWS:   `list_clipper(items_count) $(start, end_) { ... }` — block fires
 //          once per visible chunk with `[start, end_)` row indices. Render
 //          exactly those rows inside the block; rows outside the visible
-//          region are SKIPPED entirely (no widget submission). The host
-//          window must be scrollable so the clipper has something to cull.
+//          region are SKIPPED entirely (no widget submission). The current
+//          scrolling region (this demo's `child(SCROLL_AREA, ...)`) must
+//          be scrollable so the clipper has something to cull.
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/list_clipper.das
 // HEADLESS:   daslang.exe modules/dasImgui/examples/features/list_clipper.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/list_clipper.das

--- a/examples/features/log_to_text.das
+++ b/examples/features/log_to_text.das
@@ -1,0 +1,61 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: log_text + log_to_clipboard + log_finish — ImGui log capture rail.
+// SHOWS:   `log_to_clipboard(auto_open_depth?)` opens the log session
+//          targeting the clipboard. `log_text(s)` appends a line. `log_finish()`
+//          closes the session and flushes to the chosen target. Subsequent
+//          text() submissions are ALSO captured between begin/finish (ImGui's
+//          built-in capture for visible widgets). Press the button — the
+//          captured payload lands on the clipboard, paste anywhere.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/log_to_text.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/log_to_text.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/log_to_text.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("log_text / log_to_clipboard / log_finish", 520, 280)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 240.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "log family", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Click the button to capture the three lines below to the clipboard."))
+
+        if (button(COPY_BTN, (text = "copy to clipboard"))) {
+            log_to_clipboard(-1)
+            log_text("Line A — direct log_text submission")
+            log_text("Line B — second log_text line")
+            log_text("Line C — third and final")
+            log_finish()
+        }
+
+        separator(SEP)
+        text(STATIC_1, (text = "Static line above the log session — NOT captured."))
+        text(STATIC_2, (text = "(The clipboard payload only contains the three Line A/B/C lines.)"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/popup_context_window.das
+++ b/examples/features/popup_context_window.das
@@ -1,0 +1,70 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: popup_context_window — right-click context menu over the host
+//                                 window.
+// SHOWS:   `popup_context_window(POPUP, (str_id = "##ctx", flags = MouseButtonRight))`
+//          opens whenever the user right-clicks anywhere inside the enclosing
+//          window. ImGui drives open/close internally; the body runs only
+//          while open. `str_id` is the popup's stack id — use a unique
+//          non-empty string per consumer.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/popup_context_window.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/popup_context_window.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/popup_context_window.das
+// =============================================================================
+
+var private LAST_PICK = "(none yet)"
+
+[export]
+def init() {
+    harness_init("popup_context_window — right-click anywhere", 520, 280)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 240.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "popup_context_window", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Right-click anywhere in this window to open the context menu."))
+        separator(SEP)
+        text(STATUS, (text = "last pick: {LAST_PICK}"))
+
+        popup_context_window(CTX, (str_id = "##ctxwin",
+                                   flags = ImGuiPopupFlags.MouseButtonRight)) {
+            if (menu_item(ITEM_NEW, (text = "New"))) {
+                LAST_PICK = "New"
+            }
+            if (menu_item(ITEM_OPEN, (text = "Open"))) {
+                LAST_PICK = "Open"
+            }
+            if (menu_item(ITEM_SAVE, (text = "Save"))) {
+                LAST_PICK = "Save"
+            }
+            separator(SEP_MENU)
+            if (menu_item(ITEM_QUIT, (text = "Quit"))) {
+                LAST_PICK = "Quit"
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/text_filter.das
+++ b/examples/features/text_filter.das
@@ -1,0 +1,73 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: text_filter + passes_filter — incl/excl text filter rail.
+// SHOWS:   - `text_filter(FILT)` — boost wrapper over ImGuiTextFilter::Draw.
+//            Renders an inline InputText editor; user types comma-separated
+//            include tokens (`foo,bar`) or exclude tokens (`-baz`). Returns
+//            true on the frame the filter expression changes.
+//          - `passes_filter(FILT, line)` — predicate evaluated against the
+//            current filter state. Empty filter = match-all.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/text_filter.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/text_filter.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/text_filter.das
+// =============================================================================
+
+var private LOG_ROW : table<int; NarrativeState>
+
+let private LOG_LINES <- [
+    "INFO  bootstrap done",
+    "DEBUG cache warmed",
+    "WARN  retry attempt 1/3",
+    "ERROR connection timeout",
+    "INFO  request 200 ok",
+    "WARN  retry attempt 2/3",
+    "ERROR connection refused",
+    "INFO  shutdown clean",
+    "DEBUG cache flushed",
+    "INFO  goodbye"
+]
+
+[export]
+def init() {
+    harness_init("text_filter + passes_filter", 520, 420)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 380.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "text_filter", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Try: 'INFO' (incl) / '-DEBUG' (excl) / 'WARN,ERROR' (multi-incl)."))
+        text_filter(FILT, (text = "Filter (incl,-excl)", width = 220.0f))
+
+        separator(SEP)
+
+        for (i in range(length(LOG_LINES))) {
+            if (passes_filter(FILT, LOG_LINES[i])) {
+                text(LOG_ROW[i], (text = "{LOG_LINES[i]}"))
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/tree_node_open_manual.das
+++ b/examples/features/tree_node_open_manual.das
@@ -1,0 +1,66 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: tree_node_open + tree_pop — manual-pair tree node primitives.
+// SHOWS:   - `tree_node_open(label, flags?)` — TreeNodeEx in OPEN form
+//            WITHOUT auto-pair TreePop. Returns true when the node is open;
+//            caller MUST invoke `tree_pop()` when true AND `NoTreePushOnOpen`
+//            flag was NOT set.
+//          - `tree_pop()` — manual TreePop. The `tree_node(...)` block-body
+//            container auto-pairs TreePop; this wrapper is for cases where
+//            the body needs to render OUTSIDE the conditional (e.g. inline
+//            same_line() / extra widgets after the header trigger).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/tree_node_open_manual.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/tree_node_open_manual.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/tree_node_open_manual.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("tree_node_open / tree_pop — manual-pair", 520, 360)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 320.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "tree_node_open + tree_pop", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Header has a sibling button on the SAME line — that pattern needs the manual pair."))
+
+        // Render the header; if open, render an inline same_line widget
+        // OUTSIDE the conditional body, then pop manually.
+        let node_open = tree_node_open("Settings##manual")
+        same_line()
+        if (button(SETTINGS_RESET, (text = "reset"))) {}
+        if (node_open) {
+            text(BODY_HINT, (text = "(node body — rendered only while open)"))
+            text(BODY_LINE_1, (text = "  - option A"))
+            text(BODY_LINE_2, (text = "  - option B"))
+            tree_pop()
+        }
+
+        separator(SEP1)
+        text(NOTE, (text = "Compare: the tree_node(IDENT) container form auto-pairs TreePop for you."))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -3,9 +3,436 @@ options indenting = 4
 
 module app_custom_rendering
 
-require imgui
+require imgui public
+require imgui/imgui_widgets_builtin public
+require imgui/imgui_containers_builtin public
+require imgui/imgui_scope_builtin public
+require imgui/imgui_drawlist_builtin public
+require imgui/imgui_colors public
+require daslib/safe_addr
+require math
 
 // Mirrors imgui_demo.cpp:8122-8423 — static void ShowExampleAppCustomRendering(bool* p_open).
-def ShowExampleAppCustomRendering() {
-    // TODO: port section (imgui_demo.cpp:8122-8423)
+//
+// Four tabs:
+//   - Primitives — gradient strips + a 2-row "All primitives" drawer of
+//                  stroked / filled shapes (ngon / circle / ellipse / square
+//                  / triangle / concave / lines / arc / bezier curves).
+//   - Canvas     — scrollable infinite-grid canvas; left-drag adds lines,
+//                  right-drag pans, right-click opens Remove One / Remove All
+//                  context menu. Lines stored module-scope so they survive
+//                  live-reload.
+//   - BG/FG draw lists — two checkboxes; draws a circle on the background or
+//                  foreground drawlist (escapes ImGui window stacking).
+//   - Draw Channels — channels_split / channels_set_current / channels_merge
+//                  side-by-side with the naive draw order.
+
+// ===== Primitives tab state =====
+
+var private CR_SZ = 36.0f
+var private CR_THICKNESS = 3.0f
+var private CR_NGON_SIDES = 6
+var private CR_CIRCLE_SEG_OVERRIDE = false
+var private CR_CIRCLE_SEG_OVERRIDE_V = 12
+var private CR_CURVE_SEG_OVERRIDE = false
+var private CR_CURVE_SEG_OVERRIDE_V = 8
+var private CR_COLOR = float4(1.0f, 1.0f, 0.4f, 1.0f)
+
+// ===== Canvas tab state =====
+
+var private CR_CANVAS_POINTS : array<float2>
+var private CR_CANVAS_SCROLLING = float2(0.0f, 0.0f)
+var private CR_CANVAS_OPT_GRID = true
+var private CR_CANVAS_OPT_CTX = true
+var private CR_CANVAS_ADDING_LINE = false
+
+// ===== BG/FG tab state =====
+
+var private CR_DRAW_BG = true
+var private CR_DRAW_FG = true
+
+// ===== Helpers =====
+
+// Same shape as imgui_demo.cpp's PathConcaveShape — 9-point spiral that
+// produces a non-convex polygon both for PathStroke and PathFillConcave.
+def private cr_path_concave_shape(var dl : ImDrawList?; x : float; y : float; sz : float) {
+    var pts <- [
+        float2(0.0f, 0.0f), float2(0.5f, 0.4f), float2(0.5f, 0.0f),
+        float2(1.0f, 0.0f), float2(0.6f, 0.6f), float2(1.0f, 1.0f),
+        float2(0.5f, 1.0f), float2(0.5f, 0.6f), float2(0.0f, 1.0f)
+    ]
+    for (p in pts) {
+        dl |> path_line_to(float2(x + p.x * sz, y + p.y * sz))
+    }
+    delete pts
+}
+
+// Pack ImVec4 (sRGB float 0..1) into the packed ABGR uint ImGui draw API
+// expects. Matches ImColor(ImVec4) on the C++ side (no style-alpha multiply).
+def private cr_pack_color(c : float4) : uint {
+    let r = uint(clamp(c.x * 255.0f, 0.0f, 255.0f))
+    let g = uint(clamp(c.y * 255.0f, 0.0f, 255.0f))
+    let b = uint(clamp(c.z * 255.0f, 0.0f, 255.0f))
+    let a = uint(clamp(c.w * 255.0f, 0.0f, 255.0f))
+    return rgba(r, g, b, a)
+}
+
+// ===== Primitives tab =====
+
+def private show_primitives_tab() {
+    with_item_width(-GetFontSize() * 15.0f) {
+        // Gradient strips. ImGui's GetColorU32(IM_COL32(...)) multiplies the
+        // packed color by the current style alpha; the boost-side equivalent
+        // is GetColorU32(rgba(...)) which preserves the same semantics.
+        text(CR_GRAD_LABEL, (text = "Gradients"))
+        let gradient_sz = float2(CalcItemWidth(), GetFrameHeight())
+        {
+            let p0 = GetCursorScreenPos()
+            let p1 = float2(p0.x + gradient_sz.x, p0.y + gradient_sz.y)
+            let col_a = GetColorU32(rgba(0u, 0u, 0u, 255u))
+            let col_b = GetColorU32(rgba(255u, 255u, 255u, 255u))
+            with_window_drawlist() $(var dl) {
+                dl |> add_rect_filled_multi_color(p0, p1, col_a, col_b, col_b, col_a)
+            }
+            invisible_button(CR_GRAD1, (text = "##gradient1", size = gradient_sz))
+        }
+        {
+            let p0 = GetCursorScreenPos()
+            let p1 = float2(p0.x + gradient_sz.x, p0.y + gradient_sz.y)
+            let col_a = GetColorU32(rgba(0u, 255u, 0u, 255u))
+            let col_b = GetColorU32(rgba(255u, 0u, 0u, 255u))
+            with_window_drawlist() $(var dl) {
+                dl |> add_rect_filled_multi_color(p0, p1, col_a, col_b, col_b, col_a)
+            }
+            invisible_button(CR_GRAD2, (text = "##gradient2", size = gradient_sz))
+        }
+
+        // "All primitives" controls.
+        text(CR_ALL_PRIMS_LABEL, (text = "All primitives"))
+        edit_drag_float(safe_addr(CR_SZ),
+            (id = "CR_DRAG_SZ", text = "Size",
+             v_speed = 0.2f, v_min = 2.0f, v_max = 100.0f, format = "%.0f"))
+        edit_drag_float(safe_addr(CR_THICKNESS),
+            (id = "CR_DRAG_TH", text = "Thickness",
+             v_speed = 0.05f, v_min = 1.0f, v_max = 8.0f, format = "%.02f"))
+        edit_slider_int(safe_addr(CR_NGON_SIDES),
+            (id = "CR_SLIDER_NGON", text = "N-gon sides", v_min = 3, v_max = 12))
+        edit_checkbox(safe_addr(CR_CIRCLE_SEG_OVERRIDE),
+            (id = "CR_CB_CIRCLE_OVR", text = "##circlesegmentoverride"))
+        same_line()
+        edit_slider_int(safe_addr(CR_CIRCLE_SEG_OVERRIDE_V),
+            (id = "CR_SLIDER_CIRCLE_OVR", text = "Circle segments override",
+             v_min = 3, v_max = 40))
+        edit_checkbox(safe_addr(CR_CURVE_SEG_OVERRIDE),
+            (id = "CR_CB_CURVE_OVR", text = "##curvessegmentoverride"))
+        same_line()
+        edit_slider_int(safe_addr(CR_CURVE_SEG_OVERRIDE_V),
+            (id = "CR_SLIDER_CURVE_OVR", text = "Curves segments override",
+             v_min = 3, v_max = 40))
+        edit_color_edit4(safe_addr(CR_COLOR), (id = "CR_COLOR_EDIT", text = "Color"))
+
+        // Draw all the primitives row by row, two rows of stroked
+        // (thickness=1, then user thickness) + one row of filled.
+        let p = GetCursorScreenPos()
+        let col = cr_pack_color(CR_COLOR)
+        let spacing = 10.0f
+        let corners_tl_br = (ImDrawFlags.RoundCornersTopLeft |
+                             ImDrawFlags.RoundCornersBottomRight)
+        let rounding = CR_SZ / 5.0f
+        let circle_segments = CR_CIRCLE_SEG_OVERRIDE ? CR_CIRCLE_SEG_OVERRIDE_V : 0
+        let curve_segments = CR_CURVE_SEG_OVERRIDE ? CR_CURVE_SEG_OVERRIDE_V : 0
+        let sz = CR_SZ
+        var cp3 <- [
+            float2(0.0f, sz * 0.6f),
+            float2(sz * 0.5f, -sz * 0.4f),
+            float2(sz, sz)
+        ]
+        var cp4 <- [
+            float2(0.0f, 0.0f),
+            float2(sz * 1.3f, sz * 0.3f),
+            float2(sz - sz * 1.3f, sz - sz * 0.3f),
+            float2(sz, sz)
+        ]
+
+        with_window_drawlist() $(var dl) {
+            var x = p.x + 4.0f
+            var y = p.y + 4.0f
+            for (n in range(2)) {
+                let th = (n == 0) ? 1.0f : CR_THICKNESS
+                dl |> add_ngon(float2(x + sz * 0.5f, y + sz * 0.5f),
+                               sz * 0.5f, col, CR_NGON_SIDES, th); x += sz + spacing
+                dl |> add_circle(float2(x + sz * 0.5f, y + sz * 0.5f),
+                                 sz * 0.5f, col, circle_segments, th); x += sz + spacing
+                dl |> add_ellipse(float2(x + sz * 0.5f, y + sz * 0.5f),
+                                  float2(sz * 0.5f, sz * 0.3f),
+                                  col, -0.3f, circle_segments, th); x += sz + spacing
+                dl |> add_rect(float2(x, y), float2(x + sz, y + sz),
+                               col, 0.0f, ImDrawFlags.None, th); x += sz + spacing
+                dl |> add_rect(float2(x, y), float2(x + sz, y + sz),
+                               col, rounding, ImDrawFlags.None, th); x += sz + spacing
+                dl |> add_rect(float2(x, y), float2(x + sz, y + sz),
+                               col, rounding, corners_tl_br, th); x += sz + spacing
+                dl |> add_triangle(float2(x + sz * 0.5f, y),
+                                   float2(x + sz, y + sz - 0.5f),
+                                   float2(x, y + sz - 0.5f),
+                                   col, th); x += sz + spacing
+                cr_path_concave_shape(dl, x, y, sz)
+                dl |> path_stroke(col, ImDrawFlags.Closed, th); x += sz + spacing
+                dl |> add_line(float2(x, y), float2(x + sz, y), col, th); x += sz + spacing
+                dl |> add_line(float2(x, y), float2(x, y + sz), col, th); x += spacing
+                dl |> add_line(float2(x, y), float2(x + sz, y + sz), col, th); x += sz + spacing
+                dl |> path_arc_to(float2(x + sz * 0.5f, y + sz * 0.5f),
+                                  sz * 0.5f, PI, PI * -0.5f, 0)
+                dl |> path_stroke(col, ImDrawFlags.None, th); x += sz + spacing
+                dl |> add_bezier_quadratic(
+                    float2(x + cp3[0].x, y + cp3[0].y),
+                    float2(x + cp3[1].x, y + cp3[1].y),
+                    float2(x + cp3[2].x, y + cp3[2].y),
+                    col, th, curve_segments); x += sz + spacing
+                dl |> add_bezier_cubic(
+                    float2(x + cp4[0].x, y + cp4[0].y),
+                    float2(x + cp4[1].x, y + cp4[1].y),
+                    float2(x + cp4[2].x, y + cp4[2].y),
+                    float2(x + cp4[3].x, y + cp4[3].y),
+                    col, th, curve_segments)
+                x = p.x + 4.0f
+                y += sz + spacing
+            }
+            // Filled row.
+            dl |> add_ngon_filled(float2(x + sz * 0.5f, y + sz * 0.5f),
+                                  sz * 0.5f, col, CR_NGON_SIDES); x += sz + spacing
+            dl |> add_circle_filled(float2(x + sz * 0.5f, y + sz * 0.5f),
+                                    sz * 0.5f, col, circle_segments); x += sz + spacing
+            dl |> add_ellipse_filled(float2(x + sz * 0.5f, y + sz * 0.5f),
+                                     float2(sz * 0.5f, sz * 0.3f),
+                                     col, -0.3f, circle_segments); x += sz + spacing
+            dl |> add_rect_filled(float2(x, y), float2(x + sz, y + sz), col); x += sz + spacing
+            dl |> add_rect_filled(float2(x, y), float2(x + sz, y + sz),
+                                  col, 10.0f, ImDrawFlags.None); x += sz + spacing
+            dl |> add_rect_filled(float2(x, y), float2(x + sz, y + sz),
+                                  col, 10.0f, corners_tl_br); x += sz + spacing
+            dl |> add_triangle_filled(float2(x + sz * 0.5f, y),
+                                      float2(x + sz, y + sz - 0.5f),
+                                      float2(x, y + sz - 0.5f), col); x += sz + spacing
+            cr_path_concave_shape(dl, x, y, sz)
+            dl |> path_fill_concave(col); x += sz + spacing
+            dl |> add_rect_filled(float2(x, y), float2(x + sz, y + CR_THICKNESS), col); x += sz + spacing
+            dl |> add_rect_filled(float2(x, y), float2(x + CR_THICKNESS, y + sz), col); x += spacing * 2.0f
+            dl |> add_rect_filled(float2(x, y), float2(x + 1.0f, y + 1.0f), col); x += sz
+            dl |> path_arc_to(float2(x + sz * 0.5f, y + sz * 0.5f),
+                              sz * 0.5f, PI * -0.5f, PI, 0)
+            dl |> path_fill_convex(col); x += sz + spacing
+            dl |> path_line_to(float2(x + cp3[0].x, y + cp3[0].y))
+            dl |> path_bezier_quadratic_curve_to(
+                float2(x + cp3[1].x, y + cp3[1].y),
+                float2(x + cp3[2].x, y + cp3[2].y),
+                curve_segments)
+            dl |> path_fill_convex(col); x += sz + spacing
+            dl |> add_rect_filled_multi_color(float2(x, y), float2(x + sz, y + sz),
+                rgba(0u, 0u, 0u, 255u),
+                rgba(255u, 0u, 0u, 255u),
+                rgba(255u, 255u, 0u, 255u),
+                rgba(0u, 255u, 0u, 255u))
+            x += sz + spacing
+        }
+        dummy(CR_PRIM_PAD, (size = float2((sz + spacing) * 13.2f,
+                                           (sz + spacing) * 3.0f)))
+        delete cp3
+        delete cp4
+    }
+}
+
+// ===== Canvas tab =====
+
+def private show_canvas_tab() {
+    edit_checkbox(safe_addr(CR_CANVAS_OPT_GRID),
+        (id = "CR_CV_GRID", text = "Enable grid"))
+    edit_checkbox(safe_addr(CR_CANVAS_OPT_CTX),
+        (id = "CR_CV_CTX", text = "Enable context menu"))
+    text(CR_CV_HINT, (text = "Mouse Left: drag to add lines, Mouse Right: drag to scroll, click for context menu."))
+
+    let canvas_p0 = GetCursorScreenPos()
+    var canvas_sz = GetContentRegionAvail()
+    canvas_sz.x = max(canvas_sz.x, 50.0f)
+    canvas_sz.y = max(canvas_sz.y, 50.0f)
+    let canvas_p1 = float2(canvas_p0.x + canvas_sz.x, canvas_p0.y + canvas_sz.y)
+
+    with_window_drawlist() $(var dl) {
+        dl |> add_rect_filled(canvas_p0, canvas_p1, rgba(50u, 50u, 50u, 255u))
+        dl |> add_rect(canvas_p0, canvas_p1, rgba(255u, 255u, 255u, 255u))
+    }
+
+    invisible_button(CR_CV_CANVAS,
+        (text = "canvas", size = canvas_sz,
+         flags = ImGuiButtonFlags.MouseButtonLeft |
+                 ImGuiButtonFlags.MouseButtonRight))
+    let is_hovered = IsItemHovered(ImGuiHoveredFlags.None)
+    let is_active = IsItemActive()
+    let origin = float2(canvas_p0.x + CR_CANVAS_SCROLLING.x,
+                        canvas_p0.y + CR_CANVAS_SCROLLING.y)
+    let mouse_pos = GetMousePos()
+    let mouse_in_canvas = float2(mouse_pos.x - origin.x, mouse_pos.y - origin.y)
+
+    if (is_hovered && !CR_CANVAS_ADDING_LINE && IsMouseClicked(ImGuiMouseButton.Left, false)) {
+        CR_CANVAS_POINTS |> push(mouse_in_canvas)
+        CR_CANVAS_POINTS |> push(mouse_in_canvas)
+        CR_CANVAS_ADDING_LINE = true
+    }
+    if (CR_CANVAS_ADDING_LINE) {
+        let n = length(CR_CANVAS_POINTS)
+        if (n > 0) {
+            CR_CANVAS_POINTS[n - 1] = mouse_in_canvas
+        }
+        if (!IsMouseDown(ImGuiMouseButton.Left)) {
+            CR_CANVAS_ADDING_LINE = false
+        }
+    }
+
+    let pan_threshold = CR_CANVAS_OPT_CTX ? -1.0f : 0.0f
+    let io & = unsafe(GetIO())
+    if (is_active && IsMouseDragging(ImGuiMouseButton.Right, pan_threshold)) {
+        CR_CANVAS_SCROLLING.x += io.MouseDelta.x
+        CR_CANVAS_SCROLLING.y += io.MouseDelta.y
+    }
+
+    let drag_delta = GetMouseDragDelta(ImGuiMouseButton.Right, -1.0f)
+    if (CR_CANVAS_OPT_CTX && drag_delta.x == 0.0f && drag_delta.y == 0.0f) {
+        open_popup_on_item_click("context", ImGuiPopupFlags.MouseButtonRight)
+    }
+    popup_context_item(CR_CV_CTX_MENU,
+                       (str_id = "context", flags = ImGuiPopupFlags.MouseButtonRight)) {
+        if (CR_CANVAS_ADDING_LINE) {
+            let n = length(CR_CANVAS_POINTS)
+            if (n >= 2) {
+                CR_CANVAS_POINTS |> resize(n - 2)
+            }
+            CR_CANVAS_ADDING_LINE = false
+        }
+        let n = length(CR_CANVAS_POINTS)
+        if (menu_item(CR_CV_REMOVE_ONE,
+                      (text = "Remove one", shortcut = "", enabled = n > 0))) {
+            CR_CANVAS_POINTS |> resize(n - 2)
+        }
+        if (menu_item(CR_CV_REMOVE_ALL,
+                      (text = "Remove all", shortcut = "", enabled = n > 0))) {
+            CR_CANVAS_POINTS |> clear()
+        }
+    }
+
+    with_clip_rect(canvas_p0, canvas_p1, true) {
+        with_window_drawlist() $(var dl) {
+            if (CR_CANVAS_OPT_GRID) {
+                let GRID_STEP = 64.0f
+                let grid_col = rgba(200u, 200u, 200u, 40u)
+                var gx = fmod(CR_CANVAS_SCROLLING.x, GRID_STEP)
+                while (gx < canvas_sz.x) {
+                    dl |> add_line(float2(canvas_p0.x + gx, canvas_p0.y),
+                                   float2(canvas_p0.x + gx, canvas_p1.y),
+                                   grid_col, 1.0f)
+                    gx += GRID_STEP
+                }
+                var gy = fmod(CR_CANVAS_SCROLLING.y, GRID_STEP)
+                while (gy < canvas_sz.y) {
+                    dl |> add_line(float2(canvas_p0.x, canvas_p0.y + gy),
+                                   float2(canvas_p1.x, canvas_p0.y + gy),
+                                   grid_col, 1.0f)
+                    gy += GRID_STEP
+                }
+            }
+            let line_col = rgba(255u, 255u, 0u, 255u)
+            let n = length(CR_CANVAS_POINTS)
+            var i = 0
+            while (i + 1 < n) {
+                let a = CR_CANVAS_POINTS[i]
+                let b = CR_CANVAS_POINTS[i + 1]
+                dl |> add_line(float2(origin.x + a.x, origin.y + a.y),
+                               float2(origin.x + b.x, origin.y + b.y),
+                               line_col, 2.0f)
+                i += 2
+            }
+        }
+    }
+}
+
+// ===== BG/FG draw lists tab =====
+
+def private show_bgfg_tab() {
+    edit_checkbox(safe_addr(CR_DRAW_BG),
+        (id = "CR_BG_TOGGLE", text = "Draw in Background draw list"))
+    edit_checkbox(safe_addr(CR_DRAW_FG),
+        (id = "CR_FG_TOGGLE", text = "Draw in Foreground draw list"))
+    let win_pos = GetWindowPos()
+    let win_sz = GetWindowSize()
+    let center = float2(win_pos.x + win_sz.x * 0.5f, win_pos.y + win_sz.y * 0.5f)
+    if (CR_DRAW_BG) {
+        with_background_drawlist() $(var dl) {
+            dl |> add_circle(center, win_sz.x * 0.6f,
+                             rgba(255u, 0u, 0u, 200u), 0, 14.0f)
+        }
+    }
+    if (CR_DRAW_FG) {
+        with_foreground_drawlist() $(var dl) {
+            dl |> add_circle(center, win_sz.y * 0.6f,
+                             rgba(0u, 255u, 0u, 200u), 0, 10.0f)
+        }
+    }
+}
+
+// ===== Draw Channels tab =====
+
+def private show_channels_tab() {
+    text(CR_CH_NAIVE_1, (text = "Blue shape is drawn first: appears in back"))
+    text(CR_CH_NAIVE_2, (text = "Red shape is drawn after: appears in front"))
+    let p0 = GetCursorScreenPos()
+    with_window_drawlist() $(var dl) {
+        dl |> add_rect_filled(float2(p0.x, p0.y), float2(p0.x + 50.0f, p0.y + 50.0f),
+                              rgba(0u, 0u, 255u, 255u))
+        dl |> add_rect_filled(float2(p0.x + 25.0f, p0.y + 25.0f),
+                              float2(p0.x + 75.0f, p0.y + 75.0f),
+                              rgba(255u, 0u, 0u, 255u))
+    }
+    dummy(CR_CH_NAIVE_PAD, (size = float2(75.0f, 75.0f)))
+    separator(CR_CH_SEP)
+    text(CR_CH_SPLIT_1, (text = "Blue shape is drawn first, into channel 1: appears in front"))
+    text(CR_CH_SPLIT_2, (text = "Red shape is drawn after, into channel 0: appears in back"))
+    let p1 = GetCursorScreenPos()
+    with_window_drawlist() $(var dl) {
+        dl |> channels_split(2)
+        dl |> channels_set_current(1)
+        dl |> add_rect_filled(float2(p1.x, p1.y), float2(p1.x + 50.0f, p1.y + 50.0f),
+                              rgba(0u, 0u, 255u, 255u))
+        dl |> channels_set_current(0)
+        dl |> add_rect_filled(float2(p1.x + 25.0f, p1.y + 25.0f),
+                              float2(p1.x + 75.0f, p1.y + 75.0f),
+                              rgba(255u, 0u, 0u, 255u))
+        dl |> channels_merge()
+    }
+    dummy(CR_CH_SPLIT_PAD, (size = float2(75.0f, 75.0f)))
+    text(CR_CH_SPLIT_NOTE, (text = "After reordering, contents of channel 0 appears below channel 1."))
+}
+
+// ===== Entry point =====
+
+def public ShowExampleAppCustomRendering() {
+    window(CR_WIN, (text = "Example: Custom rendering", closable = true,
+                    flags = ImGuiWindowFlags.None)) {
+        tab_bar(CR_TABS, (text = "##TabBar", flags = ImGuiTabBarFlags.None)) {
+            tab_item(CR_TAB_PRIM, (text = "Primitives", closable = false,
+                                     flags = ImGuiTabItemFlags.None)) {
+                show_primitives_tab()
+            }
+            tab_item(CR_TAB_CANVAS, (text = "Canvas", closable = false,
+                                     flags = ImGuiTabItemFlags.None)) {
+                show_canvas_tab()
+            }
+            tab_item(CR_TAB_BGFG, (text = "BG/FG draw lists", closable = false,
+                                     flags = ImGuiTabItemFlags.None)) {
+                show_bgfg_tab()
+            }
+            tab_item(CR_TAB_CHANNELS, (text = "Draw Channels", closable = false,
+                                       flags = ImGuiTabItemFlags.None)) {
+                show_channels_tab()
+            }
+        }
+    }
 }

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -413,7 +413,7 @@ def private show_channels_tab() {
 
 // ===== Entry point =====
 
-def public ShowExampleAppCustomRendering() {
+def public ShowExampleAppCustomRendering() : bool {
     window(CR_WIN, (text = "Example: Custom rendering", closable = true,
                     flags = ImGuiWindowFlags.None)) {
         tab_bar(CR_TABS, (text = "##TabBar", flags = ImGuiTabBarFlags.None)) {
@@ -435,4 +435,5 @@ def public ShowExampleAppCustomRendering() {
             }
         }
     }
+    return CR_WIN.open
 }

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -127,7 +127,7 @@ def private show_primitives_tab() {
             (id = "CR_CB_CURVE_OVR", text = "##curvessegmentoverride"))
         same_line()
         edit_slider_int(safe_addr(CR_CURVE_SEG_OVERRIDE_V),
-            (id = "CR_SLIDER_CURVE_OVR", text = "Curves segments override",
+            (id = "CR_SLIDER_CURVE_OVR", text = "Curve segments override",
              v_min = 3, v_max = 40))
         edit_color_edit4(safe_addr(CR_COLOR), (id = "CR_COLOR_EDIT", text = "Color"))
 
@@ -414,7 +414,7 @@ def private show_channels_tab() {
         dl |> channels_merge()
     }
     dummy(CR_CH_SPLIT_PAD, (size = float2(75.0f, 75.0f)))
-    text(CR_CH_SPLIT_NOTE, (text = "After reordering, contents of channel 0 appears below channel 1."))
+    text(CR_CH_SPLIT_NOTE, (text = "After reordering, contents of channel 0 appear below channel 1."))
 }
 
 // ===== Entry point =====

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -297,13 +297,14 @@ def private show_canvas_tab() {
 
     let drag_delta = GetMouseDragDelta(ImGuiMouseButton.Right, -1.0f)
     // Mirrors cpp original: `popup` (BeginPopup) is unconditional, but the
-    // ONLY way the popup opens is the explicit OpenPopupOnItemClick path,
-    // double-gated by CR_CANVAS_OPT_CTX and a no-right-drag guard. Using
-    // popup_context_item here would install its OWN RMB opener that bypasses
-    // both guards (round-1 fix only gated open_popup_on_item_click but kept
-    // the popup_context_item rail, so RMB still opened the menu mid-pan).
+    // ONLY way the popup opens is the explicit open_popup_on_item_click
+    // path, double-gated by CR_CANVAS_OPT_CTX and a no-right-drag guard.
+    // Uses the STATEFUL state-arg overload — the string-id form computes
+    // GetID("context") at the call site, which doesn't match the popup
+    // container's BeginPopup ID (the container does its own PushID(IDENT)),
+    // so the popup would never actually open.
     if (CR_CANVAS_OPT_CTX && drag_delta.x == 0.0f && drag_delta.y == 0.0f) {
-        open_popup_on_item_click("context", ImGuiPopupFlags.MouseButtonRight)
+        open_popup_on_item_click(CR_CV_CTX_MENU, ImGuiPopupFlags.MouseButtonRight)
     }
     popup(CR_CV_CTX_MENU,
           (text = "context", flags = ImGuiWindowFlags.None)) {

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -296,26 +296,32 @@ def private show_canvas_tab() {
     }
 
     let drag_delta = GetMouseDragDelta(ImGuiMouseButton.Right, -1.0f)
-    if (CR_CANVAS_OPT_CTX && drag_delta.x == 0.0f && drag_delta.y == 0.0f) {
-        open_popup_on_item_click("context", ImGuiPopupFlags.MouseButtonRight)
-    }
-    popup_context_item(CR_CV_CTX_MENU,
-                       (str_id = "context", flags = ImGuiPopupFlags.MouseButtonRight)) {
-        if (CR_CANVAS_ADDING_LINE) {
+    // Gate the entire context-menu rail behind CR_CANVAS_OPT_CTX.
+    // popup_context_item installs its own RMB handler, so it must NOT
+    // run when the toggle is off — gating only open_popup_on_item_click
+    // would leave the menu opening on right-click anyway.
+    if (CR_CANVAS_OPT_CTX) {
+        if (drag_delta.x == 0.0f && drag_delta.y == 0.0f) {
+            open_popup_on_item_click("context", ImGuiPopupFlags.MouseButtonRight)
+        }
+        popup_context_item(CR_CV_CTX_MENU,
+                           (str_id = "context", flags = ImGuiPopupFlags.MouseButtonRight)) {
+            if (CR_CANVAS_ADDING_LINE) {
+                let n = length(CR_CANVAS_POINTS)
+                if (n >= 2) {
+                    CR_CANVAS_POINTS |> resize(n - 2)
+                }
+                CR_CANVAS_ADDING_LINE = false
+            }
             let n = length(CR_CANVAS_POINTS)
-            if (n >= 2) {
+            if (menu_item(CR_CV_REMOVE_ONE,
+                          (text = "Remove one", shortcut = "", enabled = n > 0))) {
                 CR_CANVAS_POINTS |> resize(n - 2)
             }
-            CR_CANVAS_ADDING_LINE = false
-        }
-        let n = length(CR_CANVAS_POINTS)
-        if (menu_item(CR_CV_REMOVE_ONE,
-                      (text = "Remove one", shortcut = "", enabled = n > 0))) {
-            CR_CANVAS_POINTS |> resize(n - 2)
-        }
-        if (menu_item(CR_CV_REMOVE_ALL,
-                      (text = "Remove all", shortcut = "", enabled = n > 0))) {
-            CR_CANVAS_POINTS |> clear()
+            if (menu_item(CR_CV_REMOVE_ALL,
+                          (text = "Remove all", shortcut = "", enabled = n > 0))) {
+                CR_CANVAS_POINTS |> clear()
+            }
         }
     }
 
@@ -414,6 +420,10 @@ def private show_channels_tab() {
 // ===== Entry point =====
 
 def public ShowExampleAppCustomRendering() : bool {
+    // X-button closes by setting CR_WIN.open=false; the aggregator then
+    // clears its SHOW flag. When the user re-checks the demo checkbox,
+    // re-enter with stale open=false — reset so the window renders again.
+    CR_WIN.open = true
     window(CR_WIN, (text = "Example: Custom rendering", closable = true,
                     flags = ImGuiWindowFlags.None)) {
         tab_bar(CR_TABS, (text = "##TabBar", flags = ImGuiTabBarFlags.None)) {

--- a/examples/imgui_demo/app_custom_rendering.das
+++ b/examples/imgui_demo/app_custom_rendering.das
@@ -296,32 +296,32 @@ def private show_canvas_tab() {
     }
 
     let drag_delta = GetMouseDragDelta(ImGuiMouseButton.Right, -1.0f)
-    // Gate the entire context-menu rail behind CR_CANVAS_OPT_CTX.
-    // popup_context_item installs its own RMB handler, so it must NOT
-    // run when the toggle is off — gating only open_popup_on_item_click
-    // would leave the menu opening on right-click anyway.
-    if (CR_CANVAS_OPT_CTX) {
-        if (drag_delta.x == 0.0f && drag_delta.y == 0.0f) {
-            open_popup_on_item_click("context", ImGuiPopupFlags.MouseButtonRight)
-        }
-        popup_context_item(CR_CV_CTX_MENU,
-                           (str_id = "context", flags = ImGuiPopupFlags.MouseButtonRight)) {
-            if (CR_CANVAS_ADDING_LINE) {
-                let n = length(CR_CANVAS_POINTS)
-                if (n >= 2) {
-                    CR_CANVAS_POINTS |> resize(n - 2)
-                }
-                CR_CANVAS_ADDING_LINE = false
-            }
+    // Mirrors cpp original: `popup` (BeginPopup) is unconditional, but the
+    // ONLY way the popup opens is the explicit OpenPopupOnItemClick path,
+    // double-gated by CR_CANVAS_OPT_CTX and a no-right-drag guard. Using
+    // popup_context_item here would install its OWN RMB opener that bypasses
+    // both guards (round-1 fix only gated open_popup_on_item_click but kept
+    // the popup_context_item rail, so RMB still opened the menu mid-pan).
+    if (CR_CANVAS_OPT_CTX && drag_delta.x == 0.0f && drag_delta.y == 0.0f) {
+        open_popup_on_item_click("context", ImGuiPopupFlags.MouseButtonRight)
+    }
+    popup(CR_CV_CTX_MENU,
+          (text = "context", flags = ImGuiWindowFlags.None)) {
+        if (CR_CANVAS_ADDING_LINE) {
             let n = length(CR_CANVAS_POINTS)
-            if (menu_item(CR_CV_REMOVE_ONE,
-                          (text = "Remove one", shortcut = "", enabled = n > 0))) {
+            if (n >= 2) {
                 CR_CANVAS_POINTS |> resize(n - 2)
             }
-            if (menu_item(CR_CV_REMOVE_ALL,
-                          (text = "Remove all", shortcut = "", enabled = n > 0))) {
-                CR_CANVAS_POINTS |> clear()
-            }
+            CR_CANVAS_ADDING_LINE = false
+        }
+        let n = length(CR_CANVAS_POINTS)
+        if (menu_item(CR_CV_REMOVE_ONE,
+                      (text = "Remove one", shortcut = "", enabled = n > 0))) {
+            CR_CANVAS_POINTS |> resize(n - 2)
+        }
+        if (menu_item(CR_CV_REMOVE_ALL,
+                      (text = "Remove all", shortcut = "", enabled = n > 0))) {
+            CR_CANVAS_POINTS |> clear()
         }
     }
 

--- a/examples/imgui_demo/app_dockspace.das
+++ b/examples/imgui_demo/app_dockspace.das
@@ -62,10 +62,20 @@ def private current_dockspace_flags() : ImGuiDockNodeFlags {
     return unsafe(reinterpret<ImGuiDockNodeFlags>(bits))
 }
 
+def private current_host_flags() : ImGuiWindowFlags {
+    // PassthruCentralNode only works when the host window itself is
+    // background-less; without NoBackground the host fill covers the
+    // central node and the pass-through visual is suppressed.
+    var bits = int(ImGuiWindowFlags.MenuBar | ImGuiWindowFlags.NoDocking)
+    if (DS_FLAG_PASSTHRU_CENTRAL) {
+        bits |= int(ImGuiWindowFlags.NoBackground)
+    }
+    return unsafe(reinterpret<ImGuiWindowFlags>(bits))
+}
+
 def private render_ds_window() {
     window(DS_WIN, (text = "DockSpace Demo", closable = true,
-                    flags = ImGuiWindowFlags.MenuBar |
-                            ImGuiWindowFlags.NoDocking)) {
+                    flags = current_host_flags())) {
         menu_bar(DS_MENU) {
             menu(DS_OPTIONS_MENU, (text = "Options", enabled = true)) {
                 edit_checkbox(safe_addr(DS_PADDING),

--- a/examples/imgui_demo/app_dockspace.das
+++ b/examples/imgui_demo/app_dockspace.das
@@ -3,9 +3,110 @@ options indenting = 4
 
 module app_dockspace
 
-require imgui
+require imgui public
+require imgui/imgui_widgets_builtin public
+require imgui/imgui_containers_builtin public
+require imgui/imgui_docking_builtin public
+require daslib/safe_addr
 
 // Mirrors imgui_demo.cpp:8424-8551 — static void ShowExampleAppDockSpace(bool* p_open).
-def ShowExampleAppDockSpace() {
-    // TODO: port section (imgui_demo.cpp:8424-8551)
+//
+// The C++ original supports a "fullscreen" mode that claims the full viewport
+// via SetNextWindowPos/Size/Viewport + WindowRounding/BorderSize style-vars +
+// NoTitleBar/NoCollapse/NoResize/NoMove window flags. We port the simpler
+// floating-host form (which the C++ comments call out as the typical use).
+// The floating form still shows the load-bearing pieces: a host window with
+// its own MenuBar + NoDocking (so the host itself isn't dockable into),
+// dockspace_in_window for the explicit DockSpace call, dockspace flag
+// toggles, and the "Close" menu item routing through take_close_request().
+
+// ===== Module-scope state =====
+
+var private DS_PADDING = false
+var private DS_FLAG_NO_DOCKING_OVER_CENTRAL = false
+var private DS_FLAG_NO_DOCKING_SPLIT = false
+var private DS_FLAG_NO_UNDOCKING = false
+var private DS_FLAG_NO_RESIZE = false
+var private DS_FLAG_AUTO_HIDE_TAB_BAR = false
+var private DS_FLAG_PASSTHRU_CENTRAL = false
+
+// Set by the "Close" menu entry; caller polls via take_close_request().
+var private DS_REQUEST_CLOSE = false
+
+def public take_close_request() : bool {
+    let v = DS_REQUEST_CLOSE
+    DS_REQUEST_CLOSE = false
+    return v
+}
+
+def private current_dockspace_flags() : ImGuiDockNodeFlags {
+    // ImGuiDockNodeFlags is a plain int enum on the C++ side; build the bit
+    // set as int and cast back at the call site.
+    var bits = 0
+    if (DS_FLAG_NO_DOCKING_OVER_CENTRAL) {
+        bits |= int(ImGuiDockNodeFlags.NoDockingOverCentralNode)
+    }
+    if (DS_FLAG_NO_DOCKING_SPLIT) {
+        bits |= int(ImGuiDockNodeFlags.NoDockingSplit)
+    }
+    if (DS_FLAG_NO_UNDOCKING) {
+        bits |= int(ImGuiDockNodeFlags.NoUndocking)
+    }
+    if (DS_FLAG_NO_RESIZE) {
+        bits |= int(ImGuiDockNodeFlags.NoResize)
+    }
+    if (DS_FLAG_AUTO_HIDE_TAB_BAR) {
+        bits |= int(ImGuiDockNodeFlags.AutoHideTabBar)
+    }
+    if (DS_FLAG_PASSTHRU_CENTRAL) {
+        bits |= int(ImGuiDockNodeFlags.PassthruCentralNode)
+    }
+    return unsafe(reinterpret<ImGuiDockNodeFlags>(bits))
+}
+
+def public ShowExampleAppDockSpace() {
+    SetNextWindowSize(ImVec2(720.0f, 480.0f), ImGuiCond.FirstUseEver)
+    window(DS_WIN, (text = "DockSpace Demo", closable = true,
+                    flags = ImGuiWindowFlags.MenuBar |
+                            ImGuiWindowFlags.NoDocking)) {
+        menu_bar(DS_MENU) {
+            menu(DS_OPTIONS_MENU, (text = "Options", enabled = true)) {
+                edit_checkbox(safe_addr(DS_PADDING),
+                    (id = "DS_PADDING_CB", text = "Padding"))
+                separator(DS_SEP_PAD)
+
+                edit_checkbox(safe_addr(DS_FLAG_NO_DOCKING_OVER_CENTRAL),
+                    (id = "DS_F_NDOC_CN", text = "Flag: NoDockingOverCentralNode"))
+                edit_checkbox(safe_addr(DS_FLAG_NO_DOCKING_SPLIT),
+                    (id = "DS_F_NDOC_SPLIT", text = "Flag: NoDockingSplit"))
+                edit_checkbox(safe_addr(DS_FLAG_NO_UNDOCKING),
+                    (id = "DS_F_NO_UNDOCK", text = "Flag: NoUndocking"))
+                edit_checkbox(safe_addr(DS_FLAG_NO_RESIZE),
+                    (id = "DS_F_NO_RESIZE", text = "Flag: NoResize"))
+                edit_checkbox(safe_addr(DS_FLAG_AUTO_HIDE_TAB_BAR),
+                    (id = "DS_F_AUTO_HIDE", text = "Flag: AutoHideTabBar"))
+                edit_checkbox(safe_addr(DS_FLAG_PASSTHRU_CENTRAL),
+                    (id = "DS_F_PASSTHRU", text = "Flag: PassthruCentralNode"))
+                separator(DS_SEP_CLOSE)
+
+                if (menu_item(DS_CLOSE_ITEM,
+                              (text = "Close", shortcut = "", enabled = true))) {
+                    DS_REQUEST_CLOSE = true
+                }
+            }
+        }
+
+        dockspace_in_window(DS, (size = float2(0.0f, 0.0f),
+                                 flags = current_dockspace_flags())) {
+            // Sample dockable panels so the dockspace has content.
+            dock_window(DS_PANEL_A, (text = "Panel A", closable = false,
+                                     flags = ImGuiWindowFlags.None)) {
+                text(DS_PANEL_A_LINE, (text = "Drag this tab to dock / undock."))
+            }
+            dock_window(DS_PANEL_B, (text = "Panel B", closable = false,
+                                     flags = ImGuiWindowFlags.None)) {
+                text(DS_PANEL_B_LINE, (text = "Right-click the title for the window menu."))
+            }
+        }
+    }
 }

--- a/examples/imgui_demo/app_dockspace.das
+++ b/examples/imgui_demo/app_dockspace.das
@@ -30,14 +30,11 @@ var private DS_FLAG_NO_RESIZE = false
 var private DS_FLAG_AUTO_HIDE_TAB_BAR = false
 var private DS_FLAG_PASSTHRU_CENTRAL = false
 
-// Set by the "Close" menu entry; caller polls via take_close_request().
+// Set by the "Close" menu entry. ShowExampleAppDockSpace returns false when
+// this flips OR when the X-button closes the window, so the aggregator's
+// `if (SHOW_X && !ShowExampleAppDockSpace()) SHOW_X = false` pattern works
+// uniformly across both close paths.
 var private DS_REQUEST_CLOSE = false
-
-def public take_close_request() : bool {
-    let v = DS_REQUEST_CLOSE
-    DS_REQUEST_CLOSE = false
-    return v
-}
 
 def private current_dockspace_flags() : ImGuiDockNodeFlags {
     // ImGuiDockNodeFlags is a plain int enum on the C++ side; build the bit
@@ -64,7 +61,7 @@ def private current_dockspace_flags() : ImGuiDockNodeFlags {
     return unsafe(reinterpret<ImGuiDockNodeFlags>(bits))
 }
 
-def public ShowExampleAppDockSpace() {
+def public ShowExampleAppDockSpace() : bool {
     SetNextWindowSize(ImVec2(720.0f, 480.0f), ImGuiCond.FirstUseEver)
     window(DS_WIN, (text = "DockSpace Demo", closable = true,
                     flags = ImGuiWindowFlags.MenuBar |
@@ -109,4 +106,7 @@ def public ShowExampleAppDockSpace() {
             }
         }
     }
+    let menu_closed = DS_REQUEST_CLOSE
+    DS_REQUEST_CLOSE = false
+    return DS_WIN.open && !menu_closed
 }

--- a/examples/imgui_demo/app_dockspace.das
+++ b/examples/imgui_demo/app_dockspace.das
@@ -7,6 +7,7 @@ require imgui public
 require imgui/imgui_widgets_builtin public
 require imgui/imgui_containers_builtin public
 require imgui/imgui_docking_builtin public
+require imgui/imgui_style_builtin public
 require daslib/safe_addr
 
 // Mirrors imgui_demo.cpp:8424-8551 — static void ShowExampleAppDockSpace(bool* p_open).
@@ -61,8 +62,7 @@ def private current_dockspace_flags() : ImGuiDockNodeFlags {
     return unsafe(reinterpret<ImGuiDockNodeFlags>(bits))
 }
 
-def public ShowExampleAppDockSpace() : bool {
-    SetNextWindowSize(ImVec2(720.0f, 480.0f), ImGuiCond.FirstUseEver)
+def private render_ds_window() {
     window(DS_WIN, (text = "DockSpace Demo", closable = true,
                     flags = ImGuiWindowFlags.MenuBar |
                             ImGuiWindowFlags.NoDocking)) {
@@ -104,6 +104,28 @@ def public ShowExampleAppDockSpace() : bool {
                                      flags = ImGuiWindowFlags.None)) {
                 text(DS_PANEL_B_LINE, (text = "Right-click the title for the window menu."))
             }
+        }
+    }
+}
+
+def public ShowExampleAppDockSpace() : bool {
+    // ConfigFlags.DockingEnable is set by the standalone harness; the
+    // imgui_demo aggregator path doesn't, so flip it on at entry. Idempotent.
+    var io & = unsafe(GetIO())
+    io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
+    // X-button closes by flipping DS_WIN.open=false; the aggregator then
+    // clears its SHOW flag and stops calling us. When the user re-checks
+    // the demo checkbox, we're re-entered with the stale open=false — reset
+    // so the window renders again.
+    DS_WIN.open = true
+    SetNextWindowSize(ImVec2(720.0f, 480.0f), ImGuiCond.FirstUseEver)
+    // Match the C++ original: when "Padding" is off, push zero WindowPadding
+    // around the host window's Begin so the dockspace fills edge-to-edge.
+    if (DS_PADDING) {
+        render_ds_window()
+    } else {
+        with_style((ImGuiStyleVar.WindowPadding, float2(0.0f, 0.0f))) {
+            render_ds_window()
         }
     }
     let menu_closed = DS_REQUEST_CLOSE

--- a/examples/imgui_demo/app_documents.das
+++ b/examples/imgui_demo/app_documents.das
@@ -26,7 +26,6 @@ require math
 struct MyDocument {
     name : string
     open : bool                 //! visible in the tab bar
-    open_prev : bool            //! copy of open from last frame
     dirty : bool                //! modified flag (drives UnsavedDocument)
     want_close : bool           //! enqueued for close confirmation
     color : float4              //! per-doc text color
@@ -35,7 +34,7 @@ struct MyDocument {
 def new_doc(name : string;
             open : bool = true;
             color : float4 = float4(1.0f, 1.0f, 1.0f, 1.0f)) : MyDocument {
-    return MyDocument(name = name, open = open, open_prev = open,
+    return MyDocument(name = name, open = open,
                       dirty = false, want_close = false, color = color)
 }
 
@@ -194,7 +193,7 @@ def private show_close_confirm() {
     popup_modal(DOCS_CLOSE_MODAL, (text = "Save?", closable = false,
                                    flags = ImGuiWindowFlags.AlwaysAutoResize)) {
         text(DOCS_CLOSE_PROMPT,
-             (text = "Save change to the following items?"))
+             (text = "Save changes to the following items?"))
         let item_height = GetTextLineHeightWithSpacing()
         child(DOCS_CLOSE_LIST,
               (text = "frame", size = float2(-1.0f, 6.25f * item_height),
@@ -243,6 +242,10 @@ def public ShowExampleAppDocuments() : bool {
         seed_docs()
         DOCS_SEEDED = true
     }
+    // X-button closes by setting DOCS_WIN.open=false; the aggregator then
+    // clears its SHOW flag. When the user re-checks the demo checkbox,
+    // re-enter with stale open=false — reset so the window renders again.
+    DOCS_WIN.open = true
     SetNextWindowSize(ImVec2(640.0f, 480.0f), ImGuiCond.FirstUseEver)
     window(DOCS_WIN, (text = "Example: Documents", closable = true,
                       flags = ImGuiWindowFlags.MenuBar)) {
@@ -250,18 +253,20 @@ def public ShowExampleAppDocuments() : bool {
             file_menu()
         }
 
-        // Debug row: per-doc checkbox to toggle visibility.
+        // Debug row: per-doc checkbox to toggle visibility. The checkbox's
+        // ToggleState.value defaults to false; mirror doc.open into it each
+        // frame so the visible state matches the data, and the click handler
+        // routes the new ToggleState.value back into doc.open.
         for (i in range(length(DOCS))) {
             var doc & = unsafe(DOCS[i])
+            DOCS_OPEN_CHECKBOX[i].value = doc.open
             if (i > 0) {
                 same_line(DOCS_DEBUG_SL[i])
             }
             if (checkbox(DOCS_OPEN_CHECKBOX[i], (text = doc.name))) {
-                if (!DOCS_OPEN_CHECKBOX[i].value) {
-                    doc.open = false
+                doc.open = DOCS_OPEN_CHECKBOX[i].value
+                if (!doc.open) {
                     doc.dirty = false
-                } else {
-                    doc.open = true
                 }
             }
         }
@@ -274,6 +279,12 @@ def public ShowExampleAppDocuments() : bool {
             for (i in range(length(DOCS))) {
                 var doc & = unsafe(DOCS[i])
                 continue if (!doc.open)
+                // DOCS_TAB[i].open backs ImGui's p_open via the closable
+                // tab_item — seed it from doc.open each frame so the tab
+                // can be reopened after a prior X-close (otherwise its
+                // .open stays false from the close and File>Open or the
+                // debug checkbox would only set doc.open, not the tab).
+                DOCS_TAB[i].open = true
                 let tab_flags = (doc.dirty
                                  ? ImGuiTabItemFlags.UnsavedDocument
                                  : ImGuiTabItemFlags.None)

--- a/examples/imgui_demo/app_documents.das
+++ b/examples/imgui_demo/app_documents.das
@@ -59,14 +59,9 @@ var private DOCS_OPEN_CHECKBOX : table<int; ToggleState>
 var private DOCS_CLOSE_NAME : table<int; NarrativeState>
 var private DOCS_DEBUG_SL : table<int; EmptyMarkerState>
 
-// "Close" menu sets the close-this-window request; caller polls.
+// "Exit" menu sets this; ShowExampleAppDocuments returns false when set OR
+// when the X-button closes the window.
 var private DOCS_REQUEST_CLOSE = false
-
-def public take_close_request() : bool {
-    let v = DOCS_REQUEST_CLOSE
-    DOCS_REQUEST_CLOSE = false
-    return v
-}
 
 def private seed_docs() {
     DOCS |> emplace(new_doc("Lettuce", true, float4(0.4f, 0.8f, 0.4f, 1.0f)))
@@ -243,7 +238,7 @@ def private show_close_confirm() {
 
 // ===== Entry point =====
 
-def public ShowExampleAppDocuments() {
+def public ShowExampleAppDocuments() : bool {
     if (!DOCS_SEEDED) {
         seed_docs()
         DOCS_SEEDED = true
@@ -302,4 +297,7 @@ def public ShowExampleAppDocuments() {
         rebuild_close_queue()
         show_close_confirm()
     }
+    let menu_closed = DOCS_REQUEST_CLOSE
+    DOCS_REQUEST_CLOSE = false
+    return DOCS_WIN.open && !menu_closed
 }

--- a/examples/imgui_demo/app_documents.das
+++ b/examples/imgui_demo/app_documents.das
@@ -187,7 +187,12 @@ def private show_close_confirm() {
         return
     }
     if (!POPUP_OPEN_LATCH) {
-        open_popup("Save?", ImGuiPopupFlags.None)
+        // Stateful overload — open_popup("Save?", ...) string-id form
+        // computes GetID("Save?") at this call site, which doesn't match
+        // the popup_modal container's BeginPopupModal ID (the container
+        // does its own PushID(DOCS_CLOSE_MODAL)), so the modal would
+        // never display.
+        open_popup(DOCS_CLOSE_MODAL)
         POPUP_OPEN_LATCH = true
     }
     popup_modal(DOCS_CLOSE_MODAL, (text = "Save?", closable = false,

--- a/examples/imgui_demo/app_documents.das
+++ b/examples/imgui_demo/app_documents.das
@@ -3,9 +3,303 @@ options indenting = 4
 
 module app_documents
 
-require imgui
+require imgui public
+require imgui/imgui_widgets_builtin public
+require imgui/imgui_containers_builtin public
+require imgui/imgui_scope_builtin public
+require imgui/imgui_style_builtin public
+require imgui/imgui_colors public
+require daslib/safe_addr
+require math
 
-// Mirrors imgui_demo.cpp:8552-end — static void ShowExampleAppDocuments(bool* p_open).
-def ShowExampleAppDocuments() {
-    // TODO: port section (imgui_demo.cpp:8552-end)
+// Mirrors imgui_demo.cpp:8552-8900 — static void ShowExampleAppDocuments(bool* p_open).
+//
+// Scope: ports the Target_Tab mode (the C++ default — local tab bar with
+// per-document tabs + per-tab context menu + close-confirmation popup_modal
+// queue for dirty docs). Skipped: Target_None (no-op) and
+// Target_DockSpaceAndWindow (would require a second flag-toggle code path
+// + the dockspace-inside-window pattern + extra docking dance not worth
+// the demo noise here).
+
+// ===== MyDocument =====
+
+struct MyDocument {
+    name : string
+    open : bool                 //! visible in the tab bar
+    open_prev : bool            //! copy of open from last frame
+    dirty : bool                //! modified flag (drives UnsavedDocument)
+    want_close : bool           //! enqueued for close confirmation
+    color : float4              //! per-doc text color
+}
+
+def new_doc(name : string;
+            open : bool = true;
+            color : float4 = float4(1.0f, 1.0f, 1.0f, 1.0f)) : MyDocument {
+    return MyDocument(name = name, open = open, open_prev = open,
+                      dirty = false, want_close = false, color = color)
+}
+
+// ===== Module-scope state =====
+
+var private DOCS : array<MyDocument>
+var private DOCS_SEEDED = false
+var private CLOSE_QUEUE : array<int>     //! indices into DOCS pending confirmation
+var private POPUP_OPEN_LATCH = false      //! once-per-queue OpenPopup gate
+
+// Per-doc dynamic states. The [container]/[widget] macros auto-emit a SINGLE
+// global per ident; for per-row loops we explicitly declare an indexed table.
+var private DOCS_TAB : table<int; TabItemState>
+var private DOCS_CTX : table<int; PopupContextItemState>
+var private DOCS_MODIFY_BTN : table<int; ClickState>
+var private DOCS_SAVE_BTN : table<int; ClickState>
+var private DOCS_CTX_SAVE_ITEM : table<int; ToggleState>
+var private DOCS_CTX_CLOSE_ITEM : table<int; ToggleState>
+var private DOCS_OPEN_SUBMENU_ITEM : table<int; ToggleState>
+var private DOCS_OPEN_CHECKBOX : table<int; ToggleState>
+var private DOCS_CLOSE_NAME : table<int; NarrativeState>
+var private DOCS_DEBUG_SL : table<int; EmptyMarkerState>
+
+// "Close" menu sets the close-this-window request; caller polls.
+var private DOCS_REQUEST_CLOSE = false
+
+def public take_close_request() : bool {
+    let v = DOCS_REQUEST_CLOSE
+    DOCS_REQUEST_CLOSE = false
+    return v
+}
+
+def private seed_docs() {
+    DOCS |> emplace(new_doc("Lettuce", true, float4(0.4f, 0.8f, 0.4f, 1.0f)))
+    DOCS |> emplace(new_doc("Eggplant", true, float4(0.8f, 0.5f, 1.0f, 1.0f)))
+    DOCS |> emplace(new_doc("Carrot", true, float4(1.0f, 0.8f, 0.5f, 1.0f)))
+    DOCS |> emplace(new_doc("Tomato", false, float4(1.0f, 0.3f, 0.4f, 1.0f)))
+    DOCS |> emplace(new_doc("A Rather Long Title", false))
+    DOCS |> emplace(new_doc("Some Document", false))
+}
+
+def private pack_color(c : float4) : uint {
+    let r = uint(clamp(c.x * 255.0f, 0.0f, 255.0f))
+    let g = uint(clamp(c.y * 255.0f, 0.0f, 255.0f))
+    let b = uint(clamp(c.z * 255.0f, 0.0f, 255.0f))
+    let a = uint(clamp(c.w * 255.0f, 0.0f, 255.0f))
+    return rgba(r, g, b, a)
+}
+
+// ===== Per-doc UI helpers =====
+
+def private display_contents(idx : int) {
+    var doc & = unsafe(DOCS[idx])
+    text(DOCS_TITLE, (text = "Document \"{doc.name}\""))
+        with_style((ImGuiCol.Text, pack_color(doc.color))) {
+            text_wrapped(DOCS_LOREM,
+                         (text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."))
+        }
+        if (button(DOCS_MODIFY_BTN[idx], (text = "Modify", size = float2(100.0f, 0.0f)))) {
+            doc.dirty = true
+        }
+        same_line()
+        if (button(DOCS_SAVE_BTN[idx], (text = "Save", size = float2(100.0f, 0.0f)))) {
+            doc.dirty = false
+        }
+    edit_color_edit4(safe_addr(doc.color), (id = "doc_color", text = "color",
+                                            flags = ImGuiColorEditFlags.None))
+}
+
+def private display_context_menu(idx : int) {
+    var doc & = unsafe(DOCS[idx])
+    popup_context_item(DOCS_CTX[idx], (str_id = "##doc_ctx_{idx}",
+                                       flags = ImGuiPopupFlags.MouseButtonRight)) {
+        if (menu_item(DOCS_CTX_SAVE_ITEM[idx],
+                      (text = "Save {doc.name}", shortcut = "CTRL+S",
+                       enabled = doc.open))) {
+            doc.dirty = false
+        }
+        if (menu_item(DOCS_CTX_CLOSE_ITEM[idx],
+                      (text = "Close", shortcut = "CTRL+W",
+                       enabled = doc.open))) {
+            doc.want_close = true
+        }
+    }
+}
+
+// ===== File menu =====
+
+def private file_menu() {
+    menu(DOCS_FILE_MENU, (text = "File", enabled = true)) {
+        var open_count = 0
+        for (d in DOCS) {
+            if (d.open) {
+                open_count++
+            }
+        }
+        menu(DOCS_OPEN_SUBMENU,
+             (text = "Open", enabled = open_count < length(DOCS))) {
+            for (i in range(length(DOCS))) {
+                var doc & = unsafe(DOCS[i])
+                if (!doc.open) {
+                    if (menu_item(DOCS_OPEN_SUBMENU_ITEM[i],
+                                  (text = doc.name, shortcut = "", enabled = true))) {
+                        doc.open = true
+                    }
+                }
+            }
+        }
+        if (menu_item(DOCS_CLOSE_ALL,
+                      (text = "Close All Documents", shortcut = "",
+                       enabled = open_count > 0))) {
+            for (i in range(length(DOCS))) {
+                DOCS[i].want_close = true
+            }
+        }
+        if (menu_item(DOCS_EXIT_ITEM,
+                      (text = "Exit", shortcut = "Ctrl+F4", enabled = true))) {
+            DOCS_REQUEST_CLOSE = true
+        }
+    }
+}
+
+// ===== Close-confirmation popup_modal =====
+
+def private rebuild_close_queue() {
+    if (!empty(CLOSE_QUEUE)) return
+    for (i in range(length(DOCS))) {
+        if (DOCS[i].want_close) {
+            DOCS[i].want_close = false
+            CLOSE_QUEUE |> push(i)
+        }
+    }
+}
+
+def private drain_close_queue_clean() {
+    // No dirty docs: just close them all.
+    for (i in CLOSE_QUEUE) {
+        DOCS[i].open = false
+        DOCS[i].dirty = false
+    }
+    CLOSE_QUEUE |> clear()
+    POPUP_OPEN_LATCH = false
+}
+
+def private show_close_confirm() {
+    if (empty(CLOSE_QUEUE)) return
+    var dirty_count = 0
+    for (i in CLOSE_QUEUE) {
+        if (DOCS[i].dirty) {
+            dirty_count++
+        }
+    }
+    if (dirty_count == 0) {
+        drain_close_queue_clean()
+        return
+    }
+    if (!POPUP_OPEN_LATCH) {
+        open_popup("Save?", ImGuiPopupFlags.None)
+        POPUP_OPEN_LATCH = true
+    }
+    popup_modal(DOCS_CLOSE_MODAL, (text = "Save?", closable = false,
+                                   flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+        text(DOCS_CLOSE_PROMPT,
+             (text = "Save change to the following items?"))
+        let item_height = GetTextLineHeightWithSpacing()
+        child(DOCS_CLOSE_LIST,
+              (text = "frame", size = float2(-1.0f, 6.25f * item_height),
+               child_flags = ImGuiChildFlags.FrameStyle,
+               window_flags = ImGuiWindowFlags.None)) {
+            for (n in range(length(CLOSE_QUEUE))) {
+                let idx = CLOSE_QUEUE[n]
+                if (DOCS[idx].dirty) {
+                    text(DOCS_CLOSE_NAME[n], (text = DOCS[idx].name))
+                }
+            }
+        }
+        let btn_sz = float2(GetFontSize() * 7.0f, 0.0f)
+        if (button(DOCS_CLOSE_YES, (text = "Yes", size = btn_sz))) {
+            for (idx in CLOSE_QUEUE) {
+                DOCS[idx].dirty = false
+                DOCS[idx].open = false
+            }
+            CLOSE_QUEUE |> clear()
+            POPUP_OPEN_LATCH = false
+            close_current_popup(DOCS_CLOSE_MODAL)
+        }
+        same_line()
+        if (button(DOCS_CLOSE_NO, (text = "No", size = btn_sz))) {
+            for (idx in CLOSE_QUEUE) {
+                DOCS[idx].open = false
+                DOCS[idx].dirty = false
+            }
+            CLOSE_QUEUE |> clear()
+            POPUP_OPEN_LATCH = false
+            close_current_popup(DOCS_CLOSE_MODAL)
+        }
+        same_line()
+        if (button(DOCS_CLOSE_CANCEL, (text = "Cancel", size = btn_sz))) {
+            CLOSE_QUEUE |> clear()
+            POPUP_OPEN_LATCH = false
+            close_current_popup(DOCS_CLOSE_MODAL)
+        }
+    }
+}
+
+// ===== Entry point =====
+
+def public ShowExampleAppDocuments() {
+    if (!DOCS_SEEDED) {
+        seed_docs()
+        DOCS_SEEDED = true
+    }
+    SetNextWindowSize(ImVec2(640.0f, 480.0f), ImGuiCond.FirstUseEver)
+    window(DOCS_WIN, (text = "Example: Documents", closable = true,
+                      flags = ImGuiWindowFlags.MenuBar)) {
+        menu_bar(DOCS_MENUBAR) {
+            file_menu()
+        }
+
+        // Debug row: per-doc checkbox to toggle visibility.
+        for (i in range(length(DOCS))) {
+            var doc & = unsafe(DOCS[i])
+            if (i > 0) {
+                same_line(DOCS_DEBUG_SL[i])
+            }
+            if (checkbox(DOCS_OPEN_CHECKBOX[i], (text = doc.name))) {
+                if (!DOCS_OPEN_CHECKBOX[i].value) {
+                    doc.open = false
+                    doc.dirty = false
+                } else {
+                    doc.open = true
+                }
+            }
+        }
+        separator(DOCS_SEP_DEBUG)
+
+        // Tabs: one per open document. UnsavedDocument flag drives the dot
+        // + the X-button-cancels-when-dirty behavior.
+        tab_bar(DOCS_TABS, (text = "##tabs",
+                            flags = ImGuiTabBarFlags.Reorderable)) {
+            for (i in range(length(DOCS))) {
+                var doc & = unsafe(DOCS[i])
+                continue if (!doc.open)
+                let tab_flags = (doc.dirty
+                                 ? ImGuiTabItemFlags.UnsavedDocument
+                                 : ImGuiTabItemFlags.None)
+                tab_item(DOCS_TAB[i], (text = doc.name, closable = true,
+                                       flags = tab_flags)) {
+                    // Cancel close attempt when dirty: requeue + reopen.
+                    let tab_open = DOCS_TAB[i].open
+                    if (!tab_open && doc.dirty) {
+                        DOCS_TAB[i].open = true
+                        doc.open = true
+                        doc.want_close = true
+                    } elif (!tab_open) {
+                        doc.open = false
+                    }
+                    display_context_menu(i)
+                    display_contents(i)
+                }
+            }
+        }
+
+        rebuild_close_queue()
+        show_close_confirm()
+    }
 }

--- a/examples/imgui_demo/app_documents.das
+++ b/examples/imgui_demo/app_documents.das
@@ -84,17 +84,17 @@ def private pack_color(c : float4) : uint {
 def private display_contents(idx : int) {
     var doc & = unsafe(DOCS[idx])
     text(DOCS_TITLE, (text = "Document \"{doc.name}\""))
-        with_style((ImGuiCol.Text, pack_color(doc.color))) {
-            text_wrapped(DOCS_LOREM,
-                         (text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."))
-        }
-        if (button(DOCS_MODIFY_BTN[idx], (text = "Modify", size = float2(100.0f, 0.0f)))) {
-            doc.dirty = true
-        }
-        same_line()
-        if (button(DOCS_SAVE_BTN[idx], (text = "Save", size = float2(100.0f, 0.0f)))) {
-            doc.dirty = false
-        }
+    with_style((ImGuiCol.Text, pack_color(doc.color))) {
+        text_wrapped(DOCS_LOREM,
+                     (text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."))
+    }
+    if (button(DOCS_MODIFY_BTN[idx], (text = "Modify", size = float2(100.0f, 0.0f)))) {
+        doc.dirty = true
+    }
+    same_line()
+    if (button(DOCS_SAVE_BTN[idx], (text = "Save", size = float2(100.0f, 0.0f)))) {
+        doc.dirty = false
+    }
     edit_color_edit4(safe_addr(doc.color), (id = "doc_color", text = "color",
                                             flags = ImGuiColorEditFlags.None))
 }
@@ -290,17 +290,25 @@ def public ShowExampleAppDocuments() : bool {
                                  : ImGuiTabItemFlags.None)
                 tab_item(DOCS_TAB[i], (text = doc.name, closable = true,
                                        flags = tab_flags)) {
-                    // Cancel close attempt when dirty: requeue + reopen.
-                    let tab_open = DOCS_TAB[i].open
-                    if (!tab_open && doc.dirty) {
-                        DOCS_TAB[i].open = true
-                        doc.open = true
-                        doc.want_close = true
-                    } elif (!tab_open) {
-                        doc.open = false
-                    }
                     display_context_menu(i)
                     display_contents(i)
+                }
+                // Tab close handling MUST live outside the tab_item body —
+                // ImGui flips p_open=false when the user X-clicks the tab
+                // header even on INACTIVE tabs whose body never runs. The
+                // prior version inside the body silently swallowed inactive-
+                // tab close attempts because the frame-top reseed flipped
+                // .open back to true before the next frame's body could
+                // observe the false value.
+                if (!DOCS_TAB[i].open) {
+                    if (doc.dirty) {
+                        // Cancel close attempt: requeue + reopen for the
+                        // confirmation popup.
+                        DOCS_TAB[i].open = true
+                        doc.want_close = true
+                    } else {
+                        doc.open = false
+                    }
                 }
             }
         }

--- a/examples/imgui_demo/harness_app_custom_rendering.das
+++ b/examples/imgui_demo/harness_app_custom_rendering.das
@@ -1,0 +1,43 @@
+options gen2
+
+require imgui/imgui_harness
+require app_custom_rendering
+
+// =============================================================================
+// HARNESS: imgui_demo Example: Custom Rendering — single-scene driver for the
+//          C++ ShowExampleAppCustomRendering port. ShowExampleAppCustomRendering
+//          opens its own window (4-tab TabBar inside), so this harness just
+//          calls it directly from the frame body.
+// SHOWS:   CR_WIN window with Primitives / Canvas / BG-FG / Channels tabs.
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_custom_rendering.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_custom_rendering.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_app_custom_rendering.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - Custom Rendering", 760, 720)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
+    app_custom_rendering::ShowExampleAppCustomRendering()
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/imgui_demo/harness_app_dockspace.das
+++ b/examples/imgui_demo/harness_app_dockspace.das
@@ -1,0 +1,45 @@
+options gen2
+
+require imgui/imgui_harness
+require app_dockspace
+
+// =============================================================================
+// HARNESS: imgui_demo Example: DockSpace — single-scene driver for the
+//          C++ ShowExampleAppDockSpace port. The function opens its own host
+//          window (MenuBar + NoDocking) with an embedded dockspace_in_window
+//          + 2 sample dock_window panels.
+// SHOWS:   DS_WIN host + DS dockspace + DS_PANEL_A / DS_PANEL_B.
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_dockspace.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_dockspace.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_app_dockspace.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - DockSpace", 760, 540)
+    var io & = unsafe(GetIO())
+    io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
+    app_dockspace::ShowExampleAppDockSpace()
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/imgui_demo/harness_app_documents.das
+++ b/examples/imgui_demo/harness_app_documents.das
@@ -1,0 +1,43 @@
+options gen2
+
+require imgui/imgui_harness
+require app_documents
+
+// =============================================================================
+// HARNESS: imgui_demo Example: Documents — single-scene driver for the
+//          C++ ShowExampleAppDocuments port (Target_Tab mode only). The
+//          function opens its own window (MenuBar + tab bar + per-doc tab
+//          + close-confirmation popup_modal).
+// SHOWS:   DOCS_WIN host with File menu, per-doc tabs, close confirmation.
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_documents.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_app_documents.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_app_documents.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - Documents", 760, 540)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
+    app_documents::ShowExampleAppDocuments()
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/imgui_demo/imgui_demo.das
+++ b/examples/imgui_demo/imgui_demo.das
@@ -40,6 +40,9 @@ var private SHOW_APP_CONSTRAINED_RESIZE = false
 var private SHOW_APP_SIMPLE_OVERLAY = false
 var private SHOW_APP_FULLSCREEN = false
 var private SHOW_APP_WINDOW_TITLES = false
+var private SHOW_APP_CUSTOM_RENDERING = false
+var private SHOW_APP_DOCKSPACE = false
+var private SHOW_APP_DOCUMENTS = false
 
 // Mirrors imgui_demo.cpp:275-6455 — void ImGui::ShowDemoWindow(bool* p_open).
 // Renamed to avoid collision with ImGui's built-in ShowDemoWindow binding.
@@ -49,7 +52,7 @@ var private SHOW_APP_WINDOW_TITLES = false
 def RunImGuiDemo() {
     window(DEMO_WIN, (text = "Dear ImGui Demo (daslang port — Phase 2a skeleton)",
                        closable = false, flags = ImGuiWindowFlags.None)) {
-        text("Phase 2a skeleton — 0/24 SECTION blocks ported + 2 example apps (Console, Log).")
+        text("Phase 2a skeleton — 0/24 SECTION blocks ported + 5 example apps (Console, Log, Custom Rendering, DockSpace, Documents).")
         text("Section stubs render below; example apps and meta windows are")
         text("not yet wired into the menu — temporary checkboxes at the bottom")
         text("toggle individual app windows.")
@@ -83,6 +86,12 @@ def RunImGuiDemo() {
                       (id = "EXAMPLES_SHOW_FULLSCREEN", text = "Show Example: Fullscreen Window"))
         edit_checkbox(safe_addr(SHOW_APP_WINDOW_TITLES),
                       (id = "EXAMPLES_SHOW_TITLES", text = "Show Example: Manipulating Window Titles"))
+        edit_checkbox(safe_addr(SHOW_APP_CUSTOM_RENDERING),
+                      (id = "EXAMPLES_SHOW_CUSTOM_RENDERING", text = "Show Example: Custom Rendering"))
+        edit_checkbox(safe_addr(SHOW_APP_DOCKSPACE),
+                      (id = "EXAMPLES_SHOW_DOCKSPACE", text = "Show Example: DockSpace"))
+        edit_checkbox(safe_addr(SHOW_APP_DOCUMENTS),
+                      (id = "EXAMPLES_SHOW_DOCUMENTS", text = "Show Example: Documents"))
     }
 
     // Example-app windows live OUTSIDE the demo window — each opens its own.
@@ -125,5 +134,16 @@ def RunImGuiDemo() {
     // WindowTitles is closable=false in cpp (all 3 windows have nullptr p_open).
     if (SHOW_APP_WINDOW_TITLES) {
         ShowExampleAppWindowTitles()
+    }
+    // PR-C/2: three example apps. All three return bool — false when the
+    // window's X-button or local menu close fires.
+    if (SHOW_APP_CUSTOM_RENDERING && !ShowExampleAppCustomRendering()) {
+        SHOW_APP_CUSTOM_RENDERING = false
+    }
+    if (SHOW_APP_DOCKSPACE && !ShowExampleAppDockSpace()) {
+        SHOW_APP_DOCKSPACE = false
+    }
+    if (SHOW_APP_DOCUMENTS && !ShowExampleAppDocuments()) {
+        SHOW_APP_DOCUMENTS = false
     }
 }

--- a/examples/imgui_demo/layout.das
+++ b/examples/imgui_demo/layout.das
@@ -53,9 +53,9 @@ var LAYOUT_CHILD_DISABLE_MOUSE_WHEEL = false
 var LAYOUT_CHILD_DISABLE_MENU = false
 var LAYOUT_CHILD_OFFSET_X = 0
 var LAYOUT_CHILD_OVERRIDE_BG = true
-var LAYOUT_CHILD_FLAGS = (int(ImGuiChildFlags.Border) |
-                          int(ImGuiChildFlags.ResizeX) |
-                          int(ImGuiChildFlags.ResizeY))
+var LAYOUT_CHILD_FLAGS = int(ImGuiChildFlags.Border |
+                             ImGuiChildFlags.ResizeX |
+                             ImGuiChildFlags.ResizeY)
 
 // ----- Widgets Width -----
 var LAYOUT_WW_FLOAT = 0.0f
@@ -209,8 +209,8 @@ def private ChildWindowsSection() {
                         }
                     }
                 }
-                let table_flags = (int(ImGuiTableFlags.Resizable) |
-                                   int(ImGuiTableFlags.NoSavedSettings))
+                let table_flags = int(ImGuiTableFlags.Resizable |
+                                      ImGuiTableFlags.NoSavedSettings)
                 data_table(LAYOUT_CHILD_TABLE,
                            (text = "split", columns = 2,
                             flags = unsafe(reinterpret<ImGuiTableFlags>(table_flags)),
@@ -234,7 +234,7 @@ def private ChildWindowsSection() {
                 "to auto-fit to vertical contents."))
         }
         with_style((ImGuiCol.ChildBg, GetStyleColorVec4(ImGuiCol.FrameBg))) {
-            let flags3 = int(ImGuiChildFlags.Border) | int(ImGuiChildFlags.ResizeY)
+            let flags3 = int(ImGuiChildFlags.Border | ImGuiChildFlags.ResizeY)
             child(LAYOUT_CHILD_RESIZABLE,
                   (text = "ResizableChild",
                    size = float2(-FLT_MIN, GetTextLineHeightWithSpacing() * 8.0f),
@@ -260,7 +260,7 @@ def private ChildWindowsSection() {
             ImVec2(0.0f, GetTextLineHeightWithSpacing() * 1.0f),
             ImVec2(FLT_MAX,
                    GetTextLineHeightWithSpacing() * float(LAYOUT_CHILD_MAX_LINES)))
-        let flags4 = int(ImGuiChildFlags.Border) | int(ImGuiChildFlags.AutoResizeY)
+        let flags4 = int(ImGuiChildFlags.Border | ImGuiChildFlags.AutoResizeY)
         child(LAYOUT_CHILD_CONSTRAINED,
               (text = "ConstrainedChild",
                size = float2(-FLT_MIN, 0.0f),
@@ -948,13 +948,13 @@ def private ScrollingSection() {
             }
         }
         var scroll_x_delta = 0.0f
-        if (small_button("<<")) {}
+        if (small_button(LAYOUT_SCROLL_LT, (text = "<<"))) {}
         if (IsItemActive()) {
             scroll_x_delta = -GetIO().DeltaTime * 1000.0f
         }
         same_line()
         text("Scroll from code"); same_line()
-        if (small_button(">>")) {}
+        if (small_button(LAYOUT_SCROLL_RT, (text = ">>"))) {}
         if (IsItemActive()) {
             scroll_x_delta = +GetIO().DeltaTime * 1000.0f
         }
@@ -963,14 +963,13 @@ def private ScrollingSection() {
         let fb_state & = LAYOUT_SCROLL_FB_CHILD
         text("{fmt_0f(fb_state.scroll.x)}/{fmt_0f(fb_state.scroll_max.x)}")
         if (scroll_x_delta != 0.0f) {
-            // Re-enter the child by name to nudge its scroll position. This
-            // is the standard ImGui trick — BeginChild outside the child body.
-            // The naked Begin/End pair is on the lint ALLOWED list for this
-            // idiom only; the `child(...)` container would push a new ID.
-            BeginChild("scrolling", float2(0.0f, 0.0f), ImGuiChildFlags.None,
-                       ImGuiWindowFlags.None)
-            SetScrollX(GetScrollX() + scroll_x_delta)
-            EndChild()
+            // Re-enter the child by name to nudge its scroll position. The
+            // wrapper replicates the `child` container's PushID(IDENT) frame
+            // so BeginChild hashes to the SAME window — without it ImGui
+            // creates a phantom sibling and SetScrollX has no visible effect.
+            child_scroll_reenter("LAYOUT_SCROLL_FB_CHILD", "scrolling") {
+                SetScrollX(GetScrollX() + scroll_x_delta)
+            }
         }
         spacing()
 

--- a/examples/imgui_demo/layout.das
+++ b/examples/imgui_demo/layout.das
@@ -43,9 +43,11 @@ require math
 //     stubs; the drawlist rail (PR-B1) doesn't carry the per-region clip-rect
 //     overrides the C++ branch uses (PushClipRect-then-AddText). TODO Phase 3.
 //   - cpp:3392-3398: BeginChild("scrolling") re-entry trick to nudge scroll
-//     state from outside the child body. ImGui hashes the child by name; the
-//     `child(...)` container would push a new ID. The two raw BeginChild /
-//     EndChild calls are ALLOWED for this idiom only.
+//     state from outside the child body. The `child_scroll_reenter(IDENT,
+//     text) { ... }` wrapper replicates the original `child(IDENT)` container's
+//     PushID(IDENT) frame so BeginChild hashes to the SAME window — without
+//     it ImGui creates a phantom sibling and SetScrollX has no visible effect.
+//     See widgets/imgui_containers_builtin.das for the wrapper definition.
 // =============================================================================
 
 // ----- Child windows section -----

--- a/examples/tutorial/drawlist.das
+++ b/examples/tutorial/drawlist.das
@@ -22,10 +22,17 @@ require imgui/imgui_visual_aids
 
 // =============================================================================
 // TUTORIAL: drawlist — three scope wrappers (with_window_drawlist /
-//           with_foreground_drawlist / with_background_drawlist) and eight
-//           primitive painters (add_line, add_rect, add_rect_filled,
-//           add_circle, add_circle_filled, add_triangle, add_triangle_filled,
-//           add_text).
+//           with_foreground_drawlist / with_background_drawlist) and the
+//           full primitive set: 8 originals (add_line, add_rect,
+//           add_rect_filled, add_circle, add_circle_filled, add_triangle,
+//           add_triangle_filled, add_text) plus the v2 additions
+//           (add_rect_filled_multi_color, add_ellipse, add_ellipse_filled,
+//           add_ngon, add_ngon_filled, add_polyline, add_bezier_cubic,
+//           add_bezier_quadratic). For the path-building, channel-splitting,
+//           and clip-rect rails see the dedicated feature files
+//           (examples/features/drawlist_path.das,
+//           examples/features/drawlist_channels.das,
+//           examples/features/clip_rect.das).
 //
 // The rail bridges to ImGui's three viewport-level draw lists with the same
 // telemetry surface as `[widget]`: path-keyed entries land in `g_registry`
@@ -39,7 +46,7 @@ require imgui/imgui_visual_aids
 
 [export]
 def init() {
-    live_create_window("dasImgui drawlist tutorial", 760, 540)
+    live_create_window("dasImgui drawlist tutorial", 760, 760)
     live_imgui_init(live_window)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.2
@@ -56,7 +63,7 @@ def update() {
     NewFrame()
 
     SetNextWindowPos(ImVec2(30.0f, 30.0f), ImGuiCond.Always)
-    SetNextWindowSize(ImVec2(700.0f, 480.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(700.0f, 700.0f), ImGuiCond.Always)
     window(DRAW_WIN, (text = "drawlist — rail tour", closable = false,
                       flags = ImGuiWindowFlags.None)) {
         text(DRAW_INTRO, (text = "The three scope wrappers + eight primitives."))
@@ -64,8 +71,8 @@ def update() {
 
         let origin = GetCursorScreenPos()
         let red    = rgba(220u,  60u,  60u, 255u)
-        let green  = rgba( 60u, 220u, 100u, 255u)
-        let blue   = rgba( 70u, 130u, 240u, 255u)
+        let green  = rgba(60u, 220u, 100u, 255u)
+        let blue   = rgba(70u, 130u, 240u, 255u)
         let yellow = rgba(240u, 220u,  60u, 255u)
         let gray   = rgba(200u, 200u, 210u, 255u)
         let bg_tint = rgba(20u, 30u, 50u, 120u)
@@ -81,7 +88,7 @@ def update() {
                            float2(origin.x + 652.0f, origin.y + 72.0f),
                            yellow, 2.0f)
             dl |> add_circle_filled(float2(origin.x +  60.0f, origin.y + 160.0f), 32.0f, blue, 0)
-            dl |> add_circle(       float2(origin.x + 150.0f, origin.y + 160.0f), 32.0f, blue, 0, 2.0f)
+            dl |> add_circle(float2(origin.x + 150.0f, origin.y + 160.0f), 32.0f, blue, 0, 2.0f)
             dl |> add_triangle_filled(float2(origin.x + 260.0f, origin.y + 124.0f),
                                       float2(origin.x + 226.0f, origin.y + 196.0f),
                                       float2(origin.x + 294.0f, origin.y + 196.0f), green)
@@ -90,9 +97,49 @@ def update() {
                                float2(origin.x + 414.0f, origin.y + 196.0f), green, 2.0f)
             dl |> add_text(float2(origin.x +  16.0f, origin.y + 220.0f), gray,
                            "add_text — rendered onto the window drawlist")
+
+            // ----- v2 additions: shape extras -----
+            // Multi-color gradient rect.
+            dl |> add_rect_filled_multi_color(
+                float2(origin.x +  16.0f, origin.y + 260.0f),
+                float2(origin.x + 240.0f, origin.y + 290.0f),
+                rgba(255u, 0u, 0u, 220u), rgba(0u, 255u, 0u, 220u),
+                rgba(0u, 0u, 255u, 220u), rgba(255u, 255u, 0u, 220u))
+            // Stroked + filled ellipse.
+            dl |> add_ellipse(float2(origin.x + 300.0f, origin.y + 275.0f),
+                              float2(36.0f, 16.0f), yellow, 0.0f, 0, 1.5f)
+            dl |> add_ellipse_filled(float2(origin.x + 400.0f, origin.y + 275.0f),
+                                     float2(36.0f, 16.0f), blue, 0.0f, 0)
+            // Stroked + filled N-gon (hexagon).
+            dl |> add_ngon(float2(origin.x + 500.0f, origin.y + 275.0f),
+                           22.0f, green, 6, 2.0f)
+            dl |> add_ngon_filled(float2(origin.x + 580.0f, origin.y + 275.0f),
+                                  22.0f, green, 6)
+            // Cubic + quadratic bezier curves.
+            dl |> add_bezier_cubic(
+                float2(origin.x +  16.0f, origin.y + 330.0f),
+                float2(origin.x + 110.0f, origin.y + 290.0f),
+                float2(origin.x + 200.0f, origin.y + 360.0f),
+                float2(origin.x + 300.0f, origin.y + 310.0f),
+                yellow, 2.0f, 0)
+            dl |> add_bezier_quadratic(
+                float2(origin.x + 320.0f, origin.y + 330.0f),
+                float2(origin.x + 430.0f, origin.y + 290.0f),
+                float2(origin.x + 540.0f, origin.y + 330.0f),
+                blue, 2.0f, 0)
+            // Polyline (open M-shape) below.
+            var poly <- [
+                float2(origin.x +  16.0f, origin.y + 380.0f),
+                float2(origin.x +  60.0f, origin.y + 350.0f),
+                float2(origin.x + 100.0f, origin.y + 370.0f),
+                float2(origin.x + 140.0f, origin.y + 350.0f),
+                float2(origin.x + 180.0f, origin.y + 380.0f)
+            ]
+            dl |> add_polyline(poly, gray, ImDrawFlags.None, 1.5f)
+            delete poly
         }
 
-        dummy(DRAW_BAND_SLOT, (size = float2(660.0f, 240.0f)))
+        dummy(DRAW_BAND_SLOT, (size = float2(660.0f, 400.0f)))
 
         text(DRAW_FG_LABEL, (text = "Foreground swatch (overlays everything):"))
 

--- a/examples/tutorial/drawlist.das
+++ b/examples/tutorial/drawlist.das
@@ -66,7 +66,7 @@ def update() {
     SetNextWindowSize(ImVec2(700.0f, 700.0f), ImGuiCond.Always)
     window(DRAW_WIN, (text = "drawlist — rail tour", closable = false,
                       flags = ImGuiWindowFlags.None)) {
-        text(DRAW_INTRO, (text = "The three scope wrappers + eight primitives."))
+        text(DRAW_INTRO, (text = "Three scope wrappers + shape primitives (8 originals + v2 extras)."))
         separator()
 
         let origin = GetCursorScreenPos()

--- a/tests/integration/record_drawlist.das
+++ b/tests/integration/record_drawlist.das
@@ -28,7 +28,7 @@ def main {
         }
 
         post_command(app, "imgui_narrate", JV((
-            text = "Three scope wrappers + eight primitives — the drawlist rail.",
+            text = "Three scope wrappers + shape primitives (8 originals + v2 extras) — the drawlist rail.",
             target = T_WIN,
             frames = 180
         )))

--- a/tests/integration/record_drawlist.das
+++ b/tests/integration/record_drawlist.das
@@ -42,6 +42,13 @@ def main {
         sleep(3500u)
 
         post_command(app, "imgui_narrate", JV((
+            text = "Shape extras — gradient rect, ellipse, hexagon (ngon), polyline, bezier curves.",
+            target = T_BAND,
+            frames = 200
+        )))
+        sleep(3500u)
+
+        post_command(app, "imgui_narrate", JV((
             text = "with_foreground_drawlist — paints over every window (top-left FG ribbon).",
             target = T_FG,
             frames = 200

--- a/tests/integration/test_app_custom_rendering.das
+++ b/tests/integration/test_app_custom_rendering.das
@@ -1,0 +1,39 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Smoke for imgui_demo ShowExampleAppCustomRendering — host window opens,
+//! the TabBar registers, the default-active Primitives tab renders, and
+//! the context-menu popup is INSTALLED (not open). Drag/click matrix is
+//! out of scope here; this is the structural-rendering rail.
+
+let CR_FEATURE = "modules/dasImgui/examples/imgui_demo/harness_app_custom_rendering.das"
+
+[test]
+def test_app_custom_rendering_smoke(t : T?) {
+    with_imgui_app(CR_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "CR_WIN", 15.0f)
+        t |> success(snap0 != null, "CR_WIN host window renders")
+        if (snap0 == null) return
+
+        t |> success(widget_exists(snap0, "CR_WIN/CR_TABS"),
+                     "CR_WIN/CR_TABS tab_bar registers")
+        let tab_prim = find_widget(snap0, "CR_WIN/CR_TABS/CR_TAB_PRIM")
+        t |> equal(string(tab_prim?["kind"] ?? ""), "tab_item",
+                   "CR_TAB_PRIM (default-active) renders as tab_item")
+
+        // Context-menu popup is always installed (per the cpp port) but
+        // open=false by default — confirms the popup container is wired.
+        let ctx = find_widget(snap0, "CR_CV_CTX_MENU")
+        t |> equal(string(ctx?["kind"] ?? ""), "popup",
+                   "CR_CV_CTX_MENU registered as kind=popup")
+        t |> equal(ctx?["payload"]?["open"] ?? true, false,
+                   "context menu starts closed")
+    }
+}

--- a/tests/integration/test_app_dockspace.das
+++ b/tests/integration/test_app_dockspace.das
@@ -1,0 +1,39 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Smoke for imgui_demo ShowExampleAppDockSpace — host window opens with
+//! its MenuBar + Options menu, the embedded dockspace_in_window registers
+//! with a non-zero dock_id, and the two sample dock_window panels both
+//! render under it.
+
+let DS_FEATURE = "modules/dasImgui/examples/imgui_demo/harness_app_dockspace.das"
+
+[test]
+def test_app_dockspace_smoke(t : T?) {
+    with_imgui_app(DS_FEATURE) $(d) {
+        var snap = wait_for_widget(d, "DS_WIN", 15.0f)
+        t |> success(snap != null, "DS_WIN host window renders")
+        if (snap == null) return
+
+        let ds = find_widget(snap, "DS_WIN/DS")
+        t |> equal(string(ds?["kind"] ?? ""), "dockspace_in_window",
+                   "DS_WIN/DS registers as kind=dockspace_in_window")
+        let dock_id = uint(ds?["payload"]?["dock_id"] ?? 0u)
+        t |> success(dock_id != 0u,
+                     "dock_id captured (got 0x{dock_id})")
+
+        t |> success(widget_exists(snap, "DS_WIN/DS/DS_PANEL_A"),
+                     "DS_PANEL_A dock_window renders")
+        t |> success(widget_exists(snap, "DS_WIN/DS/DS_PANEL_B"),
+                     "DS_PANEL_B dock_window renders")
+        t |> success(widget_exists(snap, "DS_WIN/DS_MENU/DS_OPTIONS_MENU"),
+                     "DS_MENU menu_bar + Options menu register")
+    }
+}

--- a/tests/integration/test_app_documents.das
+++ b/tests/integration/test_app_documents.das
@@ -1,0 +1,47 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Smoke for imgui_demo ShowExampleAppDocuments — host window + tab bar
+//! + per-doc state. Also verifies the round-1/round-2 fixes:
+//!   - DOCS_OPEN_CHECKBOX[i].value mirrors doc.open (seeded-open docs
+//!     render checked, not unchecked).
+//!   - DOCS_CLOSE_MODAL container is installed but starts closed (no
+//!     dirty docs in fresh fixtures).
+
+let DOCS_FEATURE = "modules/dasImgui/examples/imgui_demo/harness_app_documents.das"
+
+[test]
+def test_app_documents_smoke(t : T?) {
+    with_imgui_app(DOCS_FEATURE) $(d) {
+        var snap = wait_for_widget(d, "DOCS_WIN", 15.0f)
+        t |> success(snap != null, "DOCS_WIN host window renders")
+        if (snap == null) return
+
+        t |> success(widget_exists(snap, "DOCS_WIN/DOCS_MENUBAR/DOCS_FILE_MENU"),
+                     "File menu in the menu bar")
+        t |> success(widget_exists(snap, "DOCS_WIN/DOCS_TABS"),
+                     "DOCS_TABS tab_bar registers")
+
+        // Per round-1/#11: the debug checkbox mirrors doc.open every frame.
+        // seed_docs() opens docs 0, 1, 2 and leaves 3, 4, 5 closed.
+        let cb0_val = find_widget(snap, "DOCS_WIN/DOCS_OPEN_CHECKBOX[0]")?["payload"]?["value"] ?? false
+        t |> equal(cb0_val, true, "DOCS_OPEN_CHECKBOX[0] mirrors seeded doc.open=true (Lettuce)")
+        let cb3_val = find_widget(snap, "DOCS_WIN/DOCS_OPEN_CHECKBOX[3]")?["payload"]?["value"] ?? true
+        t |> equal(cb3_val, false, "DOCS_OPEN_CHECKBOX[3] mirrors seeded doc.open=false (Tomato)")
+
+        // Close-confirmation modal is installed; opens only when a dirty
+        // doc is being closed. Fresh fixture: starts closed.
+        let modal = find_widget(snap, "DOCS_CLOSE_MODAL")
+        t |> equal(string(modal?["kind"] ?? ""), "popup_modal",
+                   "DOCS_CLOSE_MODAL registered as popup_modal")
+        t |> equal(modal?["payload"]?["open"] ?? true, false,
+                   "close-confirmation modal starts closed (no dirty docs)")
+    }
+}

--- a/tests/integration/test_child_scroll_reenter.das
+++ b/tests/integration/test_child_scroll_reenter.das
@@ -27,7 +27,7 @@ def test_child_scroll_reenter_moves_scroll(t : T?) {
         t |> success(snap0 != null, "SCROLLY child renders")
         if (snap0 == null) return
         // SCROLLY.scroll.y starts at 0.0 — the child opens scrolled to top.
-        let y0 = (find_widget(snap0, "MAIN_WIN/SCROLLY")?["state"]?["scroll"]?["y"] ?? 0.0lf)
+        let y0 = (find_widget(snap0, "MAIN_WIN/SCROLLY")?["payload"]?["scroll"]?["y"] ?? 0.0lf)
         t |> equal(double(y0), 0.0lf, "initial SCROLLY.scroll.y == 0")
         // One click should fire child_scroll_reenter once and move scroll
         // by `delta = 8.0f` (per the feature file). Click several times to
@@ -40,7 +40,7 @@ def test_child_scroll_reenter_moves_scroll(t : T?) {
         var snap1 = snapshot(d)
         t |> success(snap1 != null, "post-click snapshot available")
         if (snap1 == null) return
-        let y1 : double = double(find_widget(snap1, "MAIN_WIN/SCROLLY")?["state"]?["scroll"]?["y"] ?? 0.0lf)
+        let y1 : double = double(find_widget(snap1, "MAIN_WIN/SCROLLY")?["payload"]?["scroll"]?["y"] ?? 0.0lf)
         t |> success(y1 > 0.0lf,
                      "SCROLLY.scroll.y moved (y={y1}); wrapper's PushID(IDENT) reentered the same window")
     }

--- a/tests/integration/test_child_scroll_reenter.das
+++ b/tests/integration/test_child_scroll_reenter.das
@@ -1,0 +1,47 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Smoke for `child_scroll_reenter` against the
+//! ``examples/features/child_scroll_reenter.das`` feature. Clicks the down
+//! button (which calls `child_scroll_reenter("SCROLLY", "lines") {
+//! SetScrollY(...) }`) and asserts the original child's observed scroll.y
+//! actually changes. The original child publishes its scroll into
+//! ``SCROLLY.scroll`` from inside its body — if the wrapper's PushID was
+//! wrong, BeginChild would hash to a phantom sibling and SCROLLY.scroll.y
+//! would never move (the contrapositive of "this test passes" is "the
+//! PushID frame in child_scroll_reenter matches the original child").
+
+let FEATURE = "modules/dasImgui/examples/features/child_scroll_reenter.das"
+
+[test]
+def test_child_scroll_reenter_moves_scroll(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN/SCROLLY", 15.0f)
+        t |> success(snap0 != null, "SCROLLY child renders")
+        if (snap0 == null) return
+        // SCROLLY.scroll.y starts at 0.0 — the child opens scrolled to top.
+        let y0 = (find_widget(snap0, "MAIN_WIN/SCROLLY")?["state"]?["scroll"]?["y"] ?? 0.0lf)
+        t |> equal(double(y0), 0.0lf, "initial SCROLLY.scroll.y == 0")
+        // One click should fire child_scroll_reenter once and move scroll
+        // by `delta = 8.0f` (per the feature file). Click several times to
+        // get a clearly-non-zero observation that's robust to single-frame
+        // jitter / button-repeat timing.
+        for (_i in range(5)) {
+            click(d, "MAIN_WIN/BTN_DOWN")
+        }
+        await_quiescent(d, 5.0f)
+        var snap1 = snapshot(d)
+        t |> success(snap1 != null, "post-click snapshot available")
+        if (snap1 == null) return
+        let y1 : double = double(find_widget(snap1, "MAIN_WIN/SCROLLY")?["state"]?["scroll"]?["y"] ?? 0.0lf)
+        t |> success(y1 > 0.0lf,
+                     "SCROLLY.scroll.y moved (y={y1}); wrapper's PushID(IDENT) reentered the same window")
+    }
+}

--- a/tests/integration/test_dockspace_in_window.das
+++ b/tests/integration/test_dockspace_in_window.das
@@ -26,7 +26,10 @@ def test_dockspace_in_window_captures_dock_id(t : T?) {
         var ds_snap = wait_for_widget(d, "HOST/DS", 15.0f)
         t |> success(ds_snap != null, "HOST/DS dockspace registers")
         if (ds_snap == null) return
-        let dock_id_0 = uint(find_widget(ds_snap, "HOST/DS")?["payload"]?["dock_id"] ?? 0u)
+        let ds_widget = find_widget(ds_snap, "HOST/DS")
+        t |> equal(string(ds_widget?["kind"] ?? ""), "dockspace_in_window",
+                   "HOST/DS registers as kind=dockspace_in_window (not bare dockspace)")
+        let dock_id_0 = uint(ds_widget?["payload"]?["dock_id"] ?? 0u)
         t |> success(dock_id_0 != 0u,
                      "DS.dock_id captured on first render (got 0x{dock_id_0})")
         // Wait a few frames; dock_id must stay stable.

--- a/tests/integration/test_dockspace_in_window.das
+++ b/tests/integration/test_dockspace_in_window.das
@@ -26,14 +26,14 @@ def test_dockspace_in_window_captures_dock_id(t : T?) {
         var ds_snap = wait_for_widget(d, "HOST/DS", 15.0f)
         t |> success(ds_snap != null, "HOST/DS dockspace registers")
         if (ds_snap == null) return
-        let dock_id_0 = uint(find_widget(ds_snap, "HOST/DS")?["state"]?["dock_id"] ?? 0u)
+        let dock_id_0 = uint(find_widget(ds_snap, "HOST/DS")?["payload"]?["dock_id"] ?? 0u)
         t |> success(dock_id_0 != 0u,
                      "DS.dock_id captured on first render (got 0x{dock_id_0})")
         // Wait a few frames; dock_id must stay stable.
         await_quiescent(d, 5.0f)
         var snap1 = snapshot(d)
         if (snap1 == null) return
-        let dock_id_1 = uint(find_widget(snap1, "HOST/DS")?["state"]?["dock_id"] ?? 0u)
+        let dock_id_1 = uint(find_widget(snap1, "HOST/DS")?["payload"]?["dock_id"] ?? 0u)
         t |> equal(dock_id_1, dock_id_0,
                    "DS.dock_id stable across frames")
     }

--- a/tests/integration/test_dockspace_in_window.das
+++ b/tests/integration/test_dockspace_in_window.das
@@ -1,0 +1,53 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Smoke for `dockspace_in_window` against
+//! ``examples/features/dockspace_in_window.das``. Asserts:
+//!   1. DS captures a non-zero dock_id after the first render.
+//!   2. dock_id persists across frames (same id on a later snapshot).
+//!   3. dock_window children render under the HOST/DS path.
+
+let FEATURE = "modules/dasImgui/examples/features/dockspace_in_window.das"
+
+[test]
+def test_dockspace_in_window_captures_dock_id(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "HOST", 15.0f)
+        t |> success(snap0 != null, "HOST window renders")
+        if (snap0 == null) return
+        // dockspace_in_window publishes its kind under HOST/DS.
+        var ds_snap = wait_for_widget(d, "HOST/DS", 15.0f)
+        t |> success(ds_snap != null, "HOST/DS dockspace registers")
+        if (ds_snap == null) return
+        let dock_id_0 = uint(find_widget(ds_snap, "HOST/DS")?["state"]?["dock_id"] ?? 0u)
+        t |> success(dock_id_0 != 0u,
+                     "DS.dock_id captured on first render (got 0x{dock_id_0})")
+        // Wait a few frames; dock_id must stay stable.
+        await_quiescent(d, 5.0f)
+        var snap1 = snapshot(d)
+        if (snap1 == null) return
+        let dock_id_1 = uint(find_widget(snap1, "HOST/DS")?["state"]?["dock_id"] ?? 0u)
+        t |> equal(dock_id_1, dock_id_0,
+                   "DS.dock_id stable across frames")
+    }
+}
+
+[test]
+def test_dockspace_in_window_child_panels_render(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        // dock_window children sit under the dockspace path.
+        var files_snap = wait_for_widget(d, "HOST/DS/FILES", 15.0f)
+        t |> success(files_snap != null,
+                     "FILES dock_window renders under HOST/DS")
+        var output_snap = wait_for_widget(d, "HOST/DS/OUTPUT", 15.0f)
+        t |> success(output_snap != null,
+                     "OUTPUT dock_window renders under HOST/DS")
+    }
+}

--- a/tests/integration/test_dockspace_in_window.das
+++ b/tests/integration/test_dockspace_in_window.das
@@ -32,6 +32,7 @@ def test_dockspace_in_window_captures_dock_id(t : T?) {
         // Wait a few frames; dock_id must stay stable.
         await_quiescent(d, 5.0f)
         var snap1 = snapshot(d)
+        t |> success(snap1 != null, "stable-snapshot snap1 available")
         if (snap1 == null) return
         let dock_id_1 = uint(find_widget(snap1, "HOST/DS")?["payload"]?["dock_id"] ?? 0u)
         t |> equal(dock_id_1, dock_id_0,

--- a/tests/integration/test_drawlist_channels.das
+++ b/tests/integration/test_drawlist_channels.das
@@ -1,0 +1,42 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for channels_split / channels_set_current /
+//! channels_merge. The channel helpers themselves are control-flow
+//! (no ``[drawlist_prim]`` rows), but the ``[drawlist_prim]`` calls
+//! INSIDE the split (add_text, add_rect_filled) still register —
+//! their presence in the snapshot proves the split→set_current→merge
+//! sequence drained without ImGui asserting on channel-stack misuse.
+
+let CHANNELS_FEATURE = "modules/dasImgui/examples/features/drawlist_channels.das"
+
+def has_kind(var snap : JsonValue?; kind : string) : bool {
+    var globals = snap?["globals"]
+    return false if (globals == null || !(globals.value is _object))
+    for (v in values(globals.value as _object)) {
+        if ((v?["kind"] ?? "") == kind) return true
+    }
+    return false
+}
+
+[test]
+def test_drawlist_channels_renders(t : T?) {
+    with_imgui_app(CHANNELS_FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/LEAD", 15.0f)
+        t |> success(snap != null, "MAIN_WIN/LEAD renders (window body opened)")
+        if (snap == null) return
+        t |> success(widget_exists(snap, "MAIN_WIN/CARD_SLOT"),
+                     "MAIN_WIN/CARD_SLOT registers (split body completed; merge fired)")
+        t |> success(has_kind(snap, "add_text"),
+                     "add_text on channel 1 reaches the registry")
+        t |> success(has_kind(snap, "add_rect_filled"),
+                     "add_rect_filled on channel 0 reaches the registry")
+    }
+}

--- a/tests/integration/test_drawlist_path.das
+++ b/tests/integration/test_drawlist_path.das
@@ -1,0 +1,33 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the drawlist path family (path_clear /
+//! path_line_to / path_arc_to / path_bezier_quadratic_curve_to /
+//! path_fill_convex / path_fill_concave / path_stroke). The path
+//! helpers are control-flow primitives — they shape what later
+//! ``[drawlist_prim]`` calls render but do not themselves register
+//! snapshot rows. The smoke value here is end-to-end: the body fires
+//! every path call without panicking, the host window + LEAD + slot
+//! all reach the registry, and the three shapes draw without ImGui
+//! asserting on path stack misuse.
+
+let PATH_FEATURE = "modules/dasImgui/examples/features/drawlist_path.das"
+
+[test]
+def test_drawlist_path_renders(t : T?) {
+    with_imgui_app(PATH_FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/LEAD", 15.0f)
+        t |> success(snap != null,
+                     "MAIN_WIN/LEAD renders (path body reached the trailing text)")
+        if (snap == null) return
+        t |> success(widget_exists(snap, "MAIN_WIN/PATH_SLOT"),
+                     "MAIN_WIN/PATH_SLOT registers (dummy after the path body completed)")
+    }
+}

--- a/tests/integration/test_drawlist_primitives.das
+++ b/tests/integration/test_drawlist_primitives.das
@@ -8,11 +8,14 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Integration smoke for the drawlist rail's 8 primitives. Targets the
-//! ``examples/features/drawlist.das`` feature which exercises one call of
-//! each ``add_*`` primitive under ``DRAW_WIN``. Walks the per-frame
-//! snapshot and asserts every primitive kind appears under at least one
-//! path key (the auto-synthesized ``<mod>:<line>:<col>``).
+//! Integration smoke for the drawlist rail's shape primitives — 8
+//! originals + 8 v2 extras (rect_filled_multi_color / ellipse / ngon /
+//! polyline / bezier). Targets the ``examples/features/drawlist.das``
+//! feature which exercises one call of each ``add_*`` primitive under
+//! ``DRAW_WIN``. Walks the per-frame snapshot and asserts every
+//! primitive kind appears under at least one path key (the
+//! auto-synthesized ``<mod>:<line>:<col>``). Path/channel rails get
+//! their own dedicated smoke tests.
 
 let DRAWLIST_FEATURE = "modules/dasImgui/examples/features/drawlist.das"
 

--- a/tests/integration/test_drawlist_primitives.das
+++ b/tests/integration/test_drawlist_primitives.das
@@ -17,10 +17,17 @@ require daslib/json_boost public
 let DRAWLIST_FEATURE = "modules/dasImgui/examples/features/drawlist.das"
 
 let EXPECTED_KINDS : array<string> = [
+    // Original 8 primitives.
     "add_line", "add_rect", "add_rect_filled",
     "add_circle", "add_circle_filled",
     "add_triangle", "add_triangle_filled",
-    "add_text"
+    "add_text",
+    // v2 shape extras (added in Phase 1A).
+    "add_rect_filled_multi_color",
+    "add_ellipse", "add_ellipse_filled",
+    "add_ngon", "add_ngon_filled",
+    "add_polyline",
+    "add_bezier_cubic", "add_bezier_quadratic"
 ]
 
 def has_kind(var snap : JsonValue?; kind : string) : bool {

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -201,6 +201,23 @@ def child(var state : ChildState; text : string; size : float2;
     stateless_finalize(widget_ident, "child", state)
 }
 
+def public child_scroll_reenter(widget_ident : string; text : string; blk : block) {
+    //! Re-enter an existing child window (created earlier this frame by
+    //! `child(IDENT, (text = ...))`) to nudge its scroll position via
+    //! `SetScrollX` / `SetScrollY` inside `blk`. Replicates the original
+    //! container's `PushID(IDENT)` frame (emitted by `widget_prelude`) so
+    //! `BeginChild(text, ...)` hashes to the SAME window — without it ImGui
+    //! creates a phantom sibling and the scroll nudge silently has no visible
+    //! effect. `widget_ident` MUST be the literal IDENT string the original
+    //! `child` was called with — typo = silent miss. No registry entry; this
+    //! is a scroll-nudge, not a container.
+    PushID(widget_ident)
+    BeginChild(text, float2(0.0f, 0.0f), ImGuiChildFlags.None, ImGuiWindowFlags.None)
+    invoke(blk)
+    EndChild()
+    PopID()
+}
+
 [container]
 def group(var state : GroupState; blk : block) {
     //! `BeginGroup()` / `EndGroup()` — pure layout grouping, no return value

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -399,6 +399,26 @@ def open_popup_on_item_click(str_id : string;
     OpenPopupOnItemClick(str_id, flags)
 }
 
+def open_popup_on_item_click(var state : PopupState;
+                             flags : ImGuiPopupFlags = ImGuiPopupFlags.MouseButtonRight) : void {
+    //! Stateful right-click trigger paired with `popup` / `popup_modal`
+    //! containers. Checks ``IsMouseReleased`` + ``IsItemHovered`` on the
+    //! previously-submitted item, then queues ``state.pending_open`` so the
+    //! container's NEXT visit opens the popup INSIDE its own
+    //! ``PushID(IDENT)`` scope. The string-id form
+    //! (:ref:`open_popup_on_item_click(str_id, …) <function-imgui_containers_builtin_open_popup_on_item_click_string_ImGuiPopupFlags>`)
+    //! computes ``GetID(str_id)`` at the call-site ID stack, which DOES NOT
+    //! match a registered ``popup`` container's ``BeginPopup`` ID (the
+    //! container does its own ``PushID(IDENT)`` first) — so the popup never
+    //! opens. Use this overload whenever the target popup is a
+    //! ``popup(IDENT, …)`` / ``popup_modal(IDENT, …)`` container.
+    let mb = int(flags) & int(ImGuiPopupFlags.MouseButtonMask_)
+    if (IsMouseReleased(unsafe(reinterpret<ImGuiMouseButton>(mb)))
+            && IsItemHovered(ImGuiHoveredFlags.AllowWhenBlockedByPopup)) {
+        state.pending_open = true
+    }
+}
+
 def close_current_popup(var state : PopupState) : void {
     //! Close the active popup. Sets `pending_close` for state-transition
     //! telemetry AND calls `CloseCurrentPopup()` directly so the close

--- a/widgets/imgui_docking_builtin.das
+++ b/widgets/imgui_docking_builtin.das
@@ -141,6 +141,27 @@ def dockspace(var state : DockSpaceState; flags : ImGuiDockNodeFlags; blk : bloc
     dockspace_finalize(widget_ident, state)
 }
 
+// ===== dockspace_in_window =====
+
+[container]
+def dockspace_in_window(var state : DockSpaceState; size : float2;
+                        flags : ImGuiDockNodeFlags; blk : block) {
+    //! Explicit-host dockspace — call inside a `window(HOST, (flags = MenuBar | NoDocking | ...))` body. Emits `DockSpace(GetID(widget_ident), size, flags, null)` so the dock node lives inside the host window rather than claiming the full viewport (compare `dockspace` which uses `DockSpaceOverViewport`). The host window owns its own MenuBar / NoDocking flags; this container only manages the dock node. `size=(0,0)` (typical) fills the host's available content region. `state.dock_id` is captured for `DockBuilder*` layout calls and `imgui_dock_reset` re-runs the user's setup.
+    if (state.pending_reset) {
+        if (state.dock_id != 0u) {
+            DockBuilderRemoveNode(state.dock_id)
+        }
+        state.has_initial_layout = false
+        state.pending_reset = false
+    }
+    state.flags = flags
+    let id = GetID(widget_ident)
+    DockSpace(id, size, int(flags), null)
+    state.dock_id = id
+    invoke(blk)
+    dockspace_finalize(widget_ident, state)
+}
+
 // ===== dock_window =====
 
 [container]

--- a/widgets/imgui_docking_builtin.das
+++ b/widgets/imgui_docking_builtin.das
@@ -67,7 +67,8 @@ struct DockWindowState {
 // dispatcher lambda — keeps the per-target dispatcher install single-call
 // and matches the existing `open_close_finalize` shape in containers_builtin.
 
-def private dockspace_finalize(widget_ident : string; var state : DockSpaceState) {
+def private dockspace_finalize(widget_ident : string; kind : string;
+                               var state : DockSpaceState) {
     let path = container_path_key()
     var entry : WidgetEntry
     unsafe {
@@ -81,7 +82,7 @@ def private dockspace_finalize(widget_ident : string; var state : DockSpaceState
                 }
             }
         }
-        container_finalize(widget_ident, "dockspace", entry, ser, disp)
+        container_finalize(widget_ident, kind, entry, ser, disp)
     }
 }
 
@@ -138,7 +139,7 @@ def dockspace(var state : DockSpaceState; flags : ImGuiDockNodeFlags; blk : bloc
     let id = DockSpaceOverViewport(viewport, int(flags), null)
     state.dock_id = id
     invoke(blk)
-    dockspace_finalize(widget_ident, state)
+    dockspace_finalize(widget_ident, "dockspace", state)
 }
 
 // ===== dockspace_in_window =====
@@ -159,7 +160,7 @@ def dockspace_in_window(var state : DockSpaceState; size : float2;
     DockSpace(id, size, int(flags), null)
     state.dock_id = id
     invoke(blk)
-    dockspace_finalize(widget_ident, state)
+    dockspace_finalize(widget_ident, "dockspace_in_window", state)
 }
 
 // ===== dock_window =====

--- a/widgets/imgui_drawlist_builtin.das
+++ b/widgets/imgui_drawlist_builtin.das
@@ -41,10 +41,7 @@ def public drawlist_register(widget_ident : string; kind : string; bbox : float4
     //! a loop calling the same site N times is fine (last write wins
     //! on bbox; mouse-cards targeting hits the last-painted rect).
     let path = widget_path_key(widget_ident)
-    var entry : WidgetEntry
-    entry.kind = kind
-    entry.hex_id = 0u
-    entry.bbox = bbox
+    var entry = WidgetEntry(kind = kind, hex_id = 0u, bbox = bbox)
     g_registry[path] <- entry
 }
 
@@ -165,3 +162,215 @@ def public add_text(var dl : ImDrawList?; pos : float2; col : uint; text : strin
     drawlist_register(widget_ident, "add_text",
                       float4(pos.x, pos.y, pos.x + sz.x, pos.y + sz.y))
 }
+
+// ===== Extra shape primitives =====
+
+[drawlist_prim]
+def public add_rect_filled_multi_color(var dl : ImDrawList?; a : float2; b : float2;
+                                       col_ul : uint; col_ur : uint;
+                                       col_br : uint; col_bl : uint) {
+    //! Filled rectangle with a per-corner color gradient. Corners go
+    //! upper-left / upper-right / bottom-right / bottom-left. ImGui
+    //! interpolates linearly between them across the interior.
+    *dl |> AddRectFilledMultiColor(a, b, col_ul, col_ur, col_br, col_bl)
+    drawlist_register(widget_ident, "add_rect_filled_multi_color",
+                      float4(a.x, a.y, b.x, b.y))
+}
+
+[drawlist_prim]
+def public add_ellipse(var dl : ImDrawList?; center : float2; radii : float2; col : uint;
+                       rot : float = 0.0f; num_segments : int = 0;
+                       thickness : float = 1.0f) {
+    //! Stroked ellipse. ``radii`` = (rx, ry) half-axes. ``rot`` rotates the
+    //! ellipse about ``center`` (radians). ``num_segments=0`` uses ImGui's
+    //! adaptive segment count.
+    *dl |> AddEllipse(center, radii, col, rot, num_segments, thickness)
+    drawlist_register(widget_ident, "add_ellipse",
+                      float4(center.x - radii.x, center.y - radii.y,
+                             center.x + radii.x, center.y + radii.y))
+}
+
+[drawlist_prim]
+def public add_ellipse_filled(var dl : ImDrawList?; center : float2; radii : float2; col : uint;
+                              rot : float = 0.0f; num_segments : int = 0) {
+    //! Filled ellipse. Same shape semantics as ``add_ellipse``.
+    *dl |> AddEllipseFilled(center, radii, col, rot, num_segments)
+    drawlist_register(widget_ident, "add_ellipse_filled",
+                      float4(center.x - radii.x, center.y - radii.y,
+                             center.x + radii.x, center.y + radii.y))
+}
+
+[drawlist_prim]
+def public add_ngon(var dl : ImDrawList?; center : float2; radius : float; col : uint;
+                    num_segments : int; thickness : float = 1.0f) {
+    //! Stroked regular N-gon (``num_segments`` sides). Unlike ``add_circle``,
+    //! ``num_segments`` is required — there is no adaptive default.
+    *dl |> AddNgon(center, radius, col, num_segments, thickness)
+    drawlist_register(widget_ident, "add_ngon",
+                      float4(center.x - radius, center.y - radius,
+                             center.x + radius, center.y + radius))
+}
+
+[drawlist_prim]
+def public add_ngon_filled(var dl : ImDrawList?; center : float2; radius : float; col : uint;
+                           num_segments : int) {
+    //! Filled regular N-gon (``num_segments`` sides).
+    *dl |> AddNgonFilled(center, radius, col, num_segments)
+    drawlist_register(widget_ident, "add_ngon_filled",
+                      float4(center.x - radius, center.y - radius,
+                             center.x + radius, center.y + radius))
+}
+
+[drawlist_prim]
+def public add_polyline(var dl : ImDrawList?; points : array<float2>; col : uint;
+                        flags : ImDrawFlags = ImDrawFlags.None;
+                        thickness : float = 1.0f) {
+    //! Stroked polyline through ``points``. ``flags`` (typically
+    //! ``ImDrawFlags.Closed`` for closed polygons) controls open / closed
+    //! shape. Pass ``points`` as a ``array<float2>``; the wrapper hands
+    //! the underlying pointer to ImGui.
+    let n = length(points)
+    if (n >= 2) {
+        unsafe {
+            let ptr = addr(points[0])
+            *dl |> AddPolyline(reinterpret<ImVec2?>(ptr), n, col, flags, thickness)
+        }
+    }
+    var xs_min = points[0].x
+    var ys_min = points[0].y
+    var xs_max = points[0].x
+    var ys_max = points[0].y
+    for (p in points) {
+        xs_min = min(xs_min, p.x)
+        ys_min = min(ys_min, p.y)
+        xs_max = max(xs_max, p.x)
+        ys_max = max(ys_max, p.y)
+    }
+    drawlist_register(widget_ident, "add_polyline",
+                      float4(xs_min, ys_min, xs_max, ys_max))
+}
+
+[drawlist_prim]
+def public add_bezier_cubic(var dl : ImDrawList?; p1 : float2; p2 : float2;
+                            p3 : float2; p4 : float2; col : uint;
+                            thickness : float = 1.0f; num_segments : int = 0) {
+    //! Cubic bezier curve through ``p1`` → ``p4`` with control points
+    //! ``p2`` / ``p3``. ``num_segments=0`` uses ImGui's adaptive count.
+    *dl |> AddBezierCubic(p1, p2, p3, p4, col, thickness, num_segments)
+    let xs_min = min(min(p1.x, p2.x), min(p3.x, p4.x))
+    let ys_min = min(min(p1.y, p2.y), min(p3.y, p4.y))
+    let xs_max = max(max(p1.x, p2.x), max(p3.x, p4.x))
+    let ys_max = max(max(p1.y, p2.y), max(p3.y, p4.y))
+    drawlist_register(widget_ident, "add_bezier_cubic",
+                      float4(xs_min, ys_min, xs_max, ys_max))
+}
+
+[drawlist_prim]
+def public add_bezier_quadratic(var dl : ImDrawList?; p1 : float2; p2 : float2;
+                                p3 : float2; col : uint;
+                                thickness : float = 1.0f; num_segments : int = 0) {
+    //! Quadratic bezier curve through ``p1`` → ``p3`` with one control
+    //! point ``p2``. ``num_segments=0`` uses ImGui's adaptive count.
+    *dl |> AddBezierQuadratic(p1, p2, p3, col, thickness, num_segments)
+    let xs_min = min(min(p1.x, p2.x), p3.x)
+    let ys_min = min(min(p1.y, p2.y), p3.y)
+    let xs_max = max(max(p1.x, p2.x), p3.x)
+    let ys_max = max(max(p1.y, p2.y), p3.y)
+    drawlist_register(widget_ident, "add_bezier_quadratic",
+                      float4(xs_min, ys_min, xs_max, ys_max))
+}
+
+// ===== Path-building primitives =====
+//
+// Operate on the drawlist's internal path stack. Typical sequence:
+//
+//   dl |> path_clear()
+//   dl |> path_line_to(p0)
+//   dl |> path_arc_to(center, r, a0, a1, 32)
+//   dl |> path_stroke(col, ImDrawFlags.None, 2.0f)
+//
+// No per-call registry entry — the final ``path_stroke`` /
+// ``path_fill_convex`` / ``path_fill_concave`` is what renders.
+
+def public path_clear(var dl : ImDrawList?) {
+    //! Clear the drawlist's path stack — discards any pending path_line_to /
+    //! path_arc_to / path_bezier_* points without rendering them.
+    *dl |> PathClear()
+}
+
+def public path_line_to(var dl : ImDrawList?; pos : float2) {
+    //! Append a straight-line segment to the path, ending at ``pos``.
+    *dl |> PathLineTo(pos)
+}
+
+def public path_arc_to(var dl : ImDrawList?; center : float2; radius : float;
+                       a_min : float; a_max : float; num_segments : int = 0) {
+    //! Append a circular arc to the path. Angles in radians. ``num_segments=0``
+    //! uses ImGui's adaptive count.
+    *dl |> PathArcTo(center, radius, a_min, a_max, num_segments)
+}
+
+def public path_bezier_quadratic_curve_to(var dl : ImDrawList?; p2 : float2;
+                                          p3 : float2; num_segments : int = 0) {
+    //! Append a quadratic bezier curve from the path's current endpoint to
+    //! ``p3``, with control point ``p2``. ``num_segments=0`` uses ImGui's
+    //! adaptive count.
+    *dl |> PathBezierQuadraticCurveTo(p2, p3, num_segments)
+}
+
+def public path_fill_convex(var dl : ImDrawList?; col : uint) {
+    //! Close the current path and fill it (assumed convex — faster). For
+    //! concave polygons use ``path_fill_concave``.
+    *dl |> PathFillConvex(col)
+}
+
+def public path_fill_concave(var dl : ImDrawList?; col : uint) {
+    //! Close the current path and fill it. Handles concave shapes correctly
+    //! at the cost of an internal triangulation step.
+    *dl |> PathFillConcave(col)
+}
+
+def public path_stroke(var dl : ImDrawList?; col : uint;
+                       flags : ImDrawFlags = ImDrawFlags.None;
+                       thickness : float = 1.0f) {
+    //! Stroke the current path. ``flags`` (``ImDrawFlags.Closed`` for closed
+    //! shapes) controls whether the last vertex joins back to the first.
+    *dl |> PathStroke(col, flags, thickness)
+}
+
+// ===== Channel-splitter primitives =====
+//
+// Split the drawlist into N independent layers, draw onto each, then merge
+// back into a single z-ordered output. Use this when a later draw needs to
+// land UNDER an earlier draw (typical: card background painted AFTER the
+// card contents are submitted but rendered behind them).
+//
+//   dl |> channels_split(2)
+//   dl |> channels_set_current(1)   // foreground layer
+//   // ... draw widgets / content ...
+//   dl |> channels_set_current(0)   // background layer
+//   dl |> add_rect_filled(p0, p1, bg_col)
+//   dl |> channels_merge()
+
+def public channels_split(var dl : ImDrawList?; count : int) {
+    //! Split the drawlist into ``count`` channels. Subsequent draws land on
+    //! the current channel (default 0). Pair with ``channels_merge``.
+    *dl |> ChannelsSplit(count)
+}
+
+def public channels_set_current(var dl : ImDrawList?; idx : int) {
+    //! Set the active channel index (0-based). Subsequent draws on ``dl``
+    //! go to that channel until the next ``channels_set_current`` or
+    //! ``channels_merge``.
+    *dl |> ChannelsSetCurrent(idx)
+}
+
+def public channels_merge(var dl : ImDrawList?) {
+    //! Merge all channels back into the drawlist's main draw stream. Channel
+    //! 0 renders first, then channel 1 on top, etc. Pair with
+    //! ``channels_split``.
+    *dl |> ChannelsMerge()
+}
+
+// (with_clip_rect lives in imgui_scope_builtin.das — the scope rail —
+// since it gates ImGui widgets as well as drawlist primitives.)

--- a/widgets/imgui_drawlist_builtin.das
+++ b/widgets/imgui_drawlist_builtin.das
@@ -230,11 +230,10 @@ def public add_polyline(var dl : ImDrawList?; points : array<float2>; col : uint
     //! shape. Pass ``points`` as a ``array<float2>``; the wrapper hands
     //! the underlying pointer to ImGui.
     let n = length(points)
-    if (n >= 2) {
-        unsafe {
-            let ptr = addr(points[0])
-            *dl |> AddPolyline(reinterpret<ImVec2?>(ptr), n, col, flags, thickness)
-        }
+    return if (n < 2)
+    unsafe {
+        let ptr = addr(points[0])
+        *dl |> AddPolyline(reinterpret<ImVec2?>(ptr), n, col, flags, thickness)
     }
     var xs_min = points[0].x
     var ys_min = points[0].y

--- a/widgets/imgui_layout_builtin.das
+++ b/widgets/imgui_layout_builtin.das
@@ -228,7 +228,9 @@ def public tree_node_open(text : string;
     //! `TreeNodeEx(label, flags) : bool` — open form WITHOUT auto-pair TreePop.
     //! Use when the body needs to render outside the conditional (e.g.
     //! ``same_line()`` immediately after the header trigger). Caller MUST
-    //! invoke ``tree_pop()`` when the return value is true.
+    //! invoke ``tree_pop()`` when the return value is true AND the
+    //! ``NoTreePushOnOpen`` flag was NOT set (passing that flag skips the
+    //! TreePush, so a matching TreePop would underflow the stack).
     return TreeNodeEx(text, flags)
 }
 

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -103,7 +103,7 @@ let private ALLOWED_IMGUI : table<string> <- {
     "DockBuilderSetNodeSize", "DockBuilderSetNodePos",
     "DockBuilderSplitNode", "DockBuilderDockWindow", "DockBuilderFinish",
     "DockBuilderGetNode", "DockBuilderCopyNode",
-    "DockSpace", "DockSpaceOverViewport"
+    "DockSpace", "DockSpaceOverViewport", "GetID"
 }
 
 class ImguiLintVisitor : AstVisitor {

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -85,11 +85,6 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Cursor write-state — paired with the read-side Get* above.
     "SetCursorPos", "SetCursorPosX", "SetCursorPosY", "SetCursorScreenPos",
     "GetWindowContentRegionMax",
-    // BeginChild / EndChild — strictly for the "re-enter an existing child by
-    // name to nudge its scroll state" idiom (layout.das:3938-3940). The
-    // `child(...)` container is the primary surface; these naked calls are
-    // only for the re-entry trick.
-    "BeginChild", "EndChild",
     // Drag-drop payload primitives — caller owns memory, payload typing is
     // user-controlled. v2 drag_drop_source/_target containers gate the body;
     // these calls are the payload exchange inside.


### PR DESCRIPTION
## Summary

7 commits taking imgui_demo/ one PR away from finishing the port milestone:

1. **PR-C/1C** ([9648f88](https://github.com/borisbat/dasImgui/pull/51/commits/9648f88)) — `child_scroll_reenter` wrapper + PR-50 F2 bug fix
2. **PR-C/1Z** ([bee858e](https://github.com/borisbat/dasImgui/pull/51/commits/bee858e)) — feature-coverage audit + 9 new `examples/features/*.das`
3. **PR-C/1A** ([a65357b](https://github.com/borisbat/dasImgui/pull/51/commits/a65357b)) — 12 new drawlist primitives + tutorial/RST extension + features + clip_rect rewrite
4. **PR-C/1B** ([93d1748](https://github.com/borisbat/dasImgui/pull/51/commits/93d1748)) — `dockspace_in_window` container (explicit-host variant)
5. **PR-C/2A** ([4cae951](https://github.com/borisbat/dasImgui/pull/51/commits/4cae951)) — `app_custom_rendering` port (4 tabs) + harness
6. **PR-C/2B** ([15381fa](https://github.com/borisbat/dasImgui/pull/51/commits/15381fa)) — `app_dockspace` port + harness
7. **PR-C/2C** ([50714ba](https://github.com/borisbat/dasImgui/pull/51/commits/50714ba)) — `app_documents` port + harness
8. **PR-C/3+4** ([1dd4344](https://github.com/borisbat/dasImgui/pull/51/commits/1dd4344)) — aggregator wiring + tree_node_open F1 docstring (PR-50 follow-up)

35 files touched (33 `.das` + 2 `.rst`); +~3000 lines / -~150 lines.

## What changed

### Three imgui_demo stubs become real ports

- `examples/imgui_demo/app_custom_rendering.das` (cpp:8122-8423 → 460 das lines): 4-tab TabBar (Primitives / Canvas / BG-FG / Channels). All Phase 1A drawlist primitives + invisible_button + popup_context_item + with_clip_rect.
- `examples/imgui_demo/app_dockspace.das` (cpp:8424-8551 → 140 das lines): floating-host form with embedded `dockspace_in_window` + Options menu (Padding + 6 dockspace flag toggles + Close). Skips Target_DockSpaceAndWindow secondary mode (scope discipline).
- `examples/imgui_demo/app_documents.das` (cpp:8552-8900 → 320 das lines): Target_Tab mode — per-doc tabs with UnsavedDocument flag, per-tab context menu, File > Open submenu, close-confirmation popup_modal queue (Yes/No/Cancel).
- 3 harnesses for standalone/headless/live drives.
- `imgui_demo.das` aggregator: 3 toggles + 3 invocations (uniform `if (SHOW_X && !ShowExampleAppX()) SHOW_X = false` shape).

### Primitive surface additions

- `widgets/imgui_drawlist_builtin.das` — **12 new `[drawlist_prim]` wrappers**: `add_rect_filled_multi_color`, `add_ellipse(_filled)`, `add_ngon(_filled)`, `add_polyline`, `add_bezier_cubic`, `add_bezier_quadratic`, `path_clear`/`_line_to`/`_arc_to`/`_bezier_quadratic_curve_to`/`_fill_convex`/`_fill_concave`/`_stroke`, `channels_split`/`_set_current`/`_merge`. All C++ bindings already existed in `src/dasIMGUI.func_2{3,4,5}.cpp` — no bind regen needed.
- `widgets/imgui_docking_builtin.das` — new `dockspace_in_window(NAME, size, flags) { body }` container. Sibling of `dockspace` (full-viewport `DockSpaceOverViewport`); this one wraps `DockSpace(GetID(widget_ident), size, flags, null)` for the explicit-host pattern. Reuses `DockSpaceState`.
- `widgets/imgui_containers_builtin.das` — new `child_scroll_reenter(widget_ident, text) { body }` (NOT a `[container]` — would dupe registry path) for the re-enter-by-name scroll-nudge idiom. Replicates the original `child(IDENT)` container's `PushID(IDENT)` frame so `BeginChild` hashes to the SAME window.
- `widgets/imgui_lint.das` — drops `BeginChild`/`EndChild` from `ALLOWED_IMGUI` (the wrapper now owns it), adds `GetID` for `dockspace_in_window`.

### PR-50 bug fix that fell out of F2

PR-50 added `BeginChild`/`EndChild` to `ALLOWED` for one scroll-nudge idiom at `layout.das:970`. The comment claimed `child(...)` would "push a new ID and break the trick" — actually the **opposite** is true: `child(IDENT)` does `PushID(IDENT)` via `widget_prelude` ([imgui_boost.das:137](https://github.com/borisbat/dasImgui/blob/master/widgets/imgui_boost.das#L137)) **before** `BeginChild(text, ...)`, so the original child's ImGui hash includes the IDENT. The naked `BeginChild("scrolling")` at the rewrite site sat OUTSIDE that PushID frame, hashed to a phantom sibling, and SetScrollX silently moved the phantom while the visible child stayed put. The FizzBuzz `<<`/`>>` buttons in the Scrolling demo never actually scrolled. PR-C/1C closes this — the new wrapper is a behavior fix as well as lint hygiene.

PR-C/1C also bolts proper IDENTs onto the `small_button("<<")` / `small_button(">>")` calls (were bare strings before — no stable telemetry path) so a follow-up regression test (see Deferred below) becomes writable.

### Feature-coverage audit

196 public symbols across `widgets/imgui_*_builtin.das`, 68 existing `examples/features/*.das`. Diff (filtering internal helpers + indirectly-covered predicates) yielded 9 genuine gaps; all filled this PR:

| New feature | Covers |
|---|---|
| `data_table.das` | `data_table` + 6 table_* helpers (one inventory grid scene) |
| `tree_node_open_manual.das` | `tree_node_open` + `tree_pop` (PR-50 primitives) |
| `list_clipper.das` | virtual-list culling — 1000-row scrollable child |
| `text_filter.das` | `text_filter` + `passes_filter` (incl/excl token filter on 10 log lines) |
| `log_to_text.das` | `log_text` + `log_to_clipboard` + `log_finish` |
| `input_text_callback.das` | TAB completion via `CallbackCompletion` + `DeleteChars`/`InsertChars` |
| `edit_collapsing_header.das` | closable variant on a caller-owned `bool?` |
| `popup_context_window.das` | right-click context menu |
| `align_text_to_frame_padding.das` | row-A vs row-B comparison demo |

Plus the Phase 1A additions:
- **Extended** `examples/features/drawlist.das` with the new shape primitives.
- **New** `drawlist_path.das` (path-built rounded rect + convex pentagon + concave arrow), `drawlist_channels.das` (split/merge happy path).
- **Rewrote** `examples/features/clip_rect.das` to use the v2 `with_clip_rect` wrapper + `add_circle_filled`/`add_rect_filled` instead of raw `dl.AddCircleFilled`. Dropped the `options _allow_imgui_legacy = true` opt-out.

### Tests

- New `tests/integration/test_child_scroll_reenter.das` — drives BTN_DOWN clicks, asserts `SCROLLY.scroll.y` observably moves (contrapositive: the wrapper's `PushID(IDENT)` is correct).
- New `tests/integration/test_dockspace_in_window.das` — asserts `DS.dock_id` non-zero after first render + stable across frames; FILES/OUTPUT dock_window children render under HOST/DS path.
- Extended `tests/integration/test_drawlist_primitives.das` `EXPECTED_KINDS` for 8 new primitives.

### Docs

- `doc/source/tutorials/drawlist.rst` — extended with "Shape extras", "Path building", "Channel splitting", "Clip rect scope" subsections cross-linking to dedicated feature files.
- `doc/source/tutorials/docking.rst` — new "Variant: dockspace inside a host window" subsection.
- Extended `tests/integration/record_drawlist.das` narration for the new shape-extras section.

## Plan reference

Full plan in `C:\Users\Boris\.claude\plans\eager-splashing-lecun.md` (approved before kickoff). Scope decisions documented per-phase in the individual commit messages.

## Verification

- `mcp__daslang__lint --project-root=D:/IMGUI_DEMO` clean on all 33 changed/new `.das` files.
- `mcp__daslang__format_file`: all formatted.
- `daslang.exe -dry-run -project_root D:/IMGUI_DEMO`: all clean.
- Headless `EXIT=0` on every feature file + harness (4 features in Phase 1A + 9 in Phase 1Z + 3 harnesses in Phase 2). Tutorial uses `live_create_window` and doesn't auto-exit on `--headless-frames`; dry-run + structural review covers it.
- `sphinx-build -W` clean over `doc/source/`.

## Deferred (separate follow-ups)

- **Re-record `doc/source/_static/tutorials/drawlist.apng`** — Phase 1A wrappers + tutorial sections + recorder narration are all in; just needs a `daslang-live` spawn to actually rebuild the APNG. Existing APNG remains valid for the original primitives so CI is unaffected.
- **`tests/integration/test_layout_scroll_buttons.das`** — drives `<<`/`>>` in `harness_layout` to ratchet against PR-50 F2 regression. Requires nested `open_widget` for the LAYOUT_SECTION collapsing_header + LAYOUT_SCROLL_TN tree_node + a held-button drag to actually scroll past the activation frame. Doable, just non-trivial; Phase 1C's `test_child_scroll_reenter.das` covers the wrapper itself.

## Test plan

- [ ] Per-OS CI matrix (Ubuntu / macOS / Windows) — including the standard Windows 7-test exclude for the libhv 16-POST stall.
- [ ] `extended_checks` / GitGuardian / build / sphinx jobs all green.
- [ ] Manual smoke: open `examples/imgui_demo/harness_app_custom_rendering.das` and exercise the Canvas tab (right-click context menu / left-drag lines / right-drag pan).
- [ ] Manual smoke: open `examples/imgui_demo/harness_app_documents.das` and exercise the close-confirmation popup_modal (Modify a doc → close tab → Yes/No/Cancel).
- [ ] Manual smoke: open `harness_layout` Scrolling section, hold the `<<`/`>>` buttons in the FizzBuzz row, observe the child actually scrolls horizontally (PR-50 F2 behavior fix verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
