### PR TITLE
PR-D: tables.das port (24 sections) + sort_specs rail + final-delivery gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,15 +188,11 @@ For "how do I X?" / "why does Y behave this way?" questions about dasImgui patte
 
 Files still under `_allow_imgui_legacy = true` (pre-final-delivery checklist):
 
-- `examples/imgui_demo/widgets.das` (~865 LOC)
-- `examples/imgui_demo/inputs.das` (~450 LOC)
-- `examples/imgui_demo/layout.das` (~1214 LOC)
+- `examples/imgui_demo/tables.das` — stub at master tip; full port in flight as PR-D (cpp:4154-6044, ~1900 cpp lines, 24 sub-sections). Other 17 `examples/imgui_demo/*.das` files are sweep-clean since PR-A1/A2/B2/C (PRs #40/#48/#50/#51 — merged through 2026-05-19).
 
-Placeholder app stubs in `examples/imgui_demo/` that were never ported from `imgui_demo.cpp`'s C++ originals:
+Two example files keep ALIVE opt-outs that are intentional, not gaps:
 
-- `app_custom_rendering.das` (needs draw-list family extension)
-- `app_dockspace.das`
-- `app_documents.das`
-- `app_small.das`
+- `examples/tutorial/custom_widgets.das` — teaches building widgets from primitives; uses raw imgui by design.
+- `examples/features/widget_no_ident.das` — exercises the STYLE001-rejected `text((text=...))` form for didactic value.
 
-Final-delivery gate: `git grep _allow_imgui_legacy examples/imgui_demo/` returns nothing AND every `app_*.das` stub has a real port.
+Final-delivery gate: `git grep _allow_imgui_legacy examples/imgui_demo/` returns nothing AND every `app_*.das` stub has a real port. Currently the only `examples/imgui_demo/` file remaining is `tables.das`; the four `app_*.das` stubs (`app_custom_rendering`/`app_dockspace`/`app_documents`/`app_small`) all carry real ports as of PR #51.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,13 +186,13 @@ For "how do I X?" / "why does Y behave this way?" questions about dasImgui patte
 
 ## Followup-tracked gaps
 
-Files still under `_allow_imgui_legacy = true` (pre-final-delivery checklist):
+**Final-delivery gate: ACHIEVED as of PR-D (2026-05-19).**
 
-- `examples/imgui_demo/tables.das` — stub at master tip; full port in flight as PR-D (cpp:4154-6044, ~1900 cpp lines, 24 sub-sections). Other 17 `examples/imgui_demo/*.das` files are sweep-clean since PR-A1/A2/B2/C (PRs #40/#48/#50/#51 — merged through 2026-05-19).
+All `examples/imgui_demo/*.das` files are opt-out-free: `git grep _allow_imgui_legacy examples/imgui_demo/` returns nothing. Every `app_*.das` carries a real port. The 24-section `tables.das` port landed in PR-D (cpp:4154-6044, 2911 das lines across 8 commits).
 
 Two example files keep ALIVE opt-outs that are intentional, not gaps:
 
 - `examples/tutorial/custom_widgets.das` — teaches building widgets from primitives; uses raw imgui by design.
 - `examples/features/widget_no_ident.das` — exercises the STYLE001-rejected `text((text=...))` form for didactic value.
 
-Final-delivery gate: `git grep _allow_imgui_legacy examples/imgui_demo/` returns nothing AND every `app_*.das` stub has a real port. Currently the only `examples/imgui_demo/` file remaining is `tables.das`; the four `app_*.das` stubs (`app_custom_rendering`/`app_dockspace`/`app_documents`/`app_small`) all carry real ports as of PR #51.
+Section 24 Advanced's cpp Debug-details readout (cpp:6019-6031, `ImDrawList.CmdBuffer.Size + scroll cur/max`) is the one cpp construct deliberately skipped — `ImVector\`ImDrawCmd` has no `Size` accessor exposed in the daslang binding. The checkbox + readout are dropped; re-add when an `ImVector` size binding lands. Documented inline in `tables.das show_advanced()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,4 +195,7 @@ Two example files keep ALIVE opt-outs that are intentional, not gaps:
 - `examples/tutorial/custom_widgets.das` — teaches building widgets from primitives; uses raw imgui by design.
 - `examples/features/widget_no_ident.das` — exercises the STYLE001-rejected `text((text=...))` form for didactic value.
 
-Section 24 Advanced's cpp Debug-details readout (cpp:6019-6031, `ImDrawList.CmdBuffer.Size + scroll cur/max`) is the one cpp construct deliberately skipped — `ImVector\`ImDrawCmd` has no `Size` accessor exposed in the daslang binding. The checkbox + readout are dropped; re-add when an `ImVector` size binding lands. Documented inline in `tables.das show_advanced()`.
+Two cpp constructs are deliberately partial in the port:
+
+- **Section 21 sub 2** (per-column manual-open popups, cpp:5560-5582) — falls back to the default per-column context menu auto-emitted by `table_headers_row` plus a hovered-column readout text. The cpp pattern wants a stateless `popup_window(str_id, flags)` wrapper to bracket raw `BeginPopup`/`EndPopup` while the caller drives `OpenPopup`/`CloseCurrentPopup` elsewhere; that wrapper doesn't exist yet (existing `popup_context_item` is trigger-bound, stateful `popup(IDENT)` requires per-IDENT state which doesn't map to the cpp's shared-string ID pattern). Documented inline in `tables.das show_context_menus()`. Backlogged for a small follow-up PR (~100-150 das lines including the new-component triad).
+- **Section 24 Advanced's cpp Debug-details readout** (cpp:6019-6031, `ImDrawList.CmdBuffer.Size + scroll cur/max`) — `ImVector\`ImDrawCmd` has no `Size` accessor exposed in the daslang binding. The checkbox + readout are dropped; re-add when an `ImVector` size binding lands. Documented inline in `tables.das show_advanced()`.

--- a/doc/source/tutorials/data_table.rst
+++ b/doc/source/tutorials/data_table.rst
@@ -81,9 +81,43 @@ arguments as the underlying ImGui calls, snake_case names:
 
 ``TableState`` (the container's state struct) echoes per-call config —
 columns, flags, outer_size, inner_width — so snapshot consumers can read
-the table's shape without parsing the daslang call site. Sort-spec capture
-and multi-select hand-off are deliberately deferred to the upcoming
+the table's shape without parsing the daslang call site. Multi-select
+hand-off and custom row-bg callbacks remain deferred to the upcoming
 ``tables.das`` port and extend the state additively.
+
+Sortable tables
+===============
+
+The tutorial table uses the full sortable shape — ``Sortable | SortMulti
+| Reorderable | Hideable`` flags on the table, a stable ``user_id`` on
+each ``table_setup_column``, and a ``sort_specs()`` block-arg helper
+inside the body that ImGui fires when the sort state goes dirty.
+
+* ``ImGuiTableFlags.Sortable`` enables single-column sort (click any
+  header). Adding ``ImGuiTableFlags.SortMulti`` enables multi-column
+  sort (Shift+click a second header to append a secondary sort key).
+* ``table_setup_column("Name", flags, init_width, user_id=COL_NAME)``
+  tags the column with a stable identifier (a ``uint``). The sort
+  comparator dispatches on ``column_user_id`` rather than
+  ``column_index``, so the sort stays correct after the user reorders
+  columns via drag.
+* ``sort_specs() $(specs) { ... }`` is the wrapper that captures the
+  ImGui ``TableGetSortSpecs()`` data, converts each
+  ``ImGuiTableColumnSortSpecs`` entry into a daslang-friendly
+  ``TableSortSpec`` (with ``column_index``, ``column_user_id``,
+  ``sort_order``, ``sort_direction``), invokes the body block with the
+  array, and auto-clears the ``SpecsDirty`` flag on return. The block
+  only fires when ImGui reports dirty (header click), so the comparator
+  cost is paid once per sort change rather than every frame.
+
+The block-body comparator pattern walks the specs in priority order and
+returns on the first spec that disambiguates a pair — ``sort_order = 0``
+is the primary key, ``sort_order = 1`` is the first tiebreak, and so on.
+A final tiebreak on a unique field (here: ``name``) keeps the order
+total.
+
+For a complete standalone example (inventory table with id / name / qty
+columns and a multi-key comparator), see ``examples/features/sort_specs.das``.
 
 Why the name
 ============
@@ -105,7 +139,11 @@ open and reloads on source edits.
 
    Full source: :download:`examples/tutorial/data_table.das <../../../examples/tutorial/data_table.das>`
 
-   Integration test: ``tests/integration/test_app_small_property_editor.das``
-   (uses the same ``data_table`` container surface).
+   Sortable inventory example: :download:`examples/features/sort_specs.das <../../../examples/features/sort_specs.das>`
+   — the canonical ``sort_specs()`` reference with a multi-key comparator.
+
+   Integration tests: ``tests/integration/test_app_small_property_editor.das``
+   (uses the same ``data_table`` container surface) and
+   ``tests/integration/test_sort_specs.das`` (smoke for the sortable rail).
 
    :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/data_table.rst
+++ b/doc/source/tutorials/data_table.rst
@@ -82,8 +82,9 @@ arguments as the underlying ImGui calls, snake_case names:
 ``TableState`` (the container's state struct) echoes per-call config —
 columns, flags, outer_size, inner_width — so snapshot consumers can read
 the table's shape without parsing the daslang call site. Multi-select
-hand-off and custom row-bg callbacks remain deferred to the upcoming
-``tables.das`` port and extend the state additively.
+hand-off remains deferred — pinned ImGui 1.90.6 doesn't expose
+``BeginMultiSelect`` / ``ImGuiMultiSelectIO``. A custom row-bg callback
+API would extend the state additively if added later.
 
 Sortable tables
 ===============

--- a/examples/features/sort_specs.das
+++ b/examples/features/sort_specs.das
@@ -1,0 +1,164 @@
+options gen2
+
+require imgui/imgui_harness
+require imgui/imgui_table_builtin
+require strings
+
+// =============================================================================
+// FEATURE: sort_specs — sortable inventory table.
+// SHOWS:   - `data_table(SORT_TABLE, (flags = ... | Sortable | SortMulti, ...))`
+//            — table created with sort-capable flags.
+//          - `table_setup_column(label, flags, _, user_id)` — `user_id` argument
+//            tags each column with a stable identifier the sort callback uses to
+//            recognize columns independent of the runtime column order
+//            (Reorderable + Hideable).
+//          - `sort_specs() <| $(specs) { sort_items(specs) }` — fires only when
+//            ImGui reports SpecsDirty; the wrapper auto-clears the dirty flag.
+//            Supports multi-column sort: hold Shift while clicking a second
+//            header.
+//          - Each `TableSortSpec` carries column_index / column_user_id /
+//            sort_order / sort_direction so the comparator can drive both
+//            primary and tiebreak ordering.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/sort_specs.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/sort_specs.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/sort_specs.das
+// =============================================================================
+
+struct private InvItem {
+    id   : int
+    name : string
+    qty  : int
+}
+
+// Stable column identifiers passed to table_setup_column(.., user_id=...). Using
+// these instead of column_index in the comparator keeps the sort robust when the
+// user reorders columns via drag.
+let private COL_ID   = 0x0001u
+let private COL_NAME = 0x0002u
+let private COL_QTY  = 0x0003u
+
+var private SORT_ITEMS : array<InvItem>
+var private SORT_ROW_ID   : table<int; NarrativeState>
+var private SORT_ROW_NAME : table<int; NarrativeState>
+var private SORT_ROW_QTY  : table<int; NarrativeState>
+
+let private SEED_NAMES <- ["Widget", "Sprocket", "Gizmo", "Doohickey",
+                           "Thingamajig", "Whatsit", "Doodad", "Gadget",
+                           "Contraption", "Bauble", "Trinket", "Whatchamacallit"]
+
+[init]
+def seed_items() {
+    SORT_ITEMS |> reserve(length(SEED_NAMES))
+    for (i in range(length(SEED_NAMES))) {
+        SORT_ITEMS |> push(InvItem(
+            id = i + 100,
+            name = SEED_NAMES[i],
+            qty = (i * i - i) % 20))
+    }
+}
+
+def compare_field(spec : TableSortSpec; a : InvItem; b : InvItem) : int {
+    // Returns -1 / 0 / 1 for a-vs-b along the column the spec names.
+    var ord = 0
+    if (spec.column_user_id == COL_ID) {
+        ord = a.id - b.id
+    } elif (spec.column_user_id == COL_NAME) {
+        if (a.name < b.name) {
+            ord = -1
+        } elif (a.name > b.name) {
+            ord = 1
+        }
+    } elif (spec.column_user_id == COL_QTY) {
+        ord = a.qty - b.qty
+    }
+    if (spec.sort_direction == ImGuiSortDirection.Descending) {
+        ord = -ord
+    }
+    return ord
+}
+
+def sort_items_with_specs(specs : array<TableSortSpec>) {
+    // Multi-key comparator: walk specs in order, return on the first spec that
+    // disambiguates a vs b. Final tiebreak by id so the order is total.
+    SORT_ITEMS |> sort() $(a, b) {
+        for (s in specs) {
+            let ord = compare_field(s, a, b)
+            if (ord != 0) return ord < 0
+        }
+        return a.id < b.id
+    }
+}
+
+[export]
+def init() {
+    harness_init("sort_specs — sortable inventory table", 640, 460)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(600.0f, 420.0f), ImGuiCond.Always)
+    window(SORT_WIN, (text = "sort_specs", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Click headers to sort. Hold Shift + click for multi-column sort."))
+
+        data_table(SORT_TABLE, (text = "inventory_sort", columns = 3,
+                                flags = ImGuiTableFlags.Resizable |
+                                        ImGuiTableFlags.Reorderable |
+                                        ImGuiTableFlags.Hideable |
+                                        ImGuiTableFlags.Sortable |
+                                        ImGuiTableFlags.SortMulti |
+                                        ImGuiTableFlags.RowBg |
+                                        ImGuiTableFlags.BordersOuter |
+                                        ImGuiTableFlags.BordersV |
+                                        ImGuiTableFlags.ScrollY,
+                                outer_size = float2(0.0f, 280.0f),
+                                inner_width = 0.0f)) {
+            table_setup_column("ID",   ImGuiTableColumnFlags.DefaultSort |
+                                       ImGuiTableColumnFlags.WidthFixed,
+                               0.0f, COL_ID)
+            table_setup_column("Name", ImGuiTableColumnFlags.WidthStretch,
+                               0.0f, COL_NAME)
+            table_setup_column("Qty",  ImGuiTableColumnFlags.PreferSortDescending |
+                                       ImGuiTableColumnFlags.WidthFixed,
+                               80.0f, COL_QTY)
+            table_setup_scroll_freeze(0, 1)
+            table_headers_row()
+
+            sort_specs() $(specs) {
+                sort_items_with_specs(specs)
+            }
+
+            for (i in range(length(SORT_ITEMS))) {
+                table_next_row()
+                if (table_set_column_index(0)) {
+                    text(SORT_ROW_ID[i],   (text = "{SORT_ITEMS[i].id}"))
+                }
+                if (table_next_column()) {
+                    text(SORT_ROW_NAME[i], (text = "{SORT_ITEMS[i].name}"))
+                }
+                if (table_next_column()) {
+                    text(SORT_ROW_QTY[i],  (text = "{SORT_ITEMS[i].qty}"))
+                }
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/table_set_bg_color.das
+++ b/examples/features/table_set_bg_color.das
@@ -1,0 +1,136 @@
+options gen2
+
+require imgui/imgui_harness
+require imgui/imgui_table_builtin
+
+// =============================================================================
+// FEATURE: table_set_bg_color — per-row and per-cell background tinting.
+// SHOWS:   - `table_set_bg_color(ImGuiTableBgTarget.RowBg0, color)` after
+//            `table_next_row()` — paints the entire row's first bg layer.
+//            Useful for status/severity stripes that read at a glance.
+//          - `table_set_bg_color(ImGuiTableBgTarget.CellBg, color)` after
+//            `table_set_column_index(...)` / `table_next_column()` —
+//            paints just the current cell. Stacks above RowBg0/RowBg1.
+//          - Color packing via `rgba(r, g, b, a)` direct — no Style.Alpha
+//            multiplier (use `GetColorU32(float4(...))` if you want one).
+//          - `RowBg` table flag is independent of `table_set_bg_color` —
+//            the flag gives default alternating zebra; the override
+//            paints on top.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/table_set_bg_color.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/table_set_bg_color.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/table_set_bg_color.das
+// =============================================================================
+
+struct private StatusRow {
+    id     : int
+    name   : string
+    status : string
+    value  : int
+}
+
+var private BG_ROWS : array<StatusRow>
+
+var private BG_ROW_ID     : table<int; NarrativeState>
+var private BG_ROW_NAME   : table<int; NarrativeState>
+var private BG_ROW_STATUS : table<int; NarrativeState>
+var private BG_ROW_VALUE  : table<int; NarrativeState>
+
+[init]
+def seed_bg_rows() {
+    BG_ROWS <- [
+        StatusRow(id = 0, name = "server-01", status = "ok",   value = 12),
+        StatusRow(id = 1, name = "server-02", status = "warn", value = 67),
+        StatusRow(id = 2, name = "server-03", status = "crit", value = 94),
+        StatusRow(id = 3, name = "server-04", status = "ok",   value = 34),
+        StatusRow(id = 4, name = "server-05", status = "warn", value = 58),
+        StatusRow(id = 5, name = "server-06", status = "crit", value = 88),
+        StatusRow(id = 6, name = "server-07", status = "ok",   value = 21),
+        StatusRow(id = 7, name = "server-08", status = "ok",   value = 45)
+    ]
+}
+
+// Returns 0u for "ok" (no tint), warn = amber, crit = muted red.
+// Low alpha keeps text legible over the tint.
+def private status_row_color(s : string) : uint {
+    if (s == "warn") return rgba(220u, 170u, 50u, 70u)
+    if (s == "crit") return rgba(220u, 60u, 60u, 90u)
+    return 0u
+}
+
+[export]
+def init() {
+    harness_init("table_set_bg_color — row & cell background tints", 560, 380)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(520.0f, 340.0f), ImGuiCond.Always)
+    window(BG_WIN, (text = "table_set_bg_color", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "RowBg0 = full-row tint by status. CellBg = overlay on Value cells over threshold."))
+
+        data_table(BG_TABLE, (text = "status_table", columns = 4,
+                              flags = ImGuiTableFlags.RowBg |
+                                      ImGuiTableFlags.BordersOuter |
+                                      ImGuiTableFlags.BordersV |
+                                      ImGuiTableFlags.ScrollY,
+                              outer_size = float2(0.0f, 240.0f),
+                              inner_width = 0.0f)) {
+            table_setup_column("ID",     ImGuiTableColumnFlags.WidthFixed,   40.0f)
+            table_setup_column("Name",   ImGuiTableColumnFlags.WidthStretch)
+            table_setup_column("Status", ImGuiTableColumnFlags.WidthFixed,   80.0f)
+            table_setup_column("Value",  ImGuiTableColumnFlags.WidthFixed,   80.0f)
+            table_setup_scroll_freeze(0, 1)
+            table_headers_row()
+
+            for (i in range(length(BG_ROWS))) {
+                let r = BG_ROWS[i]
+                table_next_row()
+
+                // Row-level tint: full-row RowBg0 by status severity.
+                let row_color = status_row_color(r.status)
+                if (row_color != 0u) {
+                    table_set_bg_color(ImGuiTableBgTarget.RowBg0, row_color)
+                }
+
+                if (table_set_column_index(0)) {
+                    text(BG_ROW_ID[i], (text = "{r.id}"))
+                }
+                if (table_next_column()) {
+                    text(BG_ROW_NAME[i], (text = r.name))
+                }
+                if (table_next_column()) {
+                    text(BG_ROW_STATUS[i], (text = r.status))
+                }
+                if (table_next_column()) {
+                    text(BG_ROW_VALUE[i], (text = "{r.value}"))
+                    // Cell-level overlay: deep red for >80, amber for >50.
+                    if (r.value > 80) {
+                        table_set_bg_color(ImGuiTableBgTarget.CellBg, rgba(220u, 50u, 50u, 110u))
+                    } elif (r.value > 50) {
+                        table_set_bg_color(ImGuiTableBgTarget.CellBg, rgba(220u, 140u, 50u, 110u))
+                    }
+                }
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/imgui_demo/harness_tables.das
+++ b/examples/imgui_demo/harness_tables.das
@@ -1,0 +1,47 @@
+options gen2
+
+require imgui/imgui_harness
+require tables
+
+// =============================================================================
+// HARNESS: imgui_demo tables — single-scene driver for the C++
+//          ShowDemoWindowTables port. Lives next to tables.das because
+//          daslang require uses sibling-directory resolution.
+// SHOWS:   TABLES_SECTION collapsing_header inside a host MAIN_WIN window
+//          (ShowDemoWindowTables does NOT open its own window).
+// STANDALONE: daslang.exe modules/dasImgui/examples/imgui_demo/harness_tables.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/imgui_demo/harness_tables.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/imgui_demo/harness_tables.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("imgui_demo - Tables", 760, 640)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
+    SetNextWindowSize(ImVec2(720.0, 600.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "Tables", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        tables::ShowDemoWindowTables()
+    }
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -202,6 +202,43 @@ var private TABLES_COLFLAGS_LABEL         : table<int; NarrativeState>
 var private TABLES_COLFLAGS_INFLAG_LABEL  : table<int; NarrativeState>
 var private TABLES_COLFLAGS_OUTFLAG_LABEL : table<int; NarrativeState>
 
+// ---- Section 12 Columns widths state ----
+// Sub-table 1: default-width via TableSetupColumn (cpp:4938-4967).
+var private TABLES_CW1_FLAGS : int = int(ImGuiTableFlags.Borders |
+                                         ImGuiTableFlags.NoBordersInBodyUntilResize)
+var private TABLES_CW1_CELL : table<int; NarrativeState>  // 4*3 cells
+// Sub-table 2: explicit-width via TableSetupColumn (cpp:4969-5000).
+var private TABLES_CW2_FLAGS : int = int(ImGuiTableFlags.None)
+var private TABLES_CW2_CELL : table<int; NarrativeState>  // 5*4 cells
+
+// ---- Section 13 Nested tables state ----
+// One outer 2-col table holding a nested 2-col table in its first cell.
+var private TABLES_NESTED_OUTER_CELL : table<int; NarrativeState>  // 4 cells
+var private TABLES_NESTED_INNER_CELL : table<int; NarrativeState>  // 4 cells
+
+// ---- Section 14 Row height state ----
+// Sub 1: variable min_row_height per row.
+var private TABLES_RH1_CELL : table<int; NarrativeState>  // 8 cells
+// Sub 2: SameLine(0,0) line-height share — two rows, ColorButton + 2-line text.
+var private TABLES_RH2_COLOR_BTN : table<int; ClickState>     // 2 cells
+var private TABLES_RH2_LINE1     : table<int; NarrativeState> // 2 cells
+var private TABLES_RH2_LINE2     : table<int; NarrativeState> // 2 cells
+// Sub 3: per-row CellPadding.y mutation (every 3rd row).
+var private TABLES_RH3_CELL : table<int; NarrativeState>  // 8 cells
+
+// ---- Section 15 Outer size state ----
+// Sub 1: NoHostExtendX/Y toggles + sliding "Hello!" SameLine target.
+var private TABLES_OS1_FLAGS : int = int(ImGuiTableFlags.Borders |
+                                         ImGuiTableFlags.Resizable |
+                                         ImGuiTableFlags.ContextMenuInBody |
+                                         ImGuiTableFlags.RowBg |
+                                         ImGuiTableFlags.SizingFixedFit |
+                                         ImGuiTableFlags.NoHostExtendX)
+var private TABLES_OS1_CELL : table<int; NarrativeState>  // 10*3 cells
+// Sub 2 + 3: two explicit-size tables side-by-side.
+var private TABLES_OS2_CELL : table<int; NarrativeState>  // 5*3 cells
+var private TABLES_OS3_CELL : table<int; NarrativeState>  // 3*3 cells
+
 [init]
 def seed_columns_flags() {
     // cpp:4868 — `column_flags[3] = { DefaultSort, None, DefaultHide }`.
@@ -258,6 +295,10 @@ def ShowDemoWindowTables() {
         show_vertical_scrolling()
         show_horizontal_scrolling()
         show_columns_flags()
+        show_columns_widths()
+        show_nested_tables()
+        show_row_height()
+        show_outer_size()
 
         // Reset open_action so the next frame's tree_nodes inherit their
         // sticky open/closed state instead of being forced again.
@@ -1201,4 +1242,307 @@ def private show_column_status_flags(flags : int) {
     edit_checkbox_flags(unsafe(addr(local)),
         (id = "CSF_IH", text = "_IsHovered",
          flags_value = int(ImGuiTableColumnFlags.IsHovered)))
+}
+
+// =============================================================================
+// Section 12: Columns widths — cpp:4938-5002
+// =============================================================================
+def private show_columns_widths() {
+    apply_open_action()
+    tree_node(TABLES_CW, (text = "Columns widths",
+                          flags = ImGuiTreeNodeFlags.None)) {
+        // ----- Sub-table 1: TableSetupColumn default-width form -----
+        edit_checkbox_flags(safe_addr(TABLES_CW1_FLAGS),
+            (id = "TBL_CW1_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        edit_checkbox_flags(safe_addr(TABLES_CW1_FLAGS),
+            (id = "TBL_CW1_F_NBINBODYUNTILRESIZE",
+             text = "ImGuiTableFlags_NoBordersInBodyUntilResize",
+             flags_value = int(ImGuiTableFlags.NoBordersInBodyUntilResize)))
+
+        data_table(TABLES_CW1_T,
+                   (text = "##cw_table1", columns = 3,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_CW1_FLAGS)),
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            // Could alternatively set _SizingFixedFit on the table.
+            table_setup_column("one", ImGuiTableColumnFlags.WidthFixed, 100.0f)
+            table_setup_column("two", ImGuiTableColumnFlags.WidthFixed, 200.0f)
+            table_setup_column("three", ImGuiTableColumnFlags.WidthFixed)
+            table_headers_row()
+            for (row in range(4)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    let key = row * 3 + col
+                    if (row == 0) {
+                        let w = GetContentRegionAvail().x
+                        text(TABLES_CW1_CELL[key], (text = "(w: {w})"))
+                    } else {
+                        text(TABLES_CW1_CELL[key],
+                             (text = "Hello {col},{row}"))
+                    }
+                }
+            }
+        }
+
+        // ----- Sub-table 2: explicit width per column (TEXT_BASE_WIDTH * N) -----
+        edit_checkbox_flags(safe_addr(TABLES_CW2_FLAGS),
+            (id = "TBL_CW2_F_NOKEEP", text = "ImGuiTableFlags_NoKeepColumnsVisible",
+             flags_value = int(ImGuiTableFlags.NoKeepColumnsVisible)))
+        edit_checkbox_flags(safe_addr(TABLES_CW2_FLAGS),
+            (id = "TBL_CW2_F_BORDERS_IV", text = "ImGuiTableFlags_BordersInnerV",
+             flags_value = int(ImGuiTableFlags.BordersInnerV)))
+        edit_checkbox_flags(safe_addr(TABLES_CW2_FLAGS),
+            (id = "TBL_CW2_F_BORDERS_OV", text = "ImGuiTableFlags_BordersOuterV",
+             flags_value = int(ImGuiTableFlags.BordersOuterV)))
+
+        let text_base_width = CalcTextSize("A").x
+        data_table(TABLES_CW2_T,
+                   (text = "##cw_table2", columns = 4,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_CW2_FLAGS)),
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            table_setup_column("", ImGuiTableColumnFlags.WidthFixed, 100.0f)
+            table_setup_column("", ImGuiTableColumnFlags.WidthFixed,
+                               text_base_width * 15.0f)
+            table_setup_column("", ImGuiTableColumnFlags.WidthFixed,
+                               text_base_width * 30.0f)
+            table_setup_column("", ImGuiTableColumnFlags.WidthFixed,
+                               text_base_width * 15.0f)
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(4)) {
+                    table_set_column_index(col)
+                    let key = row * 4 + col
+                    if (row == 0) {
+                        let w = GetContentRegionAvail().x
+                        text(TABLES_CW2_CELL[key], (text = "(w: {w})"))
+                    } else {
+                        text(TABLES_CW2_CELL[key],
+                             (text = "Hello {col},{row}"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 13: Nested tables — cpp:5006-5047
+// =============================================================================
+def private show_nested_tables() {
+    apply_open_action()
+    tree_node(TABLES_NESTED, (text = "Nested tables",
+                              flags = ImGuiTreeNodeFlags.None)) {
+        let outer_flags = (ImGuiTableFlags.Borders | ImGuiTableFlags.Resizable |
+                           ImGuiTableFlags.Reorderable | ImGuiTableFlags.Hideable)
+        data_table(TABLES_NESTED_OUTER_T,
+                   (text = "##nested_outer", columns = 2,
+                    flags = outer_flags,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            table_setup_column("A0")
+            table_setup_column("A1")
+            table_headers_row()
+
+            // Cell (0, 0): outer label + nested 2-col data_table.
+            table_next_column()
+            text(TABLES_NESTED_OUTER_CELL[0], (text = "A0 Row 0"))
+
+            let rows_height = GetTextLineHeightWithSpacing() * 2.0f
+            data_table(TABLES_NESTED_INNER_T,
+                       (text = "##nested_inner", columns = 2,
+                        flags = outer_flags,
+                        outer_size = float2(0.0f, 0.0f),
+                        inner_width = 0.0f)) {
+                table_setup_column("B0")
+                table_setup_column("B1")
+                table_headers_row()
+
+                table_next_row(ImGuiTableRowFlags.None, rows_height)
+                table_next_column()
+                text(TABLES_NESTED_INNER_CELL[0], (text = "B0 Row 0"))
+                table_next_column()
+                text(TABLES_NESTED_INNER_CELL[1], (text = "B1 Row 0"))
+                table_next_row(ImGuiTableRowFlags.None, rows_height)
+                table_next_column()
+                text(TABLES_NESTED_INNER_CELL[2], (text = "B0 Row 1"))
+                table_next_column()
+                text(TABLES_NESTED_INNER_CELL[3], (text = "B1 Row 1"))
+            }
+
+            // Continue outer table after the nested one.
+            table_next_column()
+            text(TABLES_NESTED_OUTER_CELL[1], (text = "A1 Row 0"))
+            table_next_column()
+            text(TABLES_NESTED_OUTER_CELL[2], (text = "A0 Row 1"))
+            table_next_column()
+            text(TABLES_NESTED_OUTER_CELL[3], (text = "A1 Row 1"))
+        }
+    }
+}
+
+// =============================================================================
+// Section 14: Row height — cpp:5052-5112
+// =============================================================================
+def private show_row_height() {
+    apply_open_action()
+    tree_node(TABLES_RH, (text = "Row height",
+                          flags = ImGuiTreeNodeFlags.None)) {
+        let line_height = GetTextLineHeightWithSpacing()
+
+        // ----- Sub 1: min_row_height grows linearly per row -----
+        data_table(TABLES_RH1_T,
+                   (text = "##rh_table", columns = 1,
+                    flags = ImGuiTableFlags.Borders,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            for (row in range(8)) {
+                let min_row_height = float(int(line_height * 0.30f * float(row)))
+                table_next_row(ImGuiTableRowFlags.None, min_row_height)
+                table_next_column()
+                text(TABLES_RH1_CELL[row],
+                     (text = "min_row_height = {min_row_height}"))
+            }
+        }
+
+        // ----- Sub 2: SameLine(0, 0) shares line height across cells -----
+        // Two rows; each has a ColorButton in col 0 and a 2-line text in
+        // col 1. Row 1 puts an explicit `SameLine(0, 0)` before the
+        // first text line to demonstrate sharing the previous column's
+        // line height.
+        data_table(TABLES_RH2_T,
+                   (text = "##rh_share", columns = 2,
+                    flags = ImGuiTableFlags.Borders,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            let cb_color = float4(0.13f, 0.26f, 0.40f, 1.0f)
+            let cb_size = float2(40.0f, 40.0f)
+
+            table_next_row()
+            table_next_column()
+            color_button(TABLES_RH2_COLOR_BTN[0],
+                         (desc_id = "##rh2_cb0", col = cb_color, size = cb_size,
+                          flags = ImGuiColorEditFlags.None))
+            table_next_column()
+            text(TABLES_RH2_LINE1[0], (text = "Line 1"))
+            text(TABLES_RH2_LINE2[0], (text = "Line 2"))
+
+            table_next_row()
+            table_next_column()
+            color_button(TABLES_RH2_COLOR_BTN[1],
+                         (desc_id = "##rh2_cb1", col = cb_color, size = cb_size,
+                          flags = ImGuiColorEditFlags.None))
+            table_next_column()
+            // SameLine(0, 0) reuses line height from previous column.
+            same_line(TABLES_RH2_SL_REUSE,
+                      (offset_from_start_x = 0.0f, spacing = 0.0f))
+            text(TABLES_RH2_LINE1[1], (text = "Line 1, with SameLine(0,0)"))
+            text(TABLES_RH2_LINE2[1], (text = "Line 2"))
+        }
+
+        // ----- Sub 3: per-row CellPadding.y mutation (every 3rd row) -----
+        // cpp uses raw `Push/PopStyleVar(CellPadding)` only on rows where
+        // `row % 3 == 2`. The boost `with_style(...)` block scopes the
+        // push to its body, so we wrap just the row-2 emit in it.
+        data_table(TABLES_RH3_T,
+                   (text = "##rh_cellpad_y", columns = 1,
+                    flags = ImGuiTableFlags.Borders,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            let cell_padding_x = GetStyle().CellPadding.x
+            let cell_padding_y = GetStyle().CellPadding.y
+            for (row in range(8)) {
+                if (row % 3 == 2) {
+                    with_style((ImGuiStyleVar.CellPadding,
+                                float2(cell_padding_x, 20.0f))) {
+                        table_next_row(ImGuiTableRowFlags.None)
+                        table_next_column()
+                        text(TABLES_RH3_CELL[row],
+                             (text = "CellPadding.y = {cell_padding_y}"))
+                    }
+                } else {
+                    table_next_row(ImGuiTableRowFlags.None)
+                    table_next_column()
+                    text(TABLES_RH3_CELL[row],
+                         (text = "CellPadding.y = {cell_padding_y}"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 15: Outer size — cpp:5117-5179
+// =============================================================================
+def private show_outer_size() {
+    apply_open_action()
+    tree_node(TABLES_OS, (text = "Outer size",
+                          flags = ImGuiTreeNodeFlags.None)) {
+        text(TABLES_OS_HEADER_TEXT, (text = "Using NoHostExtendX and NoHostExtendY:"))
+
+        edit_checkbox_flags(safe_addr(TABLES_OS1_FLAGS),
+            (id = "TBL_OS1_F_NOHOSTX", text = "ImGuiTableFlags_NoHostExtendX",
+             flags_value = int(ImGuiTableFlags.NoHostExtendX)))
+        edit_checkbox_flags(safe_addr(TABLES_OS1_FLAGS),
+            (id = "TBL_OS1_F_NOHOSTY", text = "ImGuiTableFlags_NoHostExtendY",
+             flags_value = int(ImGuiTableFlags.NoHostExtendY)))
+
+        let line_height = GetTextLineHeightWithSpacing()
+        let outer_size_1 = float2(0.0f, line_height * 5.5f)
+        data_table(TABLES_OS1_T,
+                   (text = "##os_table1", columns = 3,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_OS1_FLAGS)),
+                    outer_size = outer_size_1,
+                    inner_width = 0.0f)) {
+            for (row in range(10)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_next_column()
+                    text(TABLES_OS1_CELL[row * 3 + col],
+                         (text = "Cell {col},{row}"))
+                }
+            }
+        }
+        same_line(TABLES_OS1_SL)
+        text(TABLES_OS1_HELLO, (text = "Hello!"))
+
+        spacing()
+        text(TABLES_OS_EXPLICIT_HEADER, (text = "Using explicit size:"))
+
+        let text_base_width = CalcTextSize("A").x
+        let explicit_size = float2(text_base_width * 30.0f, 0.0f)
+        let table_2_3_flags = (ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg)
+
+        data_table(TABLES_OS2_T,
+                   (text = "##os_table2", columns = 3,
+                    flags = table_2_3_flags,
+                    outer_size = explicit_size,
+                    inner_width = 0.0f)) {
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_next_column()
+                    text(TABLES_OS2_CELL[row * 3 + col],
+                         (text = "Cell {col},{row}"))
+                }
+            }
+        }
+        same_line(TABLES_OS_SL_2_3)
+        data_table(TABLES_OS3_T,
+                   (text = "##os_table3", columns = 3,
+                    flags = table_2_3_flags,
+                    outer_size = explicit_size,
+                    inner_width = 0.0f)) {
+            for (row in range(3)) {
+                table_next_row(ImGuiTableRowFlags.None, line_height * 1.5f)
+                for (col in range(3)) {
+                    table_next_column()
+                    text(TABLES_OS3_CELL[row * 3 + col],
+                         (text = "Cell {col},{row}"))
+                }
+            }
+        }
+    }
 }

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -4,10 +4,226 @@ options indenting = 4
 module tables
 
 require imgui
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_layout_builtin
+require imgui/imgui_id_builtin
+require imgui/imgui_scope_builtin
+require imgui/imgui_style_builtin
+require imgui/imgui_table_builtin
+require daslib/safe_addr
 
+// =============================================================================
 // Mirrors imgui_demo.cpp:4154-6044 — static void ShowDemoWindowTables().
+//
+// Port status (PR-D, this commit): section 1 Basic + section 2 Borders,
+// background. Remaining 22 sections (Resizable family / Padding / Sizing
+// policies / Scrolling / Columns flags / Background color / Tree view /
+// Custom headers / Angled headers / Context menus / Synced instances /
+// Sorting / Advanced) land in follow-up commits.
+//
+// Boost-surface conventions:
+// - cpp `static` locals → module-scope `var private` (state-hoist).
+// - cpp `PushID("Tables")` outer scope dropped — each `data_table(IDENT,
+//   ...)` already auto-PushID's its unique IDENT, so cross-section
+//   collisions can't happen.
+// - cpp Expand all / Collapse all driver → `g_open_action` gate with
+//   `apply_open_action()` called before each `tree_node(...)`. Reset to
+//   -1 at the end of the dispatcher.
+// - cpp `HelpMarker(text)` bubbles → dropped per the app_dockspace
+//   precedent (extra widget IDENTs + tooltip plumbing for context that's
+//   either obvious from the section title or redundant with our own
+//   docstring). May be reintroduced as a local helper if later sections
+//   carry load-bearing help text.
+// - Per-section helpers: one `def private show_section_<n>()` per
+//   CollapsingHeader sub-section so the dispatcher reads as a 24-line
+//   sequence.
+// =============================================================================
+
+// Shared Expand all / Collapse all driver.
+var private g_open_action : int = -1
+
+def private apply_open_action() {
+    if (g_open_action != -1) {
+        SetNextItemOpen(g_open_action != 0, ImGuiCond.Always)
+    }
+}
+
+// ---- Section 1 Basic state ----
+// All three table methods iterate procedurally; per-cell text needs its own
+// NarrativeState per call site. Indexed table state keeps each cell distinct
+// in the widget registry.
+var private TABLES_BASIC_T1_CELL : table<int; NarrativeState>
+var private TABLES_BASIC_T2_CELL : table<int; NarrativeState>
+var private TABLES_BASIC_T3_CELL : table<int; NarrativeState>
+
+// ---- Section 2 Borders, background state ----
+var private TABLES_BORDERS_FLAGS    : int  = int(ImGuiTableFlags.Borders |
+                                                 ImGuiTableFlags.RowBg)
+var private TABLES_BORDERS_CONTENTS : RadioIntState
+var private TABLES_BORDERS_T1_CELL_TEXT : table<int; NarrativeState>
+var private TABLES_BORDERS_T1_CELL_BTN  : table<int; ClickState>
+
 def ShowDemoWindowTables() {
-    if (CollapsingHeader("Tables & Columns")) {
-        Text("TODO: port section (imgui_demo.cpp:4154-6044)")
+    collapsing_header(TABLES_SECTION,
+                      (text = "Tables & Columns", closable = false,
+                       flags = ImGuiTreeNodeFlags.None)) {
+        // Expand all / Collapse all toolbar.
+        if (button(TABLES_EXPAND_ALL_BTN, (text = "Expand all"))) {
+            g_open_action = 1
+        }
+        same_line(TABLES_SL_EXPAND)
+        if (button(TABLES_COLLAPSE_ALL_BTN, (text = "Collapse all"))) {
+            g_open_action = 0
+        }
+        separator(TABLES_SEP_TOOLBAR)
+
+        show_basic()
+        show_borders_background()
+
+        // Reset open_action so the next frame's tree_nodes inherit their
+        // sticky open/closed state instead of being forced again.
+        g_open_action = -1
+    }
+}
+
+// =============================================================================
+// Section 1: Basic — cpp:4198-4256
+// =============================================================================
+def private show_basic() {
+    apply_open_action()
+    tree_node(TABLES_BASIC, (text = "Basic", flags = ImGuiTreeNodeFlags.None)) {
+        // Method 1: TableNextRow + TableSetColumnIndex per cell.
+        data_table(TABLES_BASIC_T1, (text = "##t1", columns = 3,
+                                     flags = ImGuiTableFlags.None,
+                                     outer_size = float2(0.0f, 0.0f),
+                                     inner_width = 0.0f)) {
+            for (row in range(4)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    let key = row * 3 + col
+                    text(TABLES_BASIC_T1_CELL[key],
+                         (text = "Row {row} Column {col}"))
+                }
+            }
+        }
+
+        // Method 2: TableNextRow + TableNextColumn manually per cell.
+        data_table(TABLES_BASIC_T2, (text = "##t2", columns = 3,
+                                     flags = ImGuiTableFlags.None,
+                                     outer_size = float2(0.0f, 0.0f),
+                                     inner_width = 0.0f)) {
+            for (row in range(4)) {
+                table_next_row()
+                table_next_column()
+                text(TABLES_BASIC_T2_CELL[row * 3 + 0], (text = "Row {row}"))
+                table_next_column()
+                text(TABLES_BASIC_T2_CELL[row * 3 + 1], (text = "Some contents"))
+                table_next_column()
+                text(TABLES_BASIC_T2_CELL[row * 3 + 2], (text = "123.456"))
+            }
+        }
+
+        // Method 3: TableNextColumn auto-wraps to new rows.
+        data_table(TABLES_BASIC_T3, (text = "##t3", columns = 3,
+                                     flags = ImGuiTableFlags.None,
+                                     outer_size = float2(0.0f, 0.0f),
+                                     inner_width = 0.0f)) {
+            for (item in range(14)) {
+                table_next_column()
+                text(TABLES_BASIC_T3_CELL[item], (text = "Item {item}"))
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 2: Borders, background — cpp:4261-4327
+// =============================================================================
+def private show_borders_background() {
+    apply_open_action()
+    tree_node(TABLES_BORDERS, (text = "Borders, background",
+                               flags = ImGuiTreeNodeFlags.None)) {
+        // Borders/background flag toggles. The nested with_indent blocks
+        // mirror the cpp Indent/Unindent visual grouping (BordersH /
+        // BordersV split into Outer + Inner sub-toggles).
+        edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+            (id = "TBL_B_F_ROWBG", text = "ImGuiTableFlags_RowBg",
+             flags_value = int(ImGuiTableFlags.RowBg)))
+        edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+            (id = "TBL_B_F_BORDERS", text = "ImGuiTableFlags_Borders",
+             flags_value = int(ImGuiTableFlags.Borders)))
+        with_indent(0.0f) {
+            edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                (id = "TBL_B_F_BORDERSH", text = "ImGuiTableFlags_BordersH",
+                 flags_value = int(ImGuiTableFlags.BordersH)))
+            with_indent(0.0f) {
+                edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                    (id = "TBL_B_F_BORDERSOH", text = "ImGuiTableFlags_BordersOuterH",
+                     flags_value = int(ImGuiTableFlags.BordersOuterH)))
+                edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                    (id = "TBL_B_F_BORDERSIH", text = "ImGuiTableFlags_BordersInnerH",
+                     flags_value = int(ImGuiTableFlags.BordersInnerH)))
+            }
+            edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                (id = "TBL_B_F_BORDERSV", text = "ImGuiTableFlags_BordersV",
+                 flags_value = int(ImGuiTableFlags.BordersV)))
+            with_indent(0.0f) {
+                edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                    (id = "TBL_B_F_BORDERSOV", text = "ImGuiTableFlags_BordersOuterV",
+                     flags_value = int(ImGuiTableFlags.BordersOuterV)))
+                edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                    (id = "TBL_B_F_BORDERSIV", text = "ImGuiTableFlags_BordersInnerV",
+                     flags_value = int(ImGuiTableFlags.BordersInnerV)))
+            }
+            edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                (id = "TBL_B_F_BORDERSO", text = "ImGuiTableFlags_BordersOuter",
+                 flags_value = int(ImGuiTableFlags.BordersOuter)))
+            edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+                (id = "TBL_B_F_BORDERSI", text = "ImGuiTableFlags_BordersInner",
+                 flags_value = int(ImGuiTableFlags.BordersInner)))
+        }
+
+        // Contents-type radio (Text vs FillButton) + display-headers checkbox.
+        align_text_to_frame_padding(TABLES_BORDERS_ATFP)
+        text(TABLES_BORDERS_CT_LABEL, (text = "Cell contents:"))
+        same_line(TABLES_BORDERS_SL_RT)
+        radio_button_int(TABLES_BORDERS_CONTENTS, (text = "Text", v_button = 0))
+        same_line(TABLES_BORDERS_SL_RFB)
+        radio_button_int(TABLES_BORDERS_CONTENTS, (text = "FillButton", v_button = 1))
+
+        checkbox(TABLES_BORDERS_DH_CHECK, (text = "Display headers", init = false))
+
+        edit_checkbox_flags(safe_addr(TABLES_BORDERS_FLAGS),
+            (id = "TBL_B_F_NBINBODY", text = "ImGuiTableFlags_NoBordersInBody",
+             flags_value = int(ImGuiTableFlags.NoBordersInBody)))
+
+        // 3x5 grid driven by the runtime flag set + contents-type selection.
+        data_table(TABLES_BORDERS_T1, (text = "##bt1", columns = 3,
+                                       flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_BORDERS_FLAGS)),
+                                       outer_size = float2(0.0f, 0.0f),
+                                       inner_width = 0.0f)) {
+            if (TABLES_BORDERS_DH_CHECK.value) {
+                table_setup_column("One")
+                table_setup_column("Two")
+                table_setup_column("Three")
+                table_headers_row()
+            }
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    let key = row * 3 + col
+                    let cell_text = "Hello {col},{row}"
+                    if (TABLES_BORDERS_CONTENTS.value == 0) {
+                        text(TABLES_BORDERS_T1_CELL_TEXT[key], (text = cell_text))
+                    } else {
+                        button(TABLES_BORDERS_T1_CELL_BTN[key],
+                               (text = cell_text, size = float2(-1.0f, 0.0f)))
+                    }
+                }
+            }
+        }
     }
 }

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -64,6 +64,43 @@ var private TABLES_BORDERS_CONTENTS : RadioIntState
 var private TABLES_BORDERS_T1_CELL_TEXT : table<int; NarrativeState>
 var private TABLES_BORDERS_T1_CELL_BTN  : table<int; ClickState>
 
+// ---- Section 3 Resizable, stretch state ----
+var private TABLES_RSTRETCH_FLAGS : int = int(ImGuiTableFlags.SizingStretchSame |
+                                              ImGuiTableFlags.Resizable |
+                                              ImGuiTableFlags.BordersOuter |
+                                              ImGuiTableFlags.BordersV |
+                                              ImGuiTableFlags.ContextMenuInBody)
+var private TABLES_RSTRETCH_CELL : table<int; NarrativeState>
+
+// ---- Section 4 Resizable, fixed state ----
+var private TABLES_RFIXED_FLAGS : int = int(ImGuiTableFlags.SizingFixedFit |
+                                            ImGuiTableFlags.Resizable |
+                                            ImGuiTableFlags.BordersOuter |
+                                            ImGuiTableFlags.BordersV |
+                                            ImGuiTableFlags.ContextMenuInBody)
+var private TABLES_RFIXED_CELL : table<int; NarrativeState>
+
+// ---- Section 5 Resizable, mixed state ----
+// Same flag set drives both sub-tables (3-col and 6-col). Per-column
+// WidthFixed/WidthStretch + DefaultHide configured at TableSetupColumn time.
+var private TABLES_RMIXED_FLAGS : int = int(ImGuiTableFlags.SizingFixedFit |
+                                            ImGuiTableFlags.RowBg |
+                                            ImGuiTableFlags.Borders |
+                                            ImGuiTableFlags.Resizable |
+                                            ImGuiTableFlags.Reorderable |
+                                            ImGuiTableFlags.Hideable)
+var private TABLES_RMIXED_T1_CELL : table<int; NarrativeState>
+var private TABLES_RMIXED_T2_CELL : table<int; NarrativeState>
+
+// ---- Section 6 Reorderable, hideable, with headers state ----
+var private TABLES_RHH_FLAGS : int = int(ImGuiTableFlags.Resizable |
+                                         ImGuiTableFlags.Reorderable |
+                                         ImGuiTableFlags.Hideable |
+                                         ImGuiTableFlags.BordersOuter |
+                                         ImGuiTableFlags.BordersV)
+var private TABLES_RHH_T1_CELL : table<int; NarrativeState>
+var private TABLES_RHH_T2_CELL : table<int; NarrativeState>
+
 def ShowDemoWindowTables() {
     collapsing_header(TABLES_SECTION,
                       (text = "Tables & Columns", closable = false,
@@ -80,6 +117,10 @@ def ShowDemoWindowTables() {
 
         show_basic()
         show_borders_background()
+        show_resizable_stretch()
+        show_resizable_fixed()
+        show_resizable_mixed()
+        show_reorderable_hideable_headers()
 
         // Reset open_action so the next frame's tree_nodes inherit their
         // sticky open/closed state instead of being forced again.
@@ -222,6 +263,197 @@ def private show_borders_background() {
                         button(TABLES_BORDERS_T1_CELL_BTN[key],
                                (text = cell_text, size = float2(-1.0f, 0.0f)))
                     }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 3: Resizable, stretch — cpp:4332-4359
+// =============================================================================
+def private show_resizable_stretch() {
+    apply_open_action()
+    tree_node(TABLES_RSTRETCH, (text = "Resizable, stretch",
+                                flags = ImGuiTreeNodeFlags.None)) {
+        // SizingStretchSame is the default when ScrollX is off; the two
+        // toggles below let you observe the effect of disabling Resizable
+        // or BordersV. _Resizable implicitly enables _BordersInnerV.
+        edit_checkbox_flags(safe_addr(TABLES_RSTRETCH_FLAGS),
+            (id = "TBL_RS_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        edit_checkbox_flags(safe_addr(TABLES_RSTRETCH_FLAGS),
+            (id = "TBL_RS_F_BORDERSV", text = "ImGuiTableFlags_BordersV",
+             flags_value = int(ImGuiTableFlags.BordersV)))
+
+        data_table(TABLES_RSTRETCH_T1, (text = "##rs1", columns = 3,
+                                        flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_RSTRETCH_FLAGS)),
+                                        outer_size = float2(0.0f, 0.0f),
+                                        inner_width = 0.0f)) {
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    text(TABLES_RSTRETCH_CELL[row * 3 + col],
+                         (text = "Hello {col},{row}"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 4: Resizable, fixed — cpp:4364-4393
+// =============================================================================
+def private show_resizable_fixed() {
+    apply_open_action()
+    tree_node(TABLES_RFIXED, (text = "Resizable, fixed",
+                              flags = ImGuiTreeNodeFlags.None)) {
+        // SizingFixedFit keeps columns at their initial width regardless of
+        // available space (subject to NoHostExtendX). Double-click a column
+        // border to auto-fit to contents.
+        edit_checkbox_flags(safe_addr(TABLES_RFIXED_FLAGS),
+            (id = "TBL_RF_F_NOHOST", text = "ImGuiTableFlags_NoHostExtendX",
+             flags_value = int(ImGuiTableFlags.NoHostExtendX)))
+
+        data_table(TABLES_RFIXED_T1, (text = "##rf1", columns = 3,
+                                      flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_RFIXED_FLAGS)),
+                                      outer_size = float2(0.0f, 0.0f),
+                                      inner_width = 0.0f)) {
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    text(TABLES_RFIXED_CELL[row * 3 + col],
+                         (text = "Hello {col},{row}"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 5: Resizable, mixed — cpp:4398-4443
+// =============================================================================
+def private show_resizable_mixed() {
+    apply_open_action()
+    tree_node(TABLES_RMIXED, (text = "Resizable, mixed",
+                              flags = ImGuiTreeNodeFlags.None)) {
+        // Per-column WidthFixed / WidthStretch policy mix. The 6-col second
+        // table also demonstrates DefaultHide for initial column visibility.
+        let tflags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_RMIXED_FLAGS))
+
+        // Table 1: 3 columns (2 Fixed + 1 Stretch).
+        data_table(TABLES_RMIXED_T1, (text = "##rm1", columns = 3, flags = tflags,
+                                      outer_size = float2(0.0f, 0.0f),
+                                      inner_width = 0.0f)) {
+            table_setup_column("AAA", ImGuiTableColumnFlags.WidthFixed)
+            table_setup_column("BBB", ImGuiTableColumnFlags.WidthFixed)
+            table_setup_column("CCC", ImGuiTableColumnFlags.WidthStretch)
+            table_headers_row()
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    let kind = col == 2 ? "Stretch" : "Fixed"
+                    text(TABLES_RMIXED_T1_CELL[row * 3 + col],
+                         (text = "{kind} {col},{row}"))
+                }
+            }
+        }
+
+        // Table 2: 6 columns (3 Fixed including DefaultHide + 3 Stretch
+        // including DefaultHide).
+        data_table(TABLES_RMIXED_T2, (text = "##rm2", columns = 6, flags = tflags,
+                                      outer_size = float2(0.0f, 0.0f),
+                                      inner_width = 0.0f)) {
+            table_setup_column("AAA", ImGuiTableColumnFlags.WidthFixed)
+            table_setup_column("BBB", ImGuiTableColumnFlags.WidthFixed)
+            table_setup_column("CCC", ImGuiTableColumnFlags.WidthFixed | ImGuiTableColumnFlags.DefaultHide)
+            table_setup_column("DDD", ImGuiTableColumnFlags.WidthStretch)
+            table_setup_column("EEE", ImGuiTableColumnFlags.WidthStretch)
+            table_setup_column("FFF", ImGuiTableColumnFlags.WidthStretch | ImGuiTableColumnFlags.DefaultHide)
+            table_headers_row()
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(6)) {
+                    table_set_column_index(col)
+                    let kind = col >= 3 ? "Stretch" : "Fixed"
+                    text(TABLES_RMIXED_T2_CELL[row * 6 + col],
+                         (text = "{kind} {col},{row}"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 6: Reorderable, hideable, with headers — cpp:4448-4503
+// =============================================================================
+def private show_reorderable_hideable_headers() {
+    apply_open_action()
+    tree_node(TABLES_RHH, (text = "Reorderable, hideable, with headers",
+                           flags = ImGuiTreeNodeFlags.None)) {
+        // Click + drag a header to reorder columns; right-click a header for
+        // the visibility context menu.
+        edit_checkbox_flags(safe_addr(TABLES_RHH_FLAGS),
+            (id = "TBL_RHH_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        edit_checkbox_flags(safe_addr(TABLES_RHH_FLAGS),
+            (id = "TBL_RHH_F_REORDERABLE", text = "ImGuiTableFlags_Reorderable",
+             flags_value = int(ImGuiTableFlags.Reorderable)))
+        edit_checkbox_flags(safe_addr(TABLES_RHH_FLAGS),
+            (id = "TBL_RHH_F_HIDEABLE", text = "ImGuiTableFlags_Hideable",
+             flags_value = int(ImGuiTableFlags.Hideable)))
+        edit_checkbox_flags(safe_addr(TABLES_RHH_FLAGS),
+            (id = "TBL_RHH_F_NBINBODY", text = "ImGuiTableFlags_NoBordersInBody",
+             flags_value = int(ImGuiTableFlags.NoBordersInBody)))
+        edit_checkbox_flags(safe_addr(TABLES_RHH_FLAGS),
+            (id = "TBL_RHH_F_NBINBODYUNTILRESIZE",
+             text = "ImGuiTableFlags_NoBordersInBodyUntilResize",
+             flags_value = int(ImGuiTableFlags.NoBordersInBodyUntilResize)))
+        edit_checkbox_flags(safe_addr(TABLES_RHH_FLAGS),
+            (id = "TBL_RHH_F_HIGHLIGHTHOVERED",
+             text = "ImGuiTableFlags_HighlightHoveredColumn",
+             flags_value = int(ImGuiTableFlags.HighlightHoveredColumn)))
+
+        let tflags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_RHH_FLAGS))
+
+        // Table 1: default outer_size (stretches to fill available width).
+        data_table(TABLES_RHH_T1, (text = "##rhh1", columns = 3, flags = tflags,
+                                   outer_size = float2(0.0f, 0.0f),
+                                   inner_width = 0.0f)) {
+            table_setup_column("One")
+            table_setup_column("Two")
+            table_setup_column("Three")
+            table_headers_row()
+            for (row in range(6)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    text(TABLES_RHH_T1_CELL[row * 3 + col],
+                         (text = "Hello {col},{row}"))
+                }
+            }
+        }
+
+        // Table 2: outer_size.x = 0.0f + SizingFixedFit packs columns tight
+        // (valid only without ScrollX or stretch columns).
+        let tflags2 = unsafe(reinterpret<ImGuiTableFlags>(
+                                 TABLES_RHH_FLAGS | int(ImGuiTableFlags.SizingFixedFit)))
+        data_table(TABLES_RHH_T2, (text = "##rhh2", columns = 3, flags = tflags2,
+                                   outer_size = float2(0.0f, 0.0f),
+                                   inner_width = 0.0f)) {
+            table_setup_column("One")
+            table_setup_column("Two")
+            table_setup_column("Three")
+            table_headers_row()
+            for (row in range(6)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    text(TABLES_RHH_T2_CELL[row * 3 + col],
+                         (text = "Fixed {col},{row}"))
                 }
             }
         }

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -373,11 +373,14 @@ let private TABLES_SORT_TEMPLATE_NAMES <- ["Banana", "Apple", "Cherry",
                                            "Strawberry", "Mango", "Kiwi",
                                            "Orange", "Pineapple", "Blueberry",
                                            "Plum", "Coconut", "Pear", "Apricot"]
-// Per-column user_id codes (mirror cpp MyItemColumnID).
-let private TABLES_SORT_COL_ID       = 0u
-let private TABLES_SORT_COL_NAME     = 1u
-let private TABLES_SORT_COL_ACTION   = 2u
-let private TABLES_SORT_COL_QUANTITY = 3u
+// Per-column user_id codes (mirror cpp MyItemColumnID). Description is
+// new in section 24 Advanced — kept adjacent to the section-23 entries
+// because both sections reuse the same SortItem struct + template names.
+let private TABLES_SORT_COL_ID          = 0u
+let private TABLES_SORT_COL_NAME        = 1u
+let private TABLES_SORT_COL_ACTION      = 2u
+let private TABLES_SORT_COL_QUANTITY    = 3u
+let private TABLES_SORT_COL_DESCRIPTION = 4u
 
 struct private SortItem {
     id       : int
@@ -402,6 +405,80 @@ var private TABLES_SORT_ID_TEXT     : table<int; NarrativeState>
 var private TABLES_SORT_NAME_TEXT   : table<int; NarrativeState>
 var private TABLES_SORT_ACTION_BTN  : table<int; ClickState>
 var private TABLES_SORT_QTY_TEXT    : table<int; NarrativeState>
+
+// ---- Section 24 Advanced state ----
+// Mirrors cpp:5713-6033. Reuses TABLES_SORT_TEMPLATE_NAMES + SortItem
+// struct + TABLES_SORT_COL_* user-id constants from section 23. ITEMS
+// lifecycle is independent (items_count is user-editable, body mutates
+// quantity via Chop/Eat) so the items list lives in its own array.
+
+// Contents-type enum (mirror cpp ContentsType). The Combo at the bottom
+// of the Options/Other sub-tree drives this; the per-row first column
+// switches on it.
+let private TABLES_ADV_CT_TEXT                  = 0
+let private TABLES_ADV_CT_BUTTON                = 1
+let private TABLES_ADV_CT_SMALL_BUTTON          = 2
+let private TABLES_ADV_CT_FILL_BUTTON           = 3
+let private TABLES_ADV_CT_SELECTABLE            = 4
+let private TABLES_ADV_CT_SELECTABLE_SPAN_ROW   = 5
+
+// Table flags (cpp:5724-5729). Defaults: full Resizable/Reorderable/
+// Hideable/Sortable/SortMulti + RowBg/Borders/NoBordersInBody +
+// ScrollX/ScrollY + SizingFixedFit.
+var private TABLES_ADV_FLAGS : int = int(ImGuiTableFlags.Resizable |
+                                         ImGuiTableFlags.Reorderable |
+                                         ImGuiTableFlags.Hideable |
+                                         ImGuiTableFlags.Sortable |
+                                         ImGuiTableFlags.SortMulti |
+                                         ImGuiTableFlags.RowBg |
+                                         ImGuiTableFlags.Borders |
+                                         ImGuiTableFlags.NoBordersInBody |
+                                         ImGuiTableFlags.ScrollX |
+                                         ImGuiTableFlags.ScrollY |
+                                         ImGuiTableFlags.SizingFixedFit)
+// Per-column shared flags (cpp:5730 `columns_base_flags`). Only
+// AngledHeader is editable in the Options/Headers sub-tree; OR'd into
+// every TableSetupColumn call below.
+var private TABLES_ADV_COLUMNS_BASE_FLAGS : int = int(ImGuiTableColumnFlags.None)
+
+var private TABLES_ADV_CONTENTS_TYPE      : int    = 5 // CT_SelectableSpanRow
+var private TABLES_ADV_FREEZE_COLS        : int    = 1
+var private TABLES_ADV_FREEZE_ROWS        : int    = 1
+// items_count default = template_count * 2 = 30 (cpp:5737).
+var private TABLES_ADV_ITEMS_COUNT        : int    = 30
+var private TABLES_ADV_OUTER_SIZE_VALUE   : float2 = float2(0.0f, 0.0f) // seeded in [init] from TextLineHeightWithSpacing * 12
+var private TABLES_ADV_ROW_MIN_HEIGHT     : float  = 0.0f
+var private TABLES_ADV_INNER_WIDTH        : float  = 0.0f
+var private TABLES_ADV_OUTER_SIZE_ENABLED : bool   = true
+var private TABLES_ADV_SHOW_HEADERS       : bool   = true
+var private TABLES_ADV_SHOW_WRAPPED_TEXT  : bool   = false
+// SHOW_DEBUG_DETAILS / SCROLL_CUR / SCROLL_MAX dropped — see post-table
+// comment in show_advanced(). cpp's debug readout reads
+// ImDrawList.CmdBuffer.Size, which the daslang ImVector binding doesn't
+// surface as a readable accessor.
+
+// items + selection. Items are owned per-section (separate lifecycle
+// from TABLES_SORT_ITEMS); selection is an unsorted int array of
+// item.id values (mirrors cpp's ImVector<int> selection).
+var private TABLES_ADV_ITEMS     : array<SortItem>
+var private TABLES_ADV_SELECTION : array<int>
+var private TABLES_ADV_ITEMS_NEED_SORT : bool = false
+
+// Per-row widget state — keyed by SortItem.id so paths track items
+// across re-sorts. We do NOT pre-seed: the row helper auto-inserts on
+// first access. Items_count change (rebuild_adv_items) wipes them so
+// the registry doesn't accumulate stale entries.
+var private TABLES_ADV_ID_TEXT      : table<int; NarrativeState>  // CT_Text
+var private TABLES_ADV_ID_BTN       : table<int; ClickState>      // CT_Button / SmallButton / FillButton
+var private TABLES_ADV_ID_SEL       : table<int; ClickState>      // CT_Selectable[_SpanRow]
+var private TABLES_ADV_NAME_TEXT    : table<int; NarrativeState>
+var private TABLES_ADV_CHOP_BTN     : table<int; ClickState>
+var private TABLES_ADV_EAT_BTN      : table<int; ClickState>
+var private TABLES_ADV_QTY_TEXT     : table<int; NarrativeState>
+var private TABLES_ADV_DESC_TEXT    : table<int; NarrativeState>
+var private TABLES_ADV_HIDDEN_TEXT  : table<int; NarrativeState>
+// Inter-button same_line marker — one per row.
+var private TABLES_ADV_SL_CHOP_EAT  : table<int; EmptyMarkerState>
 
 [init]
 def seed_sort_items() {
@@ -448,6 +525,67 @@ def seed_sizing_policy() {
     TABLES_SIZING_POLICY[3] = int(ImGuiTableFlags.SizingStretchSame)
 }
 
+[init]
+def seed_advanced_outer_size() {
+    // cpp:5738 — `outer_size_value = ImVec2(0.0f, TEXT_BASE_HEIGHT * 12)`.
+    // GetTextLineHeightWithSpacing() requires an active ImGui frame so we
+    // cannot call it at [init] time; use a hardcoded approximation
+    // (line_h ~= 17px at default font) which the user can immediately
+    // adjust via the Other/##OuterSize DragFloat2.
+    TABLES_ADV_OUTER_SIZE_VALUE = float2(0.0f, 17.0f * 12.0f)
+}
+
+// Synchronize TABLES_ADV_ITEMS with TABLES_ADV_ITEMS_COUNT. Called every
+// frame at the top of show_advanced(); mirrors the cpp:5870-5881 resize
+// + per-item re-seed (always overwrites, matching cpp).
+def private rebuild_adv_items() {
+    let want = max(TABLES_ADV_ITEMS_COUNT, 0)
+    if (length(TABLES_ADV_ITEMS) == want) return
+    TABLES_ADV_ITEMS |> resize(want)
+    let template_count = length(TABLES_SORT_TEMPLATE_NAMES)
+    for (n in range(want)) {
+        let template_n = n % template_count
+        TABLES_ADV_ITEMS[n].id = n
+        TABLES_ADV_ITEMS[n].name := TABLES_SORT_TEMPLATE_NAMES[template_n]
+        // cpp:5879 — only templates 3/4 get non-zero defaults.
+        var qty = 0
+        if (template_n == 3) {
+            qty = 10
+        } elif (template_n == 4) {
+            qty = 20
+        }
+        TABLES_ADV_ITEMS[n].quantity = qty
+    }
+}
+
+// Multi-key sort comparator shared with the sort_specs() block-arg below.
+// Mirrors cpp:4024-4061 MyItem::CompareWithSortSpecs — walks specs in
+// order, returns first non-zero delta with asc/desc sign applied; falls
+// back on ID tie-break (qsort is not stable, per Boris's note in the
+// strudel skill — daslang `sort()` is also qsort).
+def private adv_compare(a : SortItem; b : SortItem;
+                        specs : array<TableSortSpec>) : bool {
+    for (spec in specs) {
+        var delta = 0
+        if (spec.column_user_id == TABLES_SORT_COL_ID) {
+            delta = a.id - b.id
+        } elif (spec.column_user_id == TABLES_SORT_COL_NAME) {
+            delta = a.name < b.name ? -1 : (a.name > b.name ? 1 : 0)
+        } elif (spec.column_user_id == TABLES_SORT_COL_QUANTITY) {
+            delta = a.quantity - b.quantity
+        } elif (spec.column_user_id == TABLES_SORT_COL_DESCRIPTION) {
+            // cpp:4048 — Description sorts by Name (description is a
+            // canned literal, no per-item field).
+            delta = a.name < b.name ? -1 : (a.name > b.name ? 1 : 0)
+        }
+        if (delta != 0) {
+            let asc = spec.sort_direction == ImGuiSortDirection.Ascending
+            return asc ? delta < 0 : delta > 0
+        }
+    }
+    return a.id < b.id
+}
+
 def ShowDemoWindowTables() {
     collapsing_header(TABLES_SECTION,
                       (text = "Tables & Columns", closable = false,
@@ -485,6 +623,7 @@ def ShowDemoWindowTables() {
         show_context_menus()
         show_synced_instances()
         show_sorting()
+        show_advanced()
 
         // Reset open_action so the next frame's tree_nodes inherit their
         // sticky open/closed state instead of being forced again.
@@ -2314,5 +2453,459 @@ def private show_sorting() {
                 }
             }
         }
+    }
+}
+
+// =============================================================================
+// Section 24: Advanced — cpp:5713-6033
+//
+// The heaviest demo by far: nearly every table flag, every contents-type
+// option, scrolling debug readout, list-clipper-virtualized data with
+// PushButtonRepeat, ID-keyed widget state, Ctrl+click multi-select, and
+// quantity-edit-triggers-resort interaction. State + helpers above; the
+// helper below mirrors the cpp source linearly.
+//
+// Skipped from cpp:
+// - PushStyleCompact / PopStyleCompact (cosmetic compaction wrapper —
+//   per the established section-wide policy in this file).
+// - All HelpMarker bubbles (per the same policy).
+// =============================================================================
+def private show_advanced() {
+    apply_open_action()
+    tree_node(TABLES_ADV, (text = "Advanced",
+                           flags = ImGuiTreeNodeFlags.None)) {
+        // ---- Options sub-tree (cpp:5746-5864) ----
+        // Per-cell SetNextItemWidth(TEXT_BASE_WIDTH * 28) before each
+        // edit_drag_* call (mimics the cpp PushItemWidth(28 * width)
+        // applied once to all enclosed widgets — boost edit_* widgets
+        // don't honor PushItemWidth uniformly, so per-call SetNextItemWidth
+        // is the safer narrow-impact equivalent).
+        let text_base_width = CalcTextSize("A").x
+        let item_width = text_base_width * 28.0f
+
+        if (tree_node_ex(TABLES_ADV_OPTIONS,
+                         (text = "Options",
+                          flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+            // ---- Features sub-node (cpp:5752-5761) ----
+            if (tree_node_ex(TABLES_ADV_F_NODE,
+                             (text = "Features:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+                     flags_value = int(ImGuiTableFlags.Resizable)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_REORDERABLE", text = "ImGuiTableFlags_Reorderable",
+                     flags_value = int(ImGuiTableFlags.Reorderable)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_HIDEABLE", text = "ImGuiTableFlags_Hideable",
+                     flags_value = int(ImGuiTableFlags.Hideable)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_SORTABLE", text = "ImGuiTableFlags_Sortable",
+                     flags_value = int(ImGuiTableFlags.Sortable)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOSAVED", text = "ImGuiTableFlags_NoSavedSettings",
+                     flags_value = int(ImGuiTableFlags.NoSavedSettings)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_CTXMENU", text = "ImGuiTableFlags_ContextMenuInBody",
+                     flags_value = int(ImGuiTableFlags.ContextMenuInBody)))
+                tree_pop()
+            }
+
+            // ---- Decorations sub-node (cpp:5763-5775) ----
+            if (tree_node_ex(TABLES_ADV_D_NODE,
+                             (text = "Decorations:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_ROWBG", text = "ImGuiTableFlags_RowBg",
+                     flags_value = int(ImGuiTableFlags.RowBg)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_BORDERSV", text = "ImGuiTableFlags_BordersV",
+                     flags_value = int(ImGuiTableFlags.BordersV)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_BORDERSOV", text = "ImGuiTableFlags_BordersOuterV",
+                     flags_value = int(ImGuiTableFlags.BordersOuterV)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_BORDERSIV", text = "ImGuiTableFlags_BordersInnerV",
+                     flags_value = int(ImGuiTableFlags.BordersInnerV)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_BORDERSH", text = "ImGuiTableFlags_BordersH",
+                     flags_value = int(ImGuiTableFlags.BordersH)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_BORDERSOH", text = "ImGuiTableFlags_BordersOuterH",
+                     flags_value = int(ImGuiTableFlags.BordersOuterH)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_BORDERSIH", text = "ImGuiTableFlags_BordersInnerH",
+                     flags_value = int(ImGuiTableFlags.BordersInnerH)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOBORDERSBODY", text = "ImGuiTableFlags_NoBordersInBody",
+                     flags_value = int(ImGuiTableFlags.NoBordersInBody)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOBORDERSBODYUR", text = "ImGuiTableFlags_NoBordersInBodyUntilResize",
+                     flags_value = int(ImGuiTableFlags.NoBordersInBodyUntilResize)))
+                tree_pop()
+            }
+
+            // ---- Sizing sub-node (cpp:5777-5792) ----
+            if (tree_node_ex(TABLES_ADV_S_NODE,
+                             (text = "Sizing:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                SetNextItemWidth(item_width)
+                edit_table_sizing_flags(safe_addr(TABLES_ADV_FLAGS),
+                                        "tbl_adv_sizing_combo")
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOHOSTX", text = "ImGuiTableFlags_NoHostExtendX",
+                     flags_value = int(ImGuiTableFlags.NoHostExtendX)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOHOSTY", text = "ImGuiTableFlags_NoHostExtendY",
+                     flags_value = int(ImGuiTableFlags.NoHostExtendY)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOKEEPCV", text = "ImGuiTableFlags_NoKeepColumnsVisible",
+                     flags_value = int(ImGuiTableFlags.NoKeepColumnsVisible)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_PRECISE", text = "ImGuiTableFlags_PreciseWidths",
+                     flags_value = int(ImGuiTableFlags.PreciseWidths)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOCLIP", text = "ImGuiTableFlags_NoClip",
+                     flags_value = int(ImGuiTableFlags.NoClip)))
+                tree_pop()
+            }
+
+            // ---- Padding sub-node (cpp:5794-5800) ----
+            if (tree_node_ex(TABLES_ADV_P_NODE,
+                             (text = "Padding:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_PADOUTERX", text = "ImGuiTableFlags_PadOuterX",
+                     flags_value = int(ImGuiTableFlags.PadOuterX)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOPADOUTERX", text = "ImGuiTableFlags_NoPadOuterX",
+                     flags_value = int(ImGuiTableFlags.NoPadOuterX)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_NOPADINNERX", text = "ImGuiTableFlags_NoPadInnerX",
+                     flags_value = int(ImGuiTableFlags.NoPadInnerX)))
+                tree_pop()
+            }
+
+            // ---- Scrolling sub-node (cpp:5802-5813) ----
+            if (tree_node_ex(TABLES_ADV_SC_NODE,
+                             (text = "Scrolling:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_SCROLLX", text = "ImGuiTableFlags_ScrollX",
+                     flags_value = int(ImGuiTableFlags.ScrollX)))
+                same_line(TABLES_ADV_SL_FCOLS)
+                SetNextItemWidth(GetFrameHeight())
+                edit_drag_int(safe_addr(TABLES_ADV_FREEZE_COLS),
+                    (id = "TBL_ADV_FREEZE_COLS", text = "freeze_cols",
+                     speed = 0.2f, v_min = 0, v_max = 9, format = "%d",
+                     flags = ImGuiSliderFlags.NoInput))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_SCROLLY", text = "ImGuiTableFlags_ScrollY",
+                     flags_value = int(ImGuiTableFlags.ScrollY)))
+                same_line(TABLES_ADV_SL_FROWS)
+                SetNextItemWidth(GetFrameHeight())
+                edit_drag_int(safe_addr(TABLES_ADV_FREEZE_ROWS),
+                    (id = "TBL_ADV_FREEZE_ROWS", text = "freeze_rows",
+                     speed = 0.2f, v_min = 0, v_max = 9, format = "%d",
+                     flags = ImGuiSliderFlags.NoInput))
+                tree_pop()
+            }
+
+            // ---- Sorting sub-node (cpp:5815-5822) ----
+            if (tree_node_ex(TABLES_ADV_SO_NODE,
+                             (text = "Sorting:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_SORTMULTI", text = "ImGuiTableFlags_SortMulti",
+                     flags_value = int(ImGuiTableFlags.SortMulti)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_SORTTRISTATE", text = "ImGuiTableFlags_SortTristate",
+                     flags_value = int(ImGuiTableFlags.SortTristate)))
+                tree_pop()
+            }
+
+            // ---- Headers sub-node (cpp:5824-5831) ----
+            if (tree_node_ex(TABLES_ADV_H_NODE,
+                             (text = "Headers:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                edit_checkbox(safe_addr(TABLES_ADV_SHOW_HEADERS),
+                              (id = "TBL_ADV_SHOW_HEADERS", text = "show_headers"))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_FLAGS),
+                    (id = "TBL_ADV_F_HHC", text = "ImGuiTableFlags_HighlightHoveredColumn",
+                     flags_value = int(ImGuiTableFlags.HighlightHoveredColumn)))
+                edit_checkbox_flags(safe_addr(TABLES_ADV_COLUMNS_BASE_FLAGS),
+                    (id = "TBL_ADV_CBF_AH", text = "ImGuiTableColumnFlags_AngledHeader",
+                     flags_value = int(ImGuiTableColumnFlags.AngledHeader)))
+                tree_pop()
+            }
+
+            // ---- Other sub-node (cpp:5833-5858) ----
+            if (tree_node_ex(TABLES_ADV_O_NODE,
+                             (text = "Other:",
+                              flags = ImGuiTreeNodeFlags.DefaultOpen))) {
+                edit_checkbox(safe_addr(TABLES_ADV_SHOW_WRAPPED_TEXT),
+                              (id = "TBL_ADV_SHOW_WRAPPED",
+                               text = "show_wrapped_text"))
+                // OuterSize: DragFloat2 paired with the enable checkbox via
+                // SameLine + GetStyle().ItemInnerSpacing.x (cpp:5837-5839).
+                SetNextItemWidth(item_width)
+                edit_drag_float2(safe_addr(TABLES_ADV_OUTER_SIZE_VALUE),
+                                 (id = "TBL_ADV_OUTERSIZE",
+                                  text = "##OuterSize"))
+                same_line(TABLES_ADV_SL_OUTERSIZE,
+                          (offset_from_start_x = 0.0f,
+                           spacing = GetStyle().ItemInnerSpacing.x))
+                edit_checkbox(safe_addr(TABLES_ADV_OUTER_SIZE_ENABLED),
+                              (id = "TBL_ADV_OUTERSIZE_EN", text = "outer_size"))
+
+                // inner_width — only takes effect when ScrollX is on; we
+                // pipe 0.0 to BeginTable otherwise (cpp:5848-5849 +
+                // inner_width_to_use below).
+                SetNextItemWidth(item_width)
+                edit_drag_float(safe_addr(TABLES_ADV_INNER_WIDTH),
+                    (id = "TBL_ADV_INNER_WIDTH",
+                     text = "inner_width (when ScrollX active)",
+                     speed = 1.0f, v_min = 0.0f, v_max = FLT_MAX,
+                     format = "%.3f"))
+
+                SetNextItemWidth(item_width)
+                edit_drag_float(safe_addr(TABLES_ADV_ROW_MIN_HEIGHT),
+                    (id = "TBL_ADV_ROWMINH",
+                     text = "row_min_height",
+                     speed = 1.0f, v_min = 0.0f, v_max = FLT_MAX,
+                     format = "%.3f"))
+
+                SetNextItemWidth(item_width)
+                edit_drag_int(safe_addr(TABLES_ADV_ITEMS_COUNT),
+                    (id = "TBL_ADV_ITEMS_COUNT",
+                     text = "items_count",
+                     speed = 0.1f, v_min = 0, v_max = 9999,
+                     format = "%d"))
+
+                SetNextItemWidth(item_width)
+                var ct_items <- ["Text", "Button", "SmallButton",
+                                 "FillButton", "Selectable",
+                                 "Selectable (span row)"]
+                edit_combo(safe_addr(TABLES_ADV_CONTENTS_TYPE),
+                           (id = "TBL_ADV_CT",
+                            text = "items_type (first column)",
+                            items = ct_items))
+                delete ct_items
+
+                tree_pop()
+            }
+
+            spacing(TABLES_ADV_OPTIONS_SPACING)
+            tree_pop()
+        }
+
+        // ---- Rebuild items if count changed (cpp:5870-5881) ----
+        rebuild_adv_items()
+
+        // ---- BeginTable (cpp:5889-5890) ----
+        let inner_width_to_use = ((TABLES_ADV_FLAGS & int(ImGuiTableFlags.ScrollX)) != 0
+                                  ? TABLES_ADV_INNER_WIDTH
+                                  : 0.0f)
+        let effective_outer_size = (TABLES_ADV_OUTER_SIZE_ENABLED
+                                    ? TABLES_ADV_OUTER_SIZE_VALUE
+                                    : float2(0.0f, 0.0f))
+        data_table(TABLES_ADV_T,
+                   (text = "##table_advanced", columns = 6,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_ADV_FLAGS)),
+                    outer_size = effective_outer_size,
+                    inner_width = inner_width_to_use)) {
+            // ---- Columns (cpp:5895-5901) ----
+            // user_id passes match the sort comparator branches above.
+            // Description picks WidthStretch only when NoHostExtendX is off
+            // (cpp:5899 ternary) — otherwise the table can't grow into the
+            // stretch column. Bitfield-as-int test on TABLES_ADV_FLAGS.
+            let base = unsafe(reinterpret<ImGuiTableColumnFlags>(TABLES_ADV_COLUMNS_BASE_FLAGS))
+            table_setup_column("ID",
+                base | ImGuiTableColumnFlags.DefaultSort |
+                    ImGuiTableColumnFlags.WidthFixed |
+                    ImGuiTableColumnFlags.NoHide,
+                0.0f, TABLES_SORT_COL_ID)
+            table_setup_column("Name",
+                base | ImGuiTableColumnFlags.WidthFixed,
+                0.0f, TABLES_SORT_COL_NAME)
+            table_setup_column("Action",
+                base | ImGuiTableColumnFlags.NoSort |
+                    ImGuiTableColumnFlags.WidthFixed,
+                0.0f, TABLES_SORT_COL_ACTION)
+            table_setup_column("Quantity",
+                base | ImGuiTableColumnFlags.PreferSortDescending,
+                0.0f, TABLES_SORT_COL_QUANTITY)
+            let desc_extra = ((TABLES_ADV_FLAGS & int(ImGuiTableFlags.NoHostExtendX)) != 0
+                              ? ImGuiTableColumnFlags.None
+                              : ImGuiTableColumnFlags.WidthStretch)
+            table_setup_column("Description", base | desc_extra,
+                0.0f, TABLES_SORT_COL_DESCRIPTION)
+            table_setup_column("Hidden",
+                base | ImGuiTableColumnFlags.DefaultHide |
+                    ImGuiTableColumnFlags.NoSort)
+            table_setup_scroll_freeze(TABLES_ADV_FREEZE_COLS,
+                                      TABLES_ADV_FREEZE_ROWS)
+
+            // ---- Sort (cpp:5904-5912) ----
+            sort_specs() $(specs) {
+                TABLES_ADV_ITEMS |> sort() $(a, b) {
+                    return adv_compare(a, b, specs)
+                }
+            }
+            // cpp:5912 — always resets after the dirty pass. The
+            // sort_specs() helper clears the dirty flag on its own when
+            // invoked, so this is purely a local guard for the
+            // quantity-edit-induced re-sort (set below).
+            TABLES_ADV_ITEMS_NEED_SORT = false
+
+            // cpp:5916 — track whether the Quantity column is currently
+            // sorted; if so, Chop/Eat triggers a re-sort on button-release.
+            let sorts_specs_using_quantity = ((table_get_column_flags(3) &
+                ImGuiTableColumnFlags.IsSorted) != ImGuiTableColumnFlags.None)
+
+            // ---- Headers (cpp:5919-5922) ----
+            if (TABLES_ADV_SHOW_HEADERS &&
+                (TABLES_ADV_COLUMNS_BASE_FLAGS & int(ImGuiTableColumnFlags.AngledHeader)) != 0) {
+                table_angled_headers_row()
+            }
+            if (TABLES_ADV_SHOW_HEADERS) {
+                table_headers_row()
+            }
+
+            // ---- Body — PushButtonRepeat + ListClipper (cpp:5926-6011) ----
+            with_button_repeat(true) {
+                list_clipper(length(TABLES_ADV_ITEMS)) $(start, end_) {
+                    for (row_n in range(start, end_)) {
+                        var item & = unsafe(TABLES_ADV_ITEMS[row_n])
+                        let item_id = item.id
+                        let item_is_selected = (find_index(TABLES_ADV_SELECTION,
+                                                           item_id) != -1)
+                        with_id("adv_row_{item_id}") {
+                            table_next_row(ImGuiTableRowFlags.None,
+                                           TABLES_ADV_ROW_MIN_HEIGHT)
+                            // Col 0 (ID): contents-type switch (cpp:5949-5978).
+                            table_set_column_index(0)
+                            // cpp:5951 — sprintf(label, "%04d", item.ID).
+                            // gen2 "{val}" interpolation has no built-in
+                            // width-pad, so we approximate via
+                            // fmt_pad_left("0", 4, "{item_id}") which is
+                            // overkill for the small range; use a plain
+                            // "{item_id}" here — the cpp 4-digit zero-pad
+                            // is purely cosmetic for the demo.
+                            let text_label = "{item_id}"
+                            if (TABLES_ADV_CONTENTS_TYPE == TABLES_ADV_CT_TEXT) {
+                                text(TABLES_ADV_ID_TEXT[item_id],
+                                     (text = text_label))
+                            } elif (TABLES_ADV_CONTENTS_TYPE == TABLES_ADV_CT_BUTTON) {
+                                button(TABLES_ADV_ID_BTN[item_id],
+                                       (text = text_label))
+                            } elif (TABLES_ADV_CONTENTS_TYPE == TABLES_ADV_CT_SMALL_BUTTON) {
+                                small_button(TABLES_ADV_ID_BTN[item_id],
+                                             (text = text_label))
+                            } elif (TABLES_ADV_CONTENTS_TYPE == TABLES_ADV_CT_FILL_BUTTON) {
+                                button(TABLES_ADV_ID_BTN[item_id],
+                                       (text = text_label,
+                                        size = float2(-FLT_MIN, 0.0f)))
+                            } elif (TABLES_ADV_CONTENTS_TYPE == TABLES_ADV_CT_SELECTABLE ||
+                                    TABLES_ADV_CONTENTS_TYPE == TABLES_ADV_CT_SELECTABLE_SPAN_ROW) {
+                                let sel_flags = (TABLES_ADV_CONTENTS_TYPE == TABLES_ADV_CT_SELECTABLE_SPAN_ROW
+                                    ? ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowOverlap
+                                    : ImGuiSelectableFlags.None)
+                                if (selectable_label(TABLES_ADV_ID_SEL[item_id],
+                                                     (text = text_label,
+                                                      selected = item_is_selected,
+                                                      flags = sel_flags,
+                                                      size = float2(0.0f, TABLES_ADV_ROW_MIN_HEIGHT)))) {
+                                    // cpp:5965-5976 — Ctrl+click toggles
+                                    // the item in selection; plain click
+                                    // resets to single-selection.
+                                    if (GetIO().KeyCtrl) {
+                                        if (item_is_selected) {
+                                            let idx = find_index(TABLES_ADV_SELECTION,
+                                                                 item_id)
+                                            if (idx != -1) {
+                                                TABLES_ADV_SELECTION |> erase(idx)
+                                            }
+                                        } else {
+                                            TABLES_ADV_SELECTION |> push(item_id)
+                                        }
+                                    } else {
+                                        TABLES_ADV_SELECTION |> clear()
+                                        TABLES_ADV_SELECTION |> push(item_id)
+                                    }
+                                }
+                            }
+
+                            // Col 1 (Name) — cpp:5980-5981.
+                            if (table_set_column_index(1)) {
+                                text(TABLES_ADV_NAME_TEXT[item_id],
+                                     (text = item.name))
+                            }
+
+                            // Col 2 (Action) — Chop/Eat (cpp:5987-5994).
+                            // Re-sort triggers on button-release only
+                            // (IsItemDeactivated) so holding the button
+                            // doesn't churn the table mid-press.
+                            if (table_set_column_index(2)) {
+                                if (small_button(TABLES_ADV_CHOP_BTN[item_id],
+                                                 (text = "Chop"))) {
+                                    item.quantity++
+                                }
+                                if (sorts_specs_using_quantity && IsItemDeactivated()) {
+                                    TABLES_ADV_ITEMS_NEED_SORT = true
+                                }
+                                same_line(TABLES_ADV_SL_CHOP_EAT[item_id])
+                                if (small_button(TABLES_ADV_EAT_BTN[item_id],
+                                                 (text = "Eat"))) {
+                                    item.quantity--
+                                }
+                                if (sorts_specs_using_quantity && IsItemDeactivated()) {
+                                    TABLES_ADV_ITEMS_NEED_SORT = true
+                                }
+                            }
+
+                            // Col 3 (Quantity) — cpp:5996-5997.
+                            if (table_set_column_index(3)) {
+                                let qty = item.quantity
+                                text(TABLES_ADV_QTY_TEXT[item_id],
+                                     (text = "{qty}"))
+                            }
+
+                            // Col 4 (Description) — wrapped or plain text
+                            // depending on the Other/show_wrapped_text
+                            // checkbox (cpp:5999-6003). cpp uses an
+                            // unconditional TableSetColumnIndex(4) here
+                            // (not `if`-guarded); mirror that.
+                            table_set_column_index(4)
+                            if (TABLES_ADV_SHOW_WRAPPED_TEXT) {
+                                text_wrapped(TABLES_ADV_DESC_TEXT[item_id],
+                                             (text = "Lorem ipsum dolor sit amet"))
+                            } else {
+                                text(TABLES_ADV_DESC_TEXT[item_id],
+                                     (text = "Lorem ipsum dolor sit amet"))
+                            }
+
+                            // Col 5 (Hidden) — cpp:6005-6006.
+                            if (table_set_column_index(5)) {
+                                text(TABLES_ADV_HIDDEN_TEXT[item_id],
+                                     (text = "1234"))
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
+        // ---- Debug details (cpp:6019-6031) — NOT PORTED ----
+        // cpp here exposes a "Debug details" checkbox that prints
+        // ImDrawList::CmdBuffer.Size deltas (parent vs table draw list)
+        // and a scroll cur/max readout when the table is in its own
+        // child window. The daslang ImVector binding doesn't expose
+        // CmdBuffer.Size as a readable field (handled-type field is
+        // declared but field-of-handled-type accessor is missing —
+        // verified via mcp__daslang__find_symbol and confirmed by a
+        // compile_check). Skipping the entire debug readout (checkbox +
+        // text). Re-add when an ImVector size accessor lands.
     }
 }

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -239,6 +239,78 @@ var private TABLES_OS1_CELL : table<int; NarrativeState>  // 10*3 cells
 var private TABLES_OS2_CELL : table<int; NarrativeState>  // 5*3 cells
 var private TABLES_OS3_CELL : table<int; NarrativeState>  // 3*3 cells
 
+// ---- Section 16 Background color state ----
+// 3 mode selectors + 5*6 cell text. Each selector is an int-backed Combo.
+var private TABLES_BG_FLAGS         : int = int(ImGuiTableFlags.RowBg)
+var private TABLES_BG_ROW_BG_TYPE   : int = 1
+var private TABLES_BG_ROW_BG_TARGET : int = 1
+var private TABLES_BG_CELL_BG_TYPE  : int = 1
+var private TABLES_BG_CELL : table<int; NarrativeState>  // 5*6 cells, "row+col" charpairs
+
+// ---- Section 17 Tree view state ----
+var private TABLES_TREE_FLAGS    : int = int(ImGuiTableFlags.BordersV |
+                                             ImGuiTableFlags.BordersOuterH |
+                                             ImGuiTableFlags.Resizable |
+                                             ImGuiTableFlags.RowBg |
+                                             ImGuiTableFlags.NoBordersInBody)
+var private TABLES_TREE_NODE_FLAGS : int = int(ImGuiTreeNodeFlags.SpanAllColumns)
+// Per-node widget state — there are 9 cpp nodes (idx 0..8). Each node has
+// 1 TreeNode + 2 trailing-column texts. Keyed by node index.
+var private TABLES_TREE_NODE       : table<int; TreeNodeState>
+var private TABLES_TREE_NODE_LEAF  : table<int; TreeNodeState>
+var private TABLES_TREE_SIZE_CELL  : table<int; NarrativeState>
+var private TABLES_TREE_TYPE_CELL  : table<int; NarrativeState>
+// File-system mirror — same shape as the cpp `MyTreeNode` array.
+struct private TreeViewNode {
+    name        : string
+    node_type   : string
+    size        : int
+    child_idx   : int
+    child_count : int
+}
+let private TREE_VIEW_NODES <- [
+    TreeViewNode(name = "Root",
+                 node_type = "Folder", size = -1, child_idx = 1, child_count = 3),
+    TreeViewNode(name = "Music",
+                 node_type = "Folder", size = -1, child_idx = 4, child_count = 2),
+    TreeViewNode(name = "Textures",
+                 node_type = "Folder", size = -1, child_idx = 6, child_count = 3),
+    TreeViewNode(name = "desktop.ini",
+                 node_type = "System file", size = 1024, child_idx = -1, child_count = -1),
+    TreeViewNode(name = "File1_a.wav",
+                 node_type = "Audio file", size = 123000, child_idx = -1, child_count = -1),
+    TreeViewNode(name = "File1_b.wav",
+                 node_type = "Audio file", size = 456000, child_idx = -1, child_count = -1),
+    TreeViewNode(name = "Image001.png",
+                 node_type = "Image file", size = 203128, child_idx = -1, child_count = -1),
+    TreeViewNode(name = "Copy of Image001.png",
+                 node_type = "Image file", size = 203256, child_idx = -1, child_count = -1),
+    TreeViewNode(name = "Copy of Image001 (Final2).png",
+                 node_type = "Image file", size = 203512, child_idx = -1, child_count = -1)]
+
+// ---- Section 18 Item width state ----
+// 3-col table, 3-row body, 9 indexed SliderFloats. cpp shares a single
+// `dummy_f` across all 9; the boost slider state owns its own value, so
+// each cell here has its own — a benign divergence (still demonstrates
+// the per-column ItemWidth setup).
+var private TABLES_ITEM_WIDTH_SLIDER : table<int; SliderStateFloat>  // 3*3 sliders
+
+[init]
+def seed_item_width_sliders() {
+    // All 9 sliders share the same [0.0, 1.0] bounds.
+    for (i in range(9)) {
+        TABLES_ITEM_WIDTH_SLIDER[i].bounds = (0.0f, 1.0f)
+    }
+}
+
+// ---- Section 19 Custom headers state ----
+// 3 per-column header checkboxes (selected[]) + 3*5 selectable cells.
+// `selectable_label` is the caller-owned-bool form (mirrors cpp
+// `Selectable(buf, column_selected[col])`); state holds click bookkeeping
+// only, the selected-appearance comes from TABLES_CHDR_SELECTED[column].
+var private TABLES_CHDR_SELECTED : table<int; bool>          // 3 entries
+var private TABLES_CHDR_CELL     : table<int; ClickState>    // 5*3 cells
+
 [init]
 def seed_columns_flags() {
     // cpp:4868 — `column_flags[3] = { DefaultSort, None, DefaultHide }`.
@@ -299,6 +371,10 @@ def ShowDemoWindowTables() {
         show_nested_tables()
         show_row_height()
         show_outer_size()
+        show_background_color()
+        show_tree_view()
+        show_item_width()
+        show_custom_headers()
 
         // Reset open_action so the next frame's tree_nodes inherit their
         // sticky open/closed state instead of being forced again.
@@ -1541,6 +1617,251 @@ def private show_outer_size() {
                     table_next_column()
                     text(TABLES_OS3_CELL[row * 3 + col],
                          (text = "Cell {col},{row}"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 16: Background color — cpp:5184-5237
+// =============================================================================
+def private show_background_color() {
+    apply_open_action()
+    tree_node(TABLES_BG, (text = "Background color",
+                          flags = ImGuiTreeNodeFlags.None)) {
+        edit_checkbox_flags(safe_addr(TABLES_BG_FLAGS),
+            (id = "TBL_BG_F_BORDERS", text = "ImGuiTableFlags_Borders",
+             flags_value = int(ImGuiTableFlags.Borders)))
+        edit_checkbox_flags(safe_addr(TABLES_BG_FLAGS),
+            (id = "TBL_BG_F_ROWBG", text = "ImGuiTableFlags_RowBg",
+             flags_value = int(ImGuiTableFlags.RowBg)))
+
+        var row_bg_items <- ["None", "Red", "Gradient"]
+        edit_combo(safe_addr(TABLES_BG_ROW_BG_TYPE),
+                   (id = "TBL_BG_ROW_BG_TYPE", text = "row bg type",
+                    items = row_bg_items))
+        delete row_bg_items
+        var row_bg_target_items <- ["RowBg0", "RowBg1"]
+        edit_combo(safe_addr(TABLES_BG_ROW_BG_TARGET),
+                   (id = "TBL_BG_ROW_BG_TARGET", text = "row bg target",
+                    items = row_bg_target_items))
+        delete row_bg_target_items
+        var cell_bg_items <- ["None", "Blue"]
+        edit_combo(safe_addr(TABLES_BG_CELL_BG_TYPE),
+                   (id = "TBL_BG_CELL_BG_TYPE", text = "cell bg type",
+                    items = cell_bg_items))
+        delete cell_bg_items
+
+        // Pre-tabled charpair labels so the per-cell text matches cpp's
+        // `Text("%c%c", 'A' + row, '0' + column)` — daslang has no
+        // int→char primitive.
+        let row_letters = fixed_array("A", "B", "C", "D", "E", "F")
+        let col_digits = fixed_array("0", "1", "2", "3", "4")
+
+        data_table(TABLES_BG_T, (text = "##bg_table", columns = 5,
+                                 flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_BG_FLAGS)),
+                                 outer_size = float2(0.0f, 0.0f),
+                                 inner_width = 0.0f)) {
+            for (row in range(6)) {
+                table_next_row()
+                if (TABLES_BG_ROW_BG_TYPE != 0) {
+                    // Flat red vs gradient grey (cpp:5213). Translucent so
+                    // RowBg0/RowBg1 ordering is visible.
+                    let row_bg_color = (TABLES_BG_ROW_BG_TYPE == 1
+                        ? float4(0.7f, 0.3f, 0.3f, 0.65f)
+                        : float4(0.2f + float(row) * 0.1f, 0.2f, 0.2f, 0.65f))
+                    // ImGuiTableBgTarget.RowBg0 + N — the enum is int-castable
+                    // so the offset arithmetic is direct.
+                    let target = unsafe(reinterpret<ImGuiTableBgTarget>(
+                        int(ImGuiTableBgTarget.RowBg0) + TABLES_BG_ROW_BG_TARGET))
+                    table_set_bg_color(target, GetColorU32(row_bg_color))
+                }
+                for (col in range(5)) {
+                    table_set_column_index(col)
+                    let key = row * 5 + col
+                    text(TABLES_BG_CELL[key],
+                         (text = "{row_letters[row]}{col_digits[col]}"))
+                    // Paint cells B1->C2 in the blue cell-bg color when
+                    // cell_bg_type == 1.
+                    if (row >= 1 && row <= 2 && col >= 1 && col <= 2 &&
+                            TABLES_BG_CELL_BG_TYPE == 1) {
+                        let cell_bg_color = float4(0.3f, 0.3f, 0.7f, 0.65f)
+                        table_set_bg_color(ImGuiTableBgTarget.CellBg,
+                                           GetColorU32(cell_bg_color))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 17: Tree view — cpp:5242-5315
+// =============================================================================
+// Recursive descent through TREE_VIEW_NODES (folders + files), mirroring
+// cpp's inline `MyTreeNode::DisplayNode`. Folder = ChildCount > 0, opens
+// a `tree_node_ex` and recurses; file = leaf form `tree_node_ex` with
+// `Leaf | Bullet | NoTreePushOnOpen` so there's no paired `tree_pop()`.
+def private display_tree_view_node(node_idx : int) {
+    let node = TREE_VIEW_NODES[node_idx]
+    table_next_row()
+    table_next_column()
+    let is_folder = node.child_count > 0
+    let tree_flags = unsafe(reinterpret<ImGuiTreeNodeFlags>(TABLES_TREE_NODE_FLAGS))
+    if (is_folder) {
+        let opened = tree_node_ex(TABLES_TREE_NODE[node_idx],
+                                  (text = node.name, flags = tree_flags))
+        table_next_column()
+        text_disabled(TABLES_TREE_SIZE_CELL[node_idx], "--")
+        table_next_column()
+        text(TABLES_TREE_TYPE_CELL[node_idx], (text = node.node_type))
+        if (opened) {
+            for (child_n in range(node.child_count)) {
+                display_tree_view_node(node.child_idx + child_n)
+            }
+            tree_pop()
+        }
+    } else {
+        let leaf_flags = unsafe(reinterpret<ImGuiTreeNodeFlags>(
+            TABLES_TREE_NODE_FLAGS | int(ImGuiTreeNodeFlags.Leaf) |
+            int(ImGuiTreeNodeFlags.Bullet) |
+            int(ImGuiTreeNodeFlags.NoTreePushOnOpen)))
+        tree_node_ex(TABLES_TREE_NODE_LEAF[node_idx],
+                     (text = node.name, flags = leaf_flags))
+        table_next_column()
+        let sz = node.size
+        text(TABLES_TREE_SIZE_CELL[node_idx], (text = "{sz}"))
+        table_next_column()
+        text(TABLES_TREE_TYPE_CELL[node_idx], (text = node.node_type))
+    }
+}
+
+def private show_tree_view() {
+    apply_open_action()
+    tree_node(TABLES_TREE, (text = "Tree view",
+                            flags = ImGuiTreeNodeFlags.None)) {
+        edit_checkbox_flags(safe_addr(TABLES_TREE_NODE_FLAGS),
+            (id = "TBL_TREE_F_SPANFW", text = "ImGuiTreeNodeFlags_SpanFullWidth",
+             flags_value = int(ImGuiTreeNodeFlags.SpanFullWidth)))
+        edit_checkbox_flags(safe_addr(TABLES_TREE_NODE_FLAGS),
+            (id = "TBL_TREE_F_SPANTW", text = "ImGuiTreeNodeFlags_SpanTextWidth",
+             flags_value = int(ImGuiTreeNodeFlags.SpanTextWidth)))
+        edit_checkbox_flags(safe_addr(TABLES_TREE_NODE_FLAGS),
+            (id = "TBL_TREE_F_SPANAC", text = "ImGuiTreeNodeFlags_SpanAllColumns",
+             flags_value = int(ImGuiTreeNodeFlags.SpanAllColumns)))
+
+        let text_base_width = CalcTextSize("A").x
+        data_table(TABLES_TREE_T,
+                   (text = "##tree_3ways", columns = 3,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_TREE_FLAGS)),
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            table_setup_column("Name", ImGuiTableColumnFlags.NoHide)
+            table_setup_column("Size", ImGuiTableColumnFlags.WidthFixed,
+                               text_base_width * 12.0f)
+            table_setup_column("Type", ImGuiTableColumnFlags.WidthFixed,
+                               text_base_width * 18.0f)
+            table_headers_row()
+            display_tree_view_node(0)
+        }
+    }
+}
+
+// =============================================================================
+// Section 18: Item width — cpp:5320-5361
+// =============================================================================
+def private show_item_width() {
+    apply_open_action()
+    tree_node(TABLES_IW, (text = "Item width",
+                          flags = ImGuiTreeNodeFlags.None)) {
+        let text_base_width = CalcTextSize("A").x
+        data_table(TABLES_IW_T,
+                   (text = "##table_item_width", columns = 3,
+                    flags = ImGuiTableFlags.Borders,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            table_setup_column("small")
+            table_setup_column("half")
+            table_setup_column("right-align")
+            table_headers_row()
+
+            for (row in range(3)) {
+                table_next_row()
+                // cpp pushes once on row 0 and relies on ImGui's per-column
+                // ItemWidth preservation across the table body. The boost
+                // surface forbids raw `PushItemWidth` (lint IMGUI002) and
+                // `with_item_width` is block-scoped (pops at exit), so we
+                // call `SetNextItemWidth` per-slider per-row instead. Same
+                // visual result; trades a few extra ImGui calls for lint
+                // compliance.
+                with_id("iw_row_{row}") {
+                    table_set_column_index(0)
+                    SetNextItemWidth(text_base_width * 3.0f)
+                    slider_float(TABLES_ITEM_WIDTH_SLIDER[row * 3 + 0],
+                                 (text = "float0"))
+                    table_set_column_index(1)
+                    SetNextItemWidth(-GetContentRegionAvail().x * 0.5f)
+                    slider_float(TABLES_ITEM_WIDTH_SLIDER[row * 3 + 1],
+                                 (text = "float1"))
+                    table_set_column_index(2)
+                    SetNextItemWidth(-FLT_MIN)
+                    slider_float(TABLES_ITEM_WIDTH_SLIDER[row * 3 + 2],
+                                 (text = "##float2"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 19: Custom headers — cpp:5367-5409
+// =============================================================================
+def private show_custom_headers() {
+    apply_open_action()
+    tree_node(TABLES_CHDR, (text = "Custom headers",
+                            flags = ImGuiTreeNodeFlags.None)) {
+        let column_count = 3
+        let column_names = fixed_array("Apricot", "Banana", "Cherry")
+        let flags = (ImGuiTableFlags.Borders | ImGuiTableFlags.Reorderable |
+                     ImGuiTableFlags.Hideable)
+        data_table(TABLES_CHDR_T,
+                   (text = "##table_custom_headers", columns = column_count,
+                    flags = flags,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            for (n in range(column_count)) {
+                table_setup_column(column_names[n])
+            }
+            // Custom-header row instead of `table_headers_row()` — per
+            // cell: tight-padded Checkbox + SameLine + TableHeader(name).
+            table_next_row(ImGuiTableRowFlags.Headers)
+            for (column in range(column_count)) {
+                table_set_column_index(column)
+                let column_name = table_get_column_name(column)
+                with_id("chdr_col_{column}") {
+                    with_style((ImGuiStyleVar.FramePadding,
+                                float2(0.0f, 0.0f))) {
+                        edit_checkbox(unsafe(addr(TABLES_CHDR_SELECTED[column])),
+                                      (id = "CHDR_CHECKALL", text = "##checkall"))
+                    }
+                    same_line(TABLES_CHDR_SL_CHK,
+                              (offset_from_start_x = 0.0f,
+                               spacing = GetStyle().ItemInnerSpacing.x))
+                    table_header(column_name)
+                }
+            }
+            // Body — 3*5 selectable cells. cpp uses `Selectable(buf,
+            // column_selected[col])` (caller-owned-bool form); boost
+            // wrapper is `selectable_label(state, text, selected)`.
+            for (row in range(5)) {
+                table_next_row()
+                for (column in range(column_count)) {
+                    table_set_column_index(column)
+                    let key = row * column_count + column
+                    selectable_label(TABLES_CHDR_CELL[key],
+                                     "Cell {column},{row}",
+                                     TABLES_CHDR_SELECTED[column])
                 }
             }
         }

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -311,6 +311,112 @@ def seed_item_width_sliders() {
 var private TABLES_CHDR_SELECTED : table<int; bool>          // 3 entries
 var private TABLES_CHDR_CELL     : table<int; ClickState>    // 5*3 cells
 
+// ---- Section 20 Angled headers state ----
+let private TABLES_AH_COLUMN_NAMES <- ["Track", "cabasa", "ride", "smash",
+                                       "tom-hi", "tom-mid", "tom-low",
+                                       "hihat-o", "hihat-c", "snare-s",
+                                       "snare-c", "clap", "rim", "kick"]
+let private TABLES_AH_COLUMNS_COUNT = 14
+let private TABLES_AH_ROWS_COUNT    = 12
+var private TABLES_AH_TABLE_FLAGS : int = int(ImGuiTableFlags.SizingFixedFit |
+                                              ImGuiTableFlags.ScrollX |
+                                              ImGuiTableFlags.ScrollY |
+                                              ImGuiTableFlags.BordersOuter |
+                                              ImGuiTableFlags.BordersInnerH |
+                                              ImGuiTableFlags.Hideable |
+                                              ImGuiTableFlags.Resizable |
+                                              ImGuiTableFlags.Reorderable |
+                                              ImGuiTableFlags.HighlightHoveredColumn)
+var private TABLES_AH_COLUMN_FLAGS : int = int(ImGuiTableColumnFlags.AngledHeader |
+                                               ImGuiTableColumnFlags.WidthFixed)
+var private TABLES_AH_FROZEN_COLS  : int = 1
+var private TABLES_AH_FROZEN_ROWS  : int = 2
+var private TABLES_AH_BOOLS  : table<int; bool>             // 14*12 cells
+var private TABLES_AH_CB     : table<int; EmptyMarkerState> // 14*12 checkbox state
+var private TABLES_AH_TRACK_LABEL : table<int; NarrativeState> // 12 row labels
+var private TABLES_AH_TRACK_ATFP  : table<int; EmptyMarkerState> // 12 align markers
+
+// ---- Section 21 Context menus state ----
+// Sub 1: flag toggle + 3*4 cells (default context menus only).
+var private TABLES_CM1_FLAGS : int = int(ImGuiTableFlags.Resizable |
+                                         ImGuiTableFlags.Reorderable |
+                                         ImGuiTableFlags.Hideable |
+                                         ImGuiTableFlags.Borders |
+                                         ImGuiTableFlags.ContextMenuInBody)
+var private TABLES_CM1_CELL : table<int; NarrativeState>  // 4*3 cells
+// Sub 2: per-cell ".." popup + per-column body popup.
+var private TABLES_CM2_CELL_TEXT : table<int; NarrativeState> // 4*3 cells
+var private TABLES_CM2_SL        : table<int; EmptyMarkerState> // 4*3 same_line
+var private TABLES_CM2_DOT_BTN   : table<int; ClickState>     // 4*3 ".." buttons
+var private TABLES_CM2_DOT_POPUP : table<int; PopupContextItemState> // per-cell popup
+var private TABLES_CM2_DOT_TEXT  : table<int; NarrativeState>
+var private TABLES_CM2_DOT_CLOSE : table<int; ClickState>
+var private TABLES_CM2_HOVERED_TEXT : NarrativeState
+// "MyPopup" string-id stateless popup variables — 4 columns (3 + 1 trailing-unused).
+var private TABLES_CM2_HOVERED_COLUMN : int = -1
+
+// ---- Section 22 Synced instances state ----
+var private TABLES_SYNCED_FLAGS : int = int(ImGuiTableFlags.Resizable |
+                                            ImGuiTableFlags.Reorderable |
+                                            ImGuiTableFlags.Hideable |
+                                            ImGuiTableFlags.Borders |
+                                            ImGuiTableFlags.SizingFixedFit |
+                                            ImGuiTableFlags.NoSavedSettings)
+// Per-iter CollapsingHeader state (3 iters).
+var private TABLES_SYNCED_HEADER : table<int; CollapsingHeaderState>
+// Per-iter cell text — different cell counts per iter (9 vs 27 vs 9).
+var private TABLES_SYNCED_CELL : table<int; NarrativeState>  // key = iter * 32 + cell
+
+// ---- Section 23 Sorting state ----
+let private TABLES_SORT_TEMPLATE_NAMES <- ["Banana", "Apple", "Cherry",
+                                           "Watermelon", "Grapefruit",
+                                           "Strawberry", "Mango", "Kiwi",
+                                           "Orange", "Pineapple", "Blueberry",
+                                           "Plum", "Coconut", "Pear", "Apricot"]
+// Per-column user_id codes (mirror cpp MyItemColumnID).
+let private TABLES_SORT_COL_ID       = 0u
+let private TABLES_SORT_COL_NAME     = 1u
+let private TABLES_SORT_COL_ACTION   = 2u
+let private TABLES_SORT_COL_QUANTITY = 3u
+
+struct private SortItem {
+    id       : int
+    name     : string
+    quantity : int
+}
+var private TABLES_SORT_ITEMS : array<SortItem>
+var private TABLES_SORT_FLAGS : int = int(ImGuiTableFlags.Resizable |
+                                          ImGuiTableFlags.Reorderable |
+                                          ImGuiTableFlags.Hideable |
+                                          ImGuiTableFlags.Sortable |
+                                          ImGuiTableFlags.SortMulti |
+                                          ImGuiTableFlags.RowBg |
+                                          ImGuiTableFlags.BordersOuter |
+                                          ImGuiTableFlags.BordersV |
+                                          ImGuiTableFlags.NoBordersInBody |
+                                          ImGuiTableFlags.ScrollY)
+// Per-row state: 4 cells per row (ID/Name/Action/Quantity) — keyed by
+// SortItem.id (stable across re-orderings) so widget paths track the row
+// even after sort.
+var private TABLES_SORT_ID_TEXT     : table<int; NarrativeState>
+var private TABLES_SORT_NAME_TEXT   : table<int; NarrativeState>
+var private TABLES_SORT_ACTION_BTN  : table<int; ClickState>
+var private TABLES_SORT_QTY_TEXT    : table<int; NarrativeState>
+
+[init]
+def seed_sort_items() {
+    // cpp:5643 — 50 items, name picked from template_items_names by
+    // n % template_count, quantity = (n*n - n) % 20.
+    TABLES_SORT_ITEMS |> reserve(50)
+    for (n in range(50)) {
+        let template_n = n % length(TABLES_SORT_TEMPLATE_NAMES)
+        TABLES_SORT_ITEMS |> push(SortItem(
+            id = n,
+            name = TABLES_SORT_TEMPLATE_NAMES[template_n],
+            quantity = (n * n - n) % 20))
+    }
+}
+
 [init]
 def seed_columns_flags() {
     // cpp:4868 — `column_flags[3] = { DefaultSort, None, DefaultHide }`.
@@ -375,6 +481,10 @@ def ShowDemoWindowTables() {
         show_tree_view()
         show_item_width()
         show_custom_headers()
+        show_angled_headers()
+        show_context_menus()
+        show_synced_instances()
+        show_sorting()
 
         // Reset open_action so the next frame's tree_nodes inherit their
         // sticky open/closed state instead of being forced again.
@@ -1862,6 +1972,345 @@ def private show_custom_headers() {
                     selectable_label(TABLES_CHDR_CELL[key],
                                      "Cell {column},{row}",
                                      TABLES_CHDR_SELECTED[column])
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 20: Angled headers — cpp:5414-5476
+// =============================================================================
+def private show_angled_headers() {
+    apply_open_action()
+    tree_node(TABLES_AH, (text = "Angled headers",
+                          flags = ImGuiTreeNodeFlags.None)) {
+        edit_checkbox_flags(safe_addr(TABLES_AH_TABLE_FLAGS),
+            (id = "TBL_AH_F_SCROLLX", text = "_ScrollX",
+             flags_value = int(ImGuiTableFlags.ScrollX)))
+        edit_checkbox_flags(safe_addr(TABLES_AH_TABLE_FLAGS),
+            (id = "TBL_AH_F_SCROLLY", text = "_ScrollY",
+             flags_value = int(ImGuiTableFlags.ScrollY)))
+        edit_checkbox_flags(safe_addr(TABLES_AH_TABLE_FLAGS),
+            (id = "TBL_AH_F_RESIZABLE", text = "_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        edit_checkbox_flags(safe_addr(TABLES_AH_TABLE_FLAGS),
+            (id = "TBL_AH_F_NBINBODY", text = "_NoBordersInBody",
+             flags_value = int(ImGuiTableFlags.NoBordersInBody)))
+        edit_checkbox_flags(safe_addr(TABLES_AH_TABLE_FLAGS),
+            (id = "TBL_AH_F_HIGHLIGHTHC", text = "_HighlightHoveredColumn",
+             flags_value = int(ImGuiTableFlags.HighlightHoveredColumn)))
+
+        SetNextItemWidth(GetFontSize() * 8.0f)
+        edit_slider_int(safe_addr(TABLES_AH_FROZEN_COLS),
+            (id = "TBL_AH_FROZEN_COLS", text = "Frozen columns",
+             v_min = 0, v_max = 2))
+        SetNextItemWidth(GetFontSize() * 8.0f)
+        edit_slider_int(safe_addr(TABLES_AH_FROZEN_ROWS),
+            (id = "TBL_AH_FROZEN_ROWS", text = "Frozen rows",
+             v_min = 0, v_max = 2))
+
+        edit_checkbox_flags(safe_addr(TABLES_AH_COLUMN_FLAGS),
+            (id = "TBL_AH_CF_NOHEADERWIDTH",
+             text = "Disable header contributing to column width",
+             flags_value = int(ImGuiTableColumnFlags.NoHeaderWidth)))
+
+        // Style settings sub-node — TableAngledHeadersAngle slider +
+        // TableAngledHeadersTextAlign 2-component slider. Both reach into
+        // the shared ImGuiStyle, so wrap pointer access in unsafe(addr(...)).
+        tree_node(TABLES_AH_STYLE_NODE,
+                  (text = "Style settings", flags = ImGuiTreeNodeFlags.None)) {
+            SetNextItemWidth(GetFontSize() * 8.0f)
+            // SliderAngle uses degrees in the UI, radians on the pointer.
+            // Style field is in radians.
+            edit_slider_angle(
+                unsafe(addr(GetStyle().TableAngledHeadersAngle)),
+                (id = "TBL_AH_STYLE_ANGLE", text = "style.TableAngledHeadersAngle",
+                 v_degrees_min = -50.0f, v_degrees_max = 50.0f))
+            SetNextItemWidth(GetFontSize() * 8.0f)
+            edit_slider_float2(
+                unsafe(addr(GetStyle().TableAngledHeadersTextAlign)),
+                (id = "TBL_AH_STYLE_ALIGN",
+                 text = "style.TableAngledHeadersTextAlign",
+                 v_min = 0.0f, v_max = 1.0f, format = "%.2f"))
+        }
+
+        let line_height = GetTextLineHeightWithSpacing()
+        data_table(TABLES_AH_T,
+                   (text = "##table_angled_headers", columns = TABLES_AH_COLUMNS_COUNT,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_AH_TABLE_FLAGS)),
+                    outer_size = float2(0.0f, line_height * 12.0f),
+                    inner_width = 0.0f)) {
+            // Track column (col 0) — no-hide / no-reorder. Remaining
+            // columns share the angled-header flag set.
+            table_setup_column(TABLES_AH_COLUMN_NAMES[0],
+                               ImGuiTableColumnFlags.NoHide |
+                               ImGuiTableColumnFlags.NoReorder)
+            let col_flags = unsafe(reinterpret<ImGuiTableColumnFlags>(
+                                       TABLES_AH_COLUMN_FLAGS))
+            for (n in range(1, TABLES_AH_COLUMNS_COUNT)) {
+                table_setup_column(TABLES_AH_COLUMN_NAMES[n], col_flags)
+            }
+            table_setup_scroll_freeze(TABLES_AH_FROZEN_COLS, TABLES_AH_FROZEN_ROWS)
+
+            table_angled_headers_row()
+            table_headers_row()
+
+            for (row in range(TABLES_AH_ROWS_COUNT)) {
+                with_id("ah_row_{row}") {
+                    table_next_row()
+                    table_set_column_index(0)
+                    align_text_to_frame_padding(TABLES_AH_TRACK_ATFP[row])
+                    text(TABLES_AH_TRACK_LABEL[row], (text = "Track {row}"))
+                    for (column in range(1, TABLES_AH_COLUMNS_COUNT)) {
+                        continue if (!table_set_column_index(column))
+                        with_id("ah_col_{column}") {
+                            let key = row * TABLES_AH_COLUMNS_COUNT + column
+                            edit_checkbox(unsafe(addr(TABLES_AH_BOOLS[key])),
+                                          (id = "AH_CB", text = ""))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 21: Context menus — cpp:5483-5587
+// =============================================================================
+def private show_context_menus() {
+    apply_open_action()
+    tree_node(TABLES_CM, (text = "Context menus",
+                          flags = ImGuiTreeNodeFlags.None)) {
+        // ----- Sub-table 1: ContextMenuInBody flag toggle -----
+        // Right-clicking on the headers row OR (with the flag set) over
+        // the body opens the default table context menu (column hide,
+        // sort dir, etc.). No custom popup wiring needed.
+        edit_checkbox_flags(safe_addr(TABLES_CM1_FLAGS),
+            (id = "TBL_CM1_F_CTXINBODY", text = "ImGuiTableFlags_ContextMenuInBody",
+             flags_value = int(ImGuiTableFlags.ContextMenuInBody)))
+
+        let column_count = 3
+        data_table(TABLES_CM1_T,
+                   (text = "##table_context_menu", columns = column_count,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_CM1_FLAGS)),
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            table_setup_column("One")
+            table_setup_column("Two")
+            table_setup_column("Three")
+            table_headers_row()
+            for (row in range(4)) {
+                table_next_row()
+                for (column in range(column_count)) {
+                    table_set_column_index(column)
+                    text(TABLES_CM1_CELL[row * column_count + column],
+                         (text = "Cell {column},{row}"))
+                }
+            }
+        }
+
+        // ----- Sub-table 2: custom per-cell + per-column popups -----
+        let flags2 = (ImGuiTableFlags.Resizable | ImGuiTableFlags.SizingFixedFit |
+                      ImGuiTableFlags.Reorderable | ImGuiTableFlags.Hideable |
+                      ImGuiTableFlags.Borders)
+        data_table(TABLES_CM2_T,
+                   (text = "##table_context_menu_2", columns = column_count,
+                    flags = flags2,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            table_setup_column("One")
+            table_setup_column("Two")
+            table_setup_column("Three")
+            table_headers_row()
+            for (row in range(4)) {
+                table_next_row()
+                for (column in range(column_count)) {
+                    table_set_column_index(column)
+                    let key = row * column_count + column
+                    text(TABLES_CM2_CELL_TEXT[key],
+                         (text = "Cell {column},{row}"))
+                    same_line(TABLES_CM2_SL[key])
+                    with_id("cm2_cell_{row}_{column}") {
+                        small_button(TABLES_CM2_DOT_BTN[key], (text = ".."))
+                        popup_context_item(TABLES_CM2_DOT_POPUP[key],
+                            (str_id = "", flags = ImGuiPopupFlags.MouseButtonRight)) {
+                            text(TABLES_CM2_DOT_TEXT[key],
+                                 (text = "This is the popup for Button(\"..\") in Cell {column},{row}"))
+                            if (button(TABLES_CM2_DOT_CLOSE[key], (text = "Close"))) {
+                                close_current_popup()
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Per-column right-click popup. cpp iterates COLUMNS_COUNT + 1
+            // including the trailing unused space. The popup ID is a
+            // string-id ("MyPopup") shared across all per-column triggers —
+            // only one column is hovered at a time so they never overlap.
+            // PushID(column) keeps the popup's per-column ID disjoint.
+            // Status: simplified to track-hovered-column-only in das; the
+            // cpp manual `IsMouseReleased(1)` + `OpenPopup("MyPopup")` +
+            // `BeginPopup("MyPopup")` pattern doesn't lift to the boost
+            // surface without a stateless `popup_window` wrapper that we
+            // don't have. Falls back to the default per-column context
+            // menu (provided by table_headers_row above) plus a
+            // hovered-column readout below.
+            var hovered = -1
+            for (column in range(column_count + 1)) {
+                if ((int(table_get_column_flags(column)) &
+                     int(ImGuiTableColumnFlags.IsHovered)) != 0) {
+                    hovered = column
+                }
+            }
+            TABLES_CM2_HOVERED_COLUMN = hovered
+        }
+        text(TABLES_CM2_HOVERED_TEXT,
+             (text = "Hovered column: {TABLES_CM2_HOVERED_COLUMN}"))
+    }
+}
+
+// =============================================================================
+// Section 22: Synced instances — cpp:5594-5624
+// =============================================================================
+def private show_synced_instances() {
+    apply_open_action()
+    tree_node(TABLES_SYNCED, (text = "Synced instances",
+                              flags = ImGuiTreeNodeFlags.None)) {
+        edit_checkbox_flags(safe_addr(TABLES_SYNCED_FLAGS),
+            (id = "TBL_SYNCED_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        edit_checkbox_flags(safe_addr(TABLES_SYNCED_FLAGS),
+            (id = "TBL_SYNCED_F_SCROLLY", text = "ImGuiTableFlags_ScrollY",
+             flags_value = int(ImGuiTableFlags.ScrollY)))
+        edit_checkbox_flags(safe_addr(TABLES_SYNCED_FLAGS),
+            (id = "TBL_SYNCED_F_FIXEDFIT", text = "ImGuiTableFlags_SizingFixedFit",
+             flags_value = int(ImGuiTableFlags.SizingFixedFit)))
+        edit_checkbox_flags(safe_addr(TABLES_SYNCED_FLAGS),
+            (id = "TBL_SYNCED_F_HIGHLIGHTHC",
+             text = "ImGuiTableFlags_HighlightHoveredColumn",
+             flags_value = int(ImGuiTableFlags.HighlightHoveredColumn)))
+
+        let line_height = GetTextLineHeightWithSpacing()
+        let tflags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_SYNCED_FLAGS))
+        // 3 collapsing headers + a shared table id "Table". To match cpp's
+        // synced-instances behavior the 3 BeginTable calls must produce
+        // the SAME effective ImGui ID — the boost `data_table(IDENT, ...)`
+        // auto-PushIDs the IDENT, so we use ONE shared IDENT
+        // (TABLES_SYNCED_T) in the loop body. State is reused across the
+        // 3 iters (it's the same logical table, so this is correct).
+        // CollapsingHeader needs per-iter unique state so the open/close
+        // toggle is independent per header — indexed CollapsingHeaderState
+        // map keyed by `n`.
+        for (n in range(3)) {
+            let buf = "Synced Table {n}"
+            collapsing_header(TABLES_SYNCED_HEADER[n],
+                              (text = buf, closable = false,
+                               flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+                data_table(TABLES_SYNCED_T,
+                           (text = "Table", columns = 3, flags = tflags,
+                            outer_size = float2(0.0f, line_height * 5.0f),
+                            inner_width = 0.0f)) {
+                    table_setup_column("One")
+                    table_setup_column("Two")
+                    table_setup_column("Three")
+                    table_headers_row()
+                    let cell_count = (n == 1 ? 27 : 9)
+                    for (cell in range(cell_count)) {
+                        table_next_column()
+                        text(TABLES_SYNCED_CELL[n * 32 + cell],
+                             (text = "this cell {cell}"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 23: Sorting — cpp:5637-5713
+// =============================================================================
+def private show_sorting() {
+    apply_open_action()
+    tree_node(TABLES_SORT, (text = "Sorting", flags = ImGuiTreeNodeFlags.None)) {
+        edit_checkbox_flags(safe_addr(TABLES_SORT_FLAGS),
+            (id = "TBL_SORT_F_SORTMULTI", text = "ImGuiTableFlags_SortMulti",
+             flags_value = int(ImGuiTableFlags.SortMulti)))
+        edit_checkbox_flags(safe_addr(TABLES_SORT_FLAGS),
+            (id = "TBL_SORT_F_SORTTRISTATE", text = "ImGuiTableFlags_SortTristate",
+             flags_value = int(ImGuiTableFlags.SortTristate)))
+
+        let line_height = GetTextLineHeightWithSpacing()
+        data_table(TABLES_SORT_T,
+                   (text = "##table_sorting", columns = 4,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_SORT_FLAGS)),
+                    outer_size = float2(0.0f, line_height * 15.0f),
+                    inner_width = 0.0f)) {
+            // user_id passes per cpp:5675-5678 so the sort comparator can
+            // distinguish columns by id (vs by index — both work).
+            table_setup_column("ID",
+                ImGuiTableColumnFlags.DefaultSort | ImGuiTableColumnFlags.WidthFixed,
+                0.0f, TABLES_SORT_COL_ID)
+            table_setup_column("Name",
+                ImGuiTableColumnFlags.WidthFixed,
+                0.0f, TABLES_SORT_COL_NAME)
+            table_setup_column("Action",
+                ImGuiTableColumnFlags.NoSort | ImGuiTableColumnFlags.WidthFixed,
+                0.0f, TABLES_SORT_COL_ACTION)
+            table_setup_column("Quantity",
+                ImGuiTableColumnFlags.PreferSortDescending |
+                ImGuiTableColumnFlags.WidthStretch,
+                0.0f, TABLES_SORT_COL_QUANTITY)
+            table_setup_scroll_freeze(0, 1)
+            table_headers_row()
+
+            // Sort our items when ImGui reports the specs dirty. Multi-
+            // key comparator walks `specs` in order; ColumnUserID
+            // identifies the column. Asc/Desc flips delta sign.
+            sort_specs() $(specs) {
+                TABLES_SORT_ITEMS |> sort() $(a, b) {
+                    for (spec in specs) {
+                        var delta = 0
+                        if (spec.column_user_id == TABLES_SORT_COL_ID) {
+                            delta = a.id - b.id
+                        } elif (spec.column_user_id == TABLES_SORT_COL_NAME) {
+                            delta = a.name < b.name ? -1 : (a.name > b.name ? 1 : 0)
+                        } elif (spec.column_user_id == TABLES_SORT_COL_QUANTITY) {
+                            delta = a.quantity - b.quantity
+                        }
+                        if (delta != 0) {
+                            let asc = spec.sort_direction == ImGuiSortDirection.Ascending
+                            return asc ? delta < 0 : delta > 0
+                        }
+                    }
+                    // qsort is not stable; fall back on ID so swap order
+                    // is deterministic.
+                    return a.id < b.id
+                }
+            }
+
+            list_clipper(length(TABLES_SORT_ITEMS)) $(start, end_) {
+                for (row_n in range(start, end_)) {
+                    let item = TABLES_SORT_ITEMS[row_n]
+                    let item_id = item.id
+                    with_id("sort_item_{item_id}") {
+                        table_next_row()
+                        table_next_column()
+                        text(TABLES_SORT_ID_TEXT[item_id],
+                             (text = "{item_id}"))
+                        table_next_column()
+                        text(TABLES_SORT_NAME_TEXT[item_id],
+                             (text = item.name))
+                        table_next_column()
+                        small_button(TABLES_SORT_ACTION_BTN[item_id],
+                                     (text = "None"))
+                        table_next_column()
+                        let qty = item.quantity
+                        text(TABLES_SORT_QTY_TEXT[item_id],
+                             (text = "{qty}"))
+                    }
                 }
             }
         }

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -12,6 +12,7 @@ require imgui/imgui_scope_builtin
 require imgui/imgui_style_builtin
 require imgui/imgui_table_builtin
 require daslib/safe_addr
+require math
 
 // =============================================================================
 // Mirrors imgui_demo.cpp:4154-6044 — static void ShowDemoWindowTables().
@@ -114,6 +115,101 @@ var private TABLES_PAD2_CELL_PADDING : float2 = float2(0.0f, 0.0f)
 // seeds the buffer to "edit me" on first call (matches cpp's static init).
 var private TABLES_PAD2_CELL_IT      : table<int; InputTextState>
 
+// ---- Section 8 Sizing policies state ----
+// Quad of mini-tables, each with its own SizingFixed*/SizingStretch*
+// policy. The cpp helper EditTableSizingFlags is ported as
+// `def private edit_table_sizing_flags` below; it splices the policy bits
+// in/out of an int-typed flag word.
+var private TABLES_SIZING_FLAGS1 : int = int(ImGuiTableFlags.Resizable |
+                                             ImGuiTableFlags.NoHostExtendX)
+// Policy-per-row state: 4 outer iterations, each owns one flag word
+// (initialized via [init] to the 4 cpp defaults) plus two 3-col x 3-row
+// inner tables of NarrativeState cells.
+var private TABLES_SIZING_POLICY      : table<int; int>
+var private TABLES_SIZING_T1          : table<int; TableState>      // 4 data_tables
+var private TABLES_SIZING_T2          : table<int; TableState>      // 4 data_tables
+var private TABLES_SIZING_T1_CELL     : table<int; NarrativeState>  // key = table_n*9 + row*3 + col
+var private TABLES_SIZING_T2_CELL     : table<int; NarrativeState>
+
+// Advanced sub-block: flag toggles + dynamic-column body. CT_ enum is
+// mirrored as ints to match the cpp `static int contents_type`.
+let private TABLES_SIZING_CT_SHOW_WIDTH    = 0
+let private TABLES_SIZING_CT_SHORT_TEXT    = 1
+let private TABLES_SIZING_CT_LONG_TEXT     = 2
+let private TABLES_SIZING_CT_BUTTON        = 3
+let private TABLES_SIZING_CT_FILL_BUTTON   = 4
+let private TABLES_SIZING_CT_INPUT_TEXT    = 5
+
+var private TABLES_SIZING_ADV_FLAGS : int = int(ImGuiTableFlags.ScrollY |
+                                                ImGuiTableFlags.Borders |
+                                                ImGuiTableFlags.RowBg |
+                                                ImGuiTableFlags.Resizable)
+var private TABLES_SIZING_ADV_CT       : int = 0
+var private TABLES_SIZING_ADV_COLUMNS  : int = 3
+// Per-CT-type cell maps so widget registry paths stay disjoint when the
+// user flips contents_type at runtime (avoids state-shape mismatch).
+var private TABLES_SIZING_ADV_TEXT    : table<int; NarrativeState>
+var private TABLES_SIZING_ADV_BTN     : table<int; ClickState>
+var private TABLES_SIZING_ADV_IT      : table<int; InputTextState>
+
+// ---- Section 9 Vertical scrolling state ----
+var private TABLES_VSCROLL_FLAGS : int = int(ImGuiTableFlags.ScrollY |
+                                             ImGuiTableFlags.RowBg |
+                                             ImGuiTableFlags.BordersOuter |
+                                             ImGuiTableFlags.BordersV |
+                                             ImGuiTableFlags.Resizable |
+                                             ImGuiTableFlags.Reorderable |
+                                             ImGuiTableFlags.Hideable)
+var private TABLES_VSCROLL_CELL : table<int; NarrativeState>  // key = row*3 + col, 1000 rows
+
+// ---- Section 10 Horizontal scrolling state ----
+var private TABLES_HSCROLL_FLAGS : int = int(ImGuiTableFlags.ScrollX |
+                                             ImGuiTableFlags.ScrollY |
+                                             ImGuiTableFlags.RowBg |
+                                             ImGuiTableFlags.BordersOuter |
+                                             ImGuiTableFlags.BordersV |
+                                             ImGuiTableFlags.Resizable |
+                                             ImGuiTableFlags.Reorderable |
+                                             ImGuiTableFlags.Hideable)
+var private TABLES_HSCROLL_FREEZE_COLS : int = 1
+var private TABLES_HSCROLL_FREEZE_ROWS : int = 1
+var private TABLES_HSCROLL_CELL : table<int; NarrativeState>  // 20 rows x 7 cols
+
+// Second sub-table (Stretch + ScrollX).
+var private TABLES_HSCROLL2_FLAGS : int = int(ImGuiTableFlags.SizingStretchSame |
+                                              ImGuiTableFlags.ScrollX |
+                                              ImGuiTableFlags.ScrollY |
+                                              ImGuiTableFlags.BordersOuter |
+                                              ImGuiTableFlags.RowBg |
+                                              ImGuiTableFlags.ContextMenuInBody)
+var private TABLES_HSCROLL2_INNER_WIDTH : float = 1000.0f
+var private TABLES_HSCROLL2_CELL : table<int; NarrativeState>  // 20*7 cells
+
+// ---- Section 11 Columns flags state ----
+// Per-column input flags (DefaultSort / None / DefaultHide) — int-backed
+// so edit_checkbox_flags can edit them; reinterpreted to
+// ImGuiTableColumnFlags at TableSetupColumn time.
+var private TABLES_COLFLAGS_INPUT     : table<int; int>     // 3 columns
+// Output flags read from TableGetColumnFlags per frame; displayed in the
+// first sub-table via a disabled set of CheckboxFlags.
+var private TABLES_COLFLAGS_OUTPUT    : table<int; int>     // 3 columns
+var private TABLES_COLFLAGS_BODY_CELL : table<int; NarrativeState>  // 8*3 cells in body table
+
+// Per-column widget state for the setup-table's label cells: 1 label per
+// column → 3 each. Indexed so widget paths stay per-column-distinct.
+var private TABLES_COLFLAGS_ATFP          : table<int; EmptyMarkerState>
+var private TABLES_COLFLAGS_LABEL         : table<int; NarrativeState>
+var private TABLES_COLFLAGS_INFLAG_LABEL  : table<int; NarrativeState>
+var private TABLES_COLFLAGS_OUTFLAG_LABEL : table<int; NarrativeState>
+
+[init]
+def seed_columns_flags() {
+    // cpp:4868 — `column_flags[3] = { DefaultSort, None, DefaultHide }`.
+    TABLES_COLFLAGS_INPUT[0] = int(ImGuiTableColumnFlags.DefaultSort)
+    TABLES_COLFLAGS_INPUT[1] = int(ImGuiTableColumnFlags.None)
+    TABLES_COLFLAGS_INPUT[2] = int(ImGuiTableColumnFlags.DefaultHide)
+}
+
 [init]
 def seed_padding_cells() {
     // Pre-populate the 15-cell InputText buffer with "edit me" to mirror
@@ -124,6 +220,17 @@ def seed_padding_cells() {
     for (i in range(15)) {
         TABLES_PAD2_CELL_IT[i].value := "edit me"
     }
+}
+
+[init]
+def seed_sizing_policy() {
+    // Mirrors `static ImGuiTableFlags sizing_policy_flags[4]` in cpp:4626.
+    // Per-iteration table_n is the index into this map; the body OR's the
+    // chosen policy with TABLES_SIZING_FLAGS1 before BeginTable.
+    TABLES_SIZING_POLICY[0] = int(ImGuiTableFlags.SizingFixedFit)
+    TABLES_SIZING_POLICY[1] = int(ImGuiTableFlags.SizingFixedSame)
+    TABLES_SIZING_POLICY[2] = int(ImGuiTableFlags.SizingStretchProp)
+    TABLES_SIZING_POLICY[3] = int(ImGuiTableFlags.SizingStretchSame)
 }
 
 def ShowDemoWindowTables() {
@@ -147,6 +254,10 @@ def ShowDemoWindowTables() {
         show_resizable_mixed()
         show_reorderable_hideable_headers()
         show_padding()
+        show_sizing_policies()
+        show_vertical_scrolling()
+        show_horizontal_scrolling()
+        show_columns_flags()
 
         // Reset open_action so the next frame's tree_nodes inherit their
         // sticky open/closed state instead of being forced again.
@@ -598,4 +709,496 @@ def private show_padding() {
             }
         }
     }
+}
+
+// =============================================================================
+// Section 8: Sizing policies — cpp:4618-4722
+// =============================================================================
+// cpp helper `EditTableSizingFlags(ImGuiTableFlags*)` ported as a private
+// def. Strips the four `SizingFixed*`/`SizingStretch*` policy bits out of
+// the input flags, lets the user pick one via a Combo, and ORs it back in.
+// Pure-bits manipulation — no widget IDENT needed beyond the Combo state.
+def private edit_table_sizing_flags(var p_flags : int? implicit; id : string) {
+    let policy_mask = int(ImGuiTableFlags.SizingMask_)
+    let values = fixed_array(int(ImGuiTableFlags.None),
+                             int(ImGuiTableFlags.SizingFixedFit),
+                             int(ImGuiTableFlags.SizingFixedSame),
+                             int(ImGuiTableFlags.SizingStretchProp),
+                             int(ImGuiTableFlags.SizingStretchSame))
+    var current = 0
+    unsafe { current = *p_flags & policy_mask; }
+    var idx = 0
+    for (n in range(5)) {
+        if (values[n] == current) {
+            idx = n
+            break
+        }
+    }
+    // Per-call PushID scope so the same Combo IDENT can fire under each
+    // caller. cpp:4095 also drops "ImGuiTableFlags" from the preview text,
+    // but the boost `edit_combo` shows the selected item's full label —
+    // close enough; the full names below are self-documenting.
+    with_id(id) {
+        var items <- ["Default",
+                      "ImGuiTableFlags_SizingFixedFit",
+                      "ImGuiTableFlags_SizingFixedSame",
+                      "ImGuiTableFlags_SizingStretchProp",
+                      "ImGuiTableFlags_SizingStretchSame"]
+        var local_idx = idx
+        if (edit_combo(unsafe(addr(local_idx)),
+                       (id = "SIZING_POLICY_COMBO", text = "Sizing Policy",
+                        items = items))) {
+            unsafe { *p_flags = (*p_flags & ~policy_mask) | values[local_idx]; }
+        }
+        delete items
+    }
+}
+
+def private show_sizing_policies() {
+    apply_open_action()
+    tree_node(TABLES_SIZING, (text = "Sizing policies",
+                              flags = ImGuiTreeNodeFlags.None)) {
+        // Shared flag toggles applied on top of each per-row policy.
+        edit_checkbox_flags(safe_addr(TABLES_SIZING_FLAGS1),
+            (id = "TBL_SZ_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        edit_checkbox_flags(safe_addr(TABLES_SIZING_FLAGS1),
+            (id = "TBL_SZ_F_NOHOST", text = "ImGuiTableFlags_NoHostExtendX",
+             flags_value = int(ImGuiTableFlags.NoHostExtendX)))
+
+        // Four mini-tables, one per sizing policy. Equal-width + uneven-
+        // width content side-by-side so the policy effect is visually
+        // unambiguous. Per-table PushID via with_id("sizing_n") keeps the
+        // Combo IDs disjoint when the same edit_table_sizing_flags helper
+        // fires four times.
+        for (table_n in range(4)) {
+            with_id("sizing_{table_n}") {
+                SetNextItemWidth(GetFontSize() * 30.0f)
+                edit_table_sizing_flags(unsafe(addr(TABLES_SIZING_POLICY[table_n])),
+                                        "sizing_{table_n}")
+
+                let combined = unsafe(reinterpret<ImGuiTableFlags>(
+                    TABLES_SIZING_POLICY[table_n] | TABLES_SIZING_FLAGS1))
+
+                // Table 1: equal-width content ("Oh dear" x 3 across 3 cols).
+                data_table(TABLES_SIZING_T1[table_n],
+                           (text = "##sz1_{table_n}", columns = 3,
+                            flags = combined,
+                            outer_size = float2(0.0f, 0.0f),
+                            inner_width = 0.0f)) {
+                    for (row in range(3)) {
+                        table_next_row()
+                        let base = table_n * 9 + row * 3
+                        for (col in range(3)) {
+                            table_next_column()
+                            text(TABLES_SIZING_T1_CELL[base + col],
+                                 (text = "Oh dear"))
+                        }
+                    }
+                }
+
+                // Table 2: ragged-width content (AAAA / BBBBBBBB / CCCCCCCCCCCC).
+                data_table(TABLES_SIZING_T2[table_n],
+                           (text = "##sz2_{table_n}", columns = 3,
+                            flags = combined,
+                            outer_size = float2(0.0f, 0.0f),
+                            inner_width = 0.0f)) {
+                    let labels = fixed_array("AAAA", "BBBBBBBB", "CCCCCCCCCCCC")
+                    for (row in range(3)) {
+                        table_next_row()
+                        let base = table_n * 9 + row * 3
+                        for (col in range(3)) {
+                            table_next_column()
+                            text(TABLES_SIZING_T2_CELL[base + col],
+                                 (text = labels[col]))
+                        }
+                    }
+                }
+            }
+        }
+
+        // ----- Advanced sub-block -----
+        text(TABLES_SIZING_ADV_LABEL, (text = "Advanced"))
+        with_id("sizing_advanced") {
+            SetNextItemWidth(GetFontSize() * 30.0f)
+            edit_table_sizing_flags(safe_addr(TABLES_SIZING_ADV_FLAGS),
+                                    "sizing_adv_combo")
+
+            // Contents-type Combo (CT enum mirror).
+            var ct_items <- ["Show width", "Short Text", "Long Text",
+                             "Button", "Fill Button", "InputText"]
+            edit_combo(safe_addr(TABLES_SIZING_ADV_CT),
+                       (id = "TBL_SZ_ADV_CT", text = "Contents",
+                        items = ct_items))
+            delete ct_items
+
+            edit_drag_int(safe_addr(TABLES_SIZING_ADV_COLUMNS),
+                (id = "TBL_SZ_ADV_COLS", text = "Columns",
+                 speed = 0.1f, v_min = 1, v_max = 64, format = "%d",
+                 flags = ImGuiSliderFlags.AlwaysClamp))
+            edit_checkbox_flags(safe_addr(TABLES_SIZING_ADV_FLAGS),
+                (id = "TBL_SZ_ADV_F_RESIZABLE",
+                 text = "ImGuiTableFlags_Resizable",
+                 flags_value = int(ImGuiTableFlags.Resizable)))
+            edit_checkbox_flags(safe_addr(TABLES_SIZING_ADV_FLAGS),
+                (id = "TBL_SZ_ADV_F_PRECISE",
+                 text = "ImGuiTableFlags_PreciseWidths",
+                 flags_value = int(ImGuiTableFlags.PreciseWidths)))
+            edit_checkbox_flags(safe_addr(TABLES_SIZING_ADV_FLAGS),
+                (id = "TBL_SZ_ADV_F_SCROLLX",
+                 text = "ImGuiTableFlags_ScrollX",
+                 flags_value = int(ImGuiTableFlags.ScrollX)))
+            edit_checkbox_flags(safe_addr(TABLES_SIZING_ADV_FLAGS),
+                (id = "TBL_SZ_ADV_F_SCROLLY",
+                 text = "ImGuiTableFlags_ScrollY",
+                 flags_value = int(ImGuiTableFlags.ScrollY)))
+            edit_checkbox_flags(safe_addr(TABLES_SIZING_ADV_FLAGS),
+                (id = "TBL_SZ_ADV_F_NOCLIP",
+                 text = "ImGuiTableFlags_NoClip",
+                 flags_value = int(ImGuiTableFlags.NoClip)))
+
+            let col_count = max(TABLES_SIZING_ADV_COLUMNS, 1)
+            let line_height = GetTextLineHeightWithSpacing()
+            data_table(TABLES_SIZING_ADV_T,
+                       (text = "##sz_adv", columns = col_count,
+                        flags = unsafe(reinterpret<ImGuiTableFlags>(
+                                           TABLES_SIZING_ADV_FLAGS)),
+                        outer_size = float2(0.0f, line_height * 7.0f),
+                        inner_width = 0.0f)) {
+                for (cell in range(10 * col_count)) {
+                    table_next_column()
+                    let column = table_get_column_index()
+                    let row = table_get_row_index()
+                    let cell_label = "Hello {column},{row}"
+                    if (TABLES_SIZING_ADV_CT == TABLES_SIZING_CT_SHORT_TEXT) {
+                        text(TABLES_SIZING_ADV_TEXT[cell], (text = cell_label))
+                    } elif (TABLES_SIZING_ADV_CT == TABLES_SIZING_CT_LONG_TEXT) {
+                        let adj = column == 0 ? "long" : "longeeer"
+                        text(TABLES_SIZING_ADV_TEXT[cell],
+                             (text = "Some {adj} text {column},{row}\nOver two lines.."))
+                    } elif (TABLES_SIZING_ADV_CT == TABLES_SIZING_CT_SHOW_WIDTH) {
+                        let avail = GetContentRegionAvail().x
+                        text(TABLES_SIZING_ADV_TEXT[cell],
+                             (text = "W: {avail}"))
+                    } elif (TABLES_SIZING_ADV_CT == TABLES_SIZING_CT_BUTTON) {
+                        button(TABLES_SIZING_ADV_BTN[cell],
+                               (text = cell_label, size = float2(0.0f, 0.0f)))
+                    } elif (TABLES_SIZING_ADV_CT == TABLES_SIZING_CT_FILL_BUTTON) {
+                        button(TABLES_SIZING_ADV_BTN[cell],
+                               (text = cell_label, size = float2(-FLT_MIN, 0.0f)))
+                    } elif (TABLES_SIZING_ADV_CT == TABLES_SIZING_CT_INPUT_TEXT) {
+                        SetNextItemWidth(-FLT_MIN)
+                        input_text(TABLES_SIZING_ADV_IT[cell], (text = "##sz_adv_it"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 9: Vertical scrolling, with clipping — cpp:4727-4771
+// =============================================================================
+def private show_vertical_scrolling() {
+    apply_open_action()
+    tree_node(TABLES_VSCROLL, (text = "Vertical scrolling, with clipping",
+                               flags = ImGuiTreeNodeFlags.None)) {
+        // ScrollY toggle.
+        edit_checkbox_flags(safe_addr(TABLES_VSCROLL_FLAGS),
+            (id = "TBL_VS_F_SCROLLY", text = "ImGuiTableFlags_ScrollY",
+             flags_value = int(ImGuiTableFlags.ScrollY)))
+
+        // Outer size MUST be specified when ScrollX/ScrollY is on, or the
+        // table fills the host like a child window.
+        let line_height = GetTextLineHeightWithSpacing()
+        let outer_size = float2(0.0f, line_height * 8.0f)
+        data_table(TABLES_VSCROLL_T,
+                   (text = "##table_scrolly", columns = 3,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_VSCROLL_FLAGS)),
+                    outer_size = outer_size,
+                    inner_width = 0.0f)) {
+            table_setup_scroll_freeze(0, 1) // pin the header row
+            table_setup_column("One")
+            table_setup_column("Two")
+            table_setup_column("Three")
+            table_headers_row()
+
+            // 1000 rows via list_clipper — only the visible window is
+            // submitted per frame. The boost wrapper hides the
+            // `clipper.Begin/.Step` ceremony.
+            list_clipper(1000) $(start, end_) {
+                for (row in range(start, end_)) {
+                    table_next_row()
+                    for (col in range(3)) {
+                        table_set_column_index(col)
+                        text(TABLES_VSCROLL_CELL[row * 3 + col],
+                             (text = "Hello {col},{row}"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 10: Horizontal scrolling — cpp:4772-4861
+// =============================================================================
+def private show_horizontal_scrolling() {
+    apply_open_action()
+    tree_node(TABLES_HSCROLL, (text = "Horizontal scrolling",
+                               flags = ImGuiTreeNodeFlags.None)) {
+        edit_checkbox_flags(safe_addr(TABLES_HSCROLL_FLAGS),
+            (id = "TBL_HS_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        edit_checkbox_flags(safe_addr(TABLES_HSCROLL_FLAGS),
+            (id = "TBL_HS_F_SCROLLX", text = "ImGuiTableFlags_ScrollX",
+             flags_value = int(ImGuiTableFlags.ScrollX)))
+        edit_checkbox_flags(safe_addr(TABLES_HSCROLL_FLAGS),
+            (id = "TBL_HS_F_SCROLLY", text = "ImGuiTableFlags_ScrollY",
+             flags_value = int(ImGuiTableFlags.ScrollY)))
+
+        SetNextItemWidth(GetFrameHeight())
+        edit_drag_int(safe_addr(TABLES_HSCROLL_FREEZE_COLS),
+            (id = "TBL_HS_FREEZE_COLS", text = "freeze_cols",
+             speed = 0.2f, v_min = 0, v_max = 9, format = "%d",
+             flags = ImGuiSliderFlags.NoInput))
+        SetNextItemWidth(GetFrameHeight())
+        edit_drag_int(safe_addr(TABLES_HSCROLL_FREEZE_ROWS),
+            (id = "TBL_HS_FREEZE_ROWS", text = "freeze_rows",
+             speed = 0.2f, v_min = 0, v_max = 9, format = "%d",
+             flags = ImGuiSliderFlags.NoInput))
+
+        let line_height = GetTextLineHeightWithSpacing()
+        let outer_size = float2(0.0f, line_height * 8.0f)
+        data_table(TABLES_HSCROLL_T1,
+                   (text = "##table_scrollx", columns = 7,
+                    flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_HSCROLL_FLAGS)),
+                    outer_size = outer_size,
+                    inner_width = 0.0f)) {
+            table_setup_scroll_freeze(TABLES_HSCROLL_FREEZE_COLS,
+                                      TABLES_HSCROLL_FREEZE_ROWS)
+            table_setup_column("Line #", ImGuiTableColumnFlags.NoHide)
+            table_setup_column("One")
+            table_setup_column("Two")
+            table_setup_column("Three")
+            table_setup_column("Four")
+            table_setup_column("Five")
+            table_setup_column("Six")
+            table_headers_row()
+            for (row in range(20)) {
+                table_next_row()
+                for (col in range(7)) {
+                    // Skip non-visible columns past col 0 (cpp:4819-4820
+                    // optimization — relies on col 0 always visible because
+                    // of the freeze + NoHide).
+                    continue if (!table_set_column_index(col) && col > 0)
+                    if (col == 0) {
+                        text(TABLES_HSCROLL_CELL[row * 7 + col],
+                             (text = "Line {row}"))
+                    } else {
+                        text(TABLES_HSCROLL_CELL[row * 7 + col],
+                             (text = "Hello world {col},{row}"))
+                    }
+                }
+            }
+        }
+
+        spacing()
+        text(TABLES_HSCROLL2_LABEL, (text = "Stretch + ScrollX"))
+
+        with_id("hscroll2") {
+            with_item_width(GetFontSize() * 30.0f) {
+                edit_checkbox_flags(safe_addr(TABLES_HSCROLL2_FLAGS),
+                    (id = "TBL_HS2_F_SCROLLX", text = "ImGuiTableFlags_ScrollX",
+                     flags_value = int(ImGuiTableFlags.ScrollX)))
+                edit_drag_float(safe_addr(TABLES_HSCROLL2_INNER_WIDTH),
+                    (id = "TBL_HS2_INNER_WIDTH", text = "inner_width",
+                     v_speed = 1.0f, v_min = 0.0f, v_max = FLT_MAX,
+                     format = "%.1f"))
+            }
+            data_table(TABLES_HSCROLL2_T,
+                       (text = "##table_hscroll2", columns = 7,
+                        flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_HSCROLL2_FLAGS)),
+                        outer_size = outer_size,
+                        inner_width = TABLES_HSCROLL2_INNER_WIDTH)) {
+                for (cell in range(20 * 7)) {
+                    table_next_column()
+                    let col = table_get_column_index()
+                    let row = table_get_row_index()
+                    text(TABLES_HSCROLL2_CELL[cell],
+                         (text = "Hello world {col},{row}"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 11: Columns flags — cpp:4862-4933
+// =============================================================================
+def private show_columns_flags() {
+    apply_open_action()
+    tree_node(TABLES_COLFLAGS, (text = "Columns flags",
+                                flags = ImGuiTreeNodeFlags.None)) {
+        let column_count = 3
+        let column_names = fixed_array("One", "Two", "Three")
+
+        // ----- Setup-table: per-column flag editors + output status display -----
+        data_table(TABLES_COLFLAGS_SETUP_T,
+                   (text = "##colflags_checkboxes", columns = column_count,
+                    flags = ImGuiTableFlags.None,
+                    outer_size = float2(0.0f, 0.0f),
+                    inner_width = 0.0f)) {
+            for (column in range(column_count)) {
+                table_next_column()
+                with_id("colflags_col_{column}") {
+                    align_text_to_frame_padding(TABLES_COLFLAGS_ATFP[column])
+                    text(TABLES_COLFLAGS_LABEL[column],
+                         (text = "'{column_names[column]}'"))
+                    spacing()
+                    text(TABLES_COLFLAGS_INFLAG_LABEL[column],
+                         (text = "Input flags:"))
+                    edit_column_flags(unsafe(addr(TABLES_COLFLAGS_INPUT[column])))
+                    spacing()
+                    text(TABLES_COLFLAGS_OUTFLAG_LABEL[column],
+                         (text = "Output flags:"))
+                    with_disabled(true) {
+                        show_column_status_flags(TABLES_COLFLAGS_OUTPUT[column])
+                    }
+                }
+            }
+        }
+
+        // ----- Real table — body driven by the per-column flag input -----
+        let flags = (ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.ScrollX |
+                     ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg |
+                     ImGuiTableFlags.BordersOuter | ImGuiTableFlags.BordersV |
+                     ImGuiTableFlags.Resizable | ImGuiTableFlags.Reorderable |
+                     ImGuiTableFlags.Hideable | ImGuiTableFlags.Sortable)
+        let line_height = GetTextLineHeightWithSpacing()
+        let outer_size = float2(0.0f, line_height * 9.0f)
+        let text_base_width = CalcTextSize("A").x
+
+        data_table(TABLES_COLFLAGS_BODY_T,
+                   (text = "##colflags_body", columns = column_count,
+                    flags = flags,
+                    outer_size = outer_size,
+                    inner_width = 0.0f)) {
+            var has_angled_header = false
+            for (column in range(column_count)) {
+                let col_flags = unsafe(reinterpret<ImGuiTableColumnFlags>(
+                                           TABLES_COLFLAGS_INPUT[column]))
+                if ((TABLES_COLFLAGS_INPUT[column] &
+                     int(ImGuiTableColumnFlags.AngledHeader)) != 0) {
+                    has_angled_header = true
+                }
+                table_setup_column(column_names[column], col_flags)
+            }
+            if (has_angled_header) {
+                table_angled_headers_row()
+            }
+            table_headers_row()
+            for (column in range(column_count)) {
+                TABLES_COLFLAGS_OUTPUT[column] = int(table_get_column_flags(column))
+            }
+            let indent_step = float(int(text_base_width / 2.0f))
+            // cpp uses paired `Indent(step)` per row + final
+            // `Unindent(step * 8)` to accumulate one extra step at the
+            // start of every row. The block-scoped boost wrapper
+            // `with_indent(amount)` pops at body exit so accumulation
+            // needs an explicit per-row amount: row N starts with
+            // `(N + 1) * step` indent worth.
+            for (row in range(8)) {
+                with_indent(indent_step * float(row + 1)) {
+                    table_next_row()
+                    for (column in range(column_count)) {
+                        table_set_column_index(column)
+                        let prefix = column == 0 ? "Indented" : "Hello"
+                        let cname = table_get_column_name(column)
+                        text(TABLES_COLFLAGS_BODY_CELL[row * column_count + column],
+                             (text = "{prefix} {cname}"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// edit_column_flags — port of cpp `EditTableColumnsFlags(ImGuiTableColumnFlags*)`
+// (cpp:4121-4144). 16 checkbox toggles in vertical sequence. The macro
+// requires `id =` to be a string literal so we can't splice the column
+// index in — instead the caller wraps the call in
+// `with_id("colflags_col_{column}")` and we use fixed IDs here. ImGui's
+// ID stack hashes the with_id prefix into each IDENT, keeping the
+// per-column instances disjoint without per-column IDENT splicing.
+// Width/sort mutual-exclusion bits reproduce the cpp `if (Checkbox(...))
+// flags &= ~mask` clearing.
+def private edit_column_flags(var p_flags : int? implicit) {
+    let stretch_mask = (int(ImGuiTableColumnFlags.WidthMask_) ^
+                        int(ImGuiTableColumnFlags.WidthStretch))
+    let fixed_mask   = (int(ImGuiTableColumnFlags.WidthMask_) ^
+                        int(ImGuiTableColumnFlags.WidthFixed))
+
+    edit_checkbox_flags(p_flags, (id = "CF_DIS", text = "_Disabled",
+        flags_value = int(ImGuiTableColumnFlags.Disabled)))
+    edit_checkbox_flags(p_flags, (id = "CF_DH", text = "_DefaultHide",
+        flags_value = int(ImGuiTableColumnFlags.DefaultHide)))
+    edit_checkbox_flags(p_flags, (id = "CF_DS", text = "_DefaultSort",
+        flags_value = int(ImGuiTableColumnFlags.DefaultSort)))
+    if (edit_checkbox_flags(p_flags, (id = "CF_WS", text = "_WidthStretch",
+        flags_value = int(ImGuiTableColumnFlags.WidthStretch)))) {
+        unsafe { *p_flags = *p_flags & ~stretch_mask; }
+    }
+    if (edit_checkbox_flags(p_flags, (id = "CF_WF", text = "_WidthFixed",
+        flags_value = int(ImGuiTableColumnFlags.WidthFixed)))) {
+        unsafe { *p_flags = *p_flags & ~fixed_mask; }
+    }
+    edit_checkbox_flags(p_flags, (id = "CF_NR", text = "_NoResize",
+        flags_value = int(ImGuiTableColumnFlags.NoResize)))
+    edit_checkbox_flags(p_flags, (id = "CF_NRO", text = "_NoReorder",
+        flags_value = int(ImGuiTableColumnFlags.NoReorder)))
+    edit_checkbox_flags(p_flags, (id = "CF_NH", text = "_NoHide",
+        flags_value = int(ImGuiTableColumnFlags.NoHide)))
+    edit_checkbox_flags(p_flags, (id = "CF_NC", text = "_NoClip",
+        flags_value = int(ImGuiTableColumnFlags.NoClip)))
+    edit_checkbox_flags(p_flags, (id = "CF_NS", text = "_NoSort",
+        flags_value = int(ImGuiTableColumnFlags.NoSort)))
+    edit_checkbox_flags(p_flags, (id = "CF_NSA", text = "_NoSortAscending",
+        flags_value = int(ImGuiTableColumnFlags.NoSortAscending)))
+    edit_checkbox_flags(p_flags, (id = "CF_NSD", text = "_NoSortDescending",
+        flags_value = int(ImGuiTableColumnFlags.NoSortDescending)))
+    edit_checkbox_flags(p_flags, (id = "CF_NHL", text = "_NoHeaderLabel",
+        flags_value = int(ImGuiTableColumnFlags.NoHeaderLabel)))
+    edit_checkbox_flags(p_flags, (id = "CF_NHW", text = "_NoHeaderWidth",
+        flags_value = int(ImGuiTableColumnFlags.NoHeaderWidth)))
+    edit_checkbox_flags(p_flags, (id = "CF_PSA", text = "_PreferSortAscending",
+        flags_value = int(ImGuiTableColumnFlags.PreferSortAscending)))
+    edit_checkbox_flags(p_flags, (id = "CF_PSD", text = "_PreferSortDescending",
+        flags_value = int(ImGuiTableColumnFlags.PreferSortDescending)))
+    edit_checkbox_flags(p_flags, (id = "CF_IE", text = "_IndentEnable",
+        flags_value = int(ImGuiTableColumnFlags.IndentEnable)))
+    edit_checkbox_flags(p_flags, (id = "CF_ID", text = "_IndentDisable",
+        flags_value = int(ImGuiTableColumnFlags.IndentDisable)))
+    edit_checkbox_flags(p_flags, (id = "CF_AH", text = "_AngledHeader",
+        flags_value = int(ImGuiTableColumnFlags.AngledHeader)))
+}
+
+// show_column_status_flags — read-only display of the status bits ImGui
+// computes per frame (cpp `ShowTableColumnsStatusFlags`, cpp:4146-4152).
+// Always called inside `with_disabled(true)` so the checkboxes paint but
+// don't accept input.
+def private show_column_status_flags(flags : int) {
+    var local = flags
+    edit_checkbox_flags(unsafe(addr(local)),
+        (id = "CSF_IE", text = "_IsEnabled",
+         flags_value = int(ImGuiTableColumnFlags.IsEnabled)))
+    edit_checkbox_flags(unsafe(addr(local)),
+        (id = "CSF_IV", text = "_IsVisible",
+         flags_value = int(ImGuiTableColumnFlags.IsVisible)))
+    edit_checkbox_flags(unsafe(addr(local)),
+        (id = "CSF_IS", text = "_IsSorted",
+         flags_value = int(ImGuiTableColumnFlags.IsSorted)))
+    edit_checkbox_flags(unsafe(addr(local)),
+        (id = "CSF_IH", text = "_IsHovered",
+         flags_value = int(ImGuiTableColumnFlags.IsHovered)))
 }

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -17,11 +17,20 @@ require math
 // =============================================================================
 // Mirrors imgui_demo.cpp:4154-6044 — static void ShowDemoWindowTables().
 //
-// Port status (PR-D, this commit): section 1 Basic + section 2 Borders,
-// background. Remaining 22 sections (Resizable family / Padding / Sizing
-// policies / Scrolling / Columns flags / Background color / Tree view /
-// Custom headers / Angled headers / Context menus / Synced instances /
-// Sorting / Advanced) land in follow-up commits.
+// Port status: 24 / 24 sub-sections ported. ~2911 das lines across 8
+// commits (PR-D/2 chunks 1-8, see dasImgui PR #52). Two cpp constructs
+// deliberately partial:
+//   - Section 21 Context menus sub 2 per-column manual-open popups
+//     (cpp:5560-5582 raw `OpenPopup`/`BeginPopup` keyed on a shared
+//     "MyPopup" str_id): boost surface has no stateless `popup_window`
+//     wrapper for this pattern. Fallback: default per-column context
+//     menu (auto-emitted by `table_headers_row`) + hovered-column
+//     readout. See `show_context_menus()` body comment + backlog memory
+//     `project_dasimgui_popup_window_backlog.md`.
+//   - Section 24 Advanced Debug-details readout (cpp:6019-6031): drops
+//     the `Debug details` checkbox + `ImDrawList.CmdBuffer.Size`
+//     readout because `ImVector\`ImDrawCmd` has no `Size` accessor in
+//     the daslang binding. See `show_advanced()` body comment.
 //
 // Boost-surface conventions:
 // - cpp `static` locals → module-scope `var private` (state-hoist).
@@ -463,6 +472,13 @@ var private TABLES_ADV_SHOW_WRAPPED_TEXT  : bool   = false
 var private TABLES_ADV_ITEMS     : array<SortItem>
 var private TABLES_ADV_SELECTION : array<int>
 var private TABLES_ADV_ITEMS_NEED_SORT : bool = false
+// Cache of last-seen TableSortSpec list — populated whenever the
+// sort_specs() block fires (i.e. when ImGui reports SpecsDirty),
+// consumed when TABLES_ADV_ITEMS_NEED_SORT was set last frame by
+// Chop/Eat. Mirrors cpp's `sort_specs` pointer reuse: the boost block
+// helper auto-clears SpecsDirty on return so the raw pointer isn't
+// available to the Chop/Eat-triggered re-sort path; cache instead.
+var private TABLES_ADV_LAST_SPECS : array<TableSortSpec>
 
 // Per-row widget state — keyed by SortItem.id so paths track items
 // across re-sorts. We do NOT pre-seed: the row helper auto-inserts on
@@ -2298,7 +2314,12 @@ def private show_context_menus() {
             // menu (provided by table_headers_row above) plus a
             // hovered-column readout below.
             var hovered = -1
-            for (column in range(column_count + 1)) {
+            for (column in range(column_count)) {
+                // cpp iterates COLUMNS_COUNT + 1 to special-case the
+                // trailing unused-space column; the das port simplified
+                // that away, so cap the loop at column_count —
+                // table_get_column_flags(column_count) asserts on a
+                // 3-column table (valid indices: -1 or 0..N-1).
                 if ((int(table_get_column_flags(column)) &
                      int(ImGuiTableColumnFlags.IsHovered)) != 0) {
                     hovered = column
@@ -2746,17 +2767,31 @@ def private show_advanced() {
             table_setup_scroll_freeze(TABLES_ADV_FREEZE_COLS,
                                       TABLES_ADV_FREEZE_ROWS)
 
-            // ---- Sort (cpp:5904-5912) ----
+            // ---- Chop/Eat-triggered re-sort (cpp:5905-5910 items_need_sort path) ----
+            // Last frame's Chop/Eat may have set NEED_SORT (without
+            // dirtying SpecsDirty). Re-run the comparator against the
+            // cached specs so a quantity edit while sorted-by-quantity
+            // visibly re-orders next frame.
+            if (TABLES_ADV_ITEMS_NEED_SORT && !empty(TABLES_ADV_LAST_SPECS)) {
+                TABLES_ADV_ITEMS |> sort() $(a, b) {
+                    return adv_compare(a, b, TABLES_ADV_LAST_SPECS)
+                }
+            }
+            TABLES_ADV_ITEMS_NEED_SORT = false
+
+            // ---- SpecsDirty-driven sort (cpp:5904-5912 sort_specs path) ----
             sort_specs() $(specs) {
+                // Cache specs for the next-frame Chop/Eat-triggered
+                // re-sort path above. Clear+push avoids cross-context
+                // pointer reuse — TableSortSpec is plain workhorse fields.
+                TABLES_ADV_LAST_SPECS |> clear
+                for (s in specs) {
+                    TABLES_ADV_LAST_SPECS |> push(s)
+                }
                 TABLES_ADV_ITEMS |> sort() $(a, b) {
                     return adv_compare(a, b, specs)
                 }
             }
-            // cpp:5912 — always resets after the dirty pass. The
-            // sort_specs() helper clears the dirty flag on its own when
-            // invoked, so this is purely a local guard for the
-            // quantity-edit-induced re-sort (set below).
-            TABLES_ADV_ITEMS_NEED_SORT = false
 
             // cpp:5916 — track whether the Quantity column is currently
             // sorted; if so, Chop/Eat triggers a re-sort on button-release.

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -1796,12 +1796,13 @@ def private show_row_height() {
             let cell_padding_y = GetStyle().CellPadding.y
             for (row in range(8)) {
                 if (row % 3 == 2) {
+                    let row_pad_y = 20.0f
                     with_style((ImGuiStyleVar.CellPadding,
-                                float2(cell_padding_x, 20.0f))) {
+                                float2(cell_padding_x, row_pad_y))) {
                         table_next_row(ImGuiTableRowFlags.None)
                         table_next_column()
                         text(TABLES_RH3_CELL[row],
-                             (text = "CellPadding.y = {cell_padding_y}"))
+                             (text = "CellPadding.y = {row_pad_y}"))
                     }
                 } else {
                     table_next_row(ImGuiTableRowFlags.None)

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -101,6 +101,31 @@ var private TABLES_RHH_FLAGS : int = int(ImGuiTableFlags.Resizable |
 var private TABLES_RHH_T1_CELL : table<int; NarrativeState>
 var private TABLES_RHH_T2_CELL : table<int; NarrativeState>
 
+// ---- Section 7 Padding state ----
+// Two sub-tables: table_padding (flag toggles + Avail/FillButton cells)
+// and table_padding_2 (CellPadding style-var + InputText grid).
+var private TABLES_PAD1_FLAGS : int = int(ImGuiTableFlags.BordersV)
+var private TABLES_PAD1_AVAIL : table<int; NarrativeState>  // row 0 cells: "Avail %.2f"
+var private TABLES_PAD1_BTN   : table<int; ClickState>      // rows 1-4 cells: FillButton "Hello c,r"
+
+var private TABLES_PAD2_FLAGS        : int    = int(ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg)
+var private TABLES_PAD2_CELL_PADDING : float2 = float2(0.0f, 0.0f)
+// 15 InputText cells; the boost (text=..., init=...) named-tuple form
+// seeds the buffer to "edit me" on first call (matches cpp's static init).
+var private TABLES_PAD2_CELL_IT      : table<int; InputTextState>
+
+[init]
+def seed_padding_cells() {
+    // Pre-populate the 15-cell InputText buffer with "edit me" to mirror
+    // the cpp static char text_bufs[3*5][16] + init flag pattern. The
+    // boost init= named-tuple sugar isn't supported on indexed [widget]
+    // form (per the macro's named-init-on-indexed-form diagnostic), so
+    // direct field set in [init] is the documented workaround.
+    for (i in range(15)) {
+        TABLES_PAD2_CELL_IT[i].value := "edit me"
+    }
+}
+
 def ShowDemoWindowTables() {
     collapsing_header(TABLES_SECTION,
                       (text = "Tables & Columns", closable = false,
@@ -121,6 +146,7 @@ def ShowDemoWindowTables() {
         show_resizable_fixed()
         show_resizable_mixed()
         show_reorderable_hideable_headers()
+        show_padding()
 
         // Reset open_action so the next frame's tree_nodes inherit their
         // sticky open/closed state instead of being forced again.
@@ -454,6 +480,120 @@ def private show_reorderable_hideable_headers() {
                     table_set_column_index(col)
                     text(TABLES_RHH_T2_CELL[row * 3 + col],
                          (text = "Fixed {col},{row}"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Section 7: Padding — cpp:4508-4613
+// =============================================================================
+def private show_padding_inputtext_grid() {
+    // Body extracted so the outer conditional FrameBg push wraps a single
+    // call (instead of duplicating the 15-cell loop in each branch). Each
+    // cell's own (text, init) seeds the buffer to "edit me" on first call.
+    for (cell in range(15)) {
+        table_next_column()
+        SetNextItemWidth(-FLT_MIN)
+        input_text(TABLES_PAD2_CELL_IT[cell], (text = "##cell"))
+    }
+}
+
+def private show_padding() {
+    apply_open_action()
+    tree_node(TABLES_PADDING, (text = "Padding",
+                               flags = ImGuiTreeNodeFlags.None)) {
+        // ----- Sub-table 1: padding-flag effect on X spacing -----
+        // PadOuterX / NoPadOuterX / NoPadInnerX + BordersOuterV/InnerV.
+        // The first row's cell reads ContentRegionAvail.x so the
+        // available-width effect of each toggle is visible at a glance.
+        edit_checkbox_flags(safe_addr(TABLES_PAD1_FLAGS),
+            (id = "TBL_P1_F_PAD_OUT_X", text = "ImGuiTableFlags_PadOuterX",
+             flags_value = int(ImGuiTableFlags.PadOuterX)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD1_FLAGS),
+            (id = "TBL_P1_F_NOPAD_OUT_X", text = "ImGuiTableFlags_NoPadOuterX",
+             flags_value = int(ImGuiTableFlags.NoPadOuterX)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD1_FLAGS),
+            (id = "TBL_P1_F_NOPAD_IN_X", text = "ImGuiTableFlags_NoPadInnerX",
+             flags_value = int(ImGuiTableFlags.NoPadInnerX)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD1_FLAGS),
+            (id = "TBL_P1_F_BORDERS_OV", text = "ImGuiTableFlags_BordersOuterV",
+             flags_value = int(ImGuiTableFlags.BordersOuterV)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD1_FLAGS),
+            (id = "TBL_P1_F_BORDERS_IV", text = "ImGuiTableFlags_BordersInnerV",
+             flags_value = int(ImGuiTableFlags.BordersInnerV)))
+        checkbox(TABLES_PAD1_SHOW_HEADERS, (text = "show_headers", init = false))
+
+        data_table(TABLES_PAD1_T, (text = "##pad1", columns = 3,
+                                   flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_PAD1_FLAGS)),
+                                   outer_size = float2(0.0f, 0.0f),
+                                   inner_width = 0.0f)) {
+            if (TABLES_PAD1_SHOW_HEADERS.value) {
+                table_setup_column("One")
+                table_setup_column("Two")
+                table_setup_column("Three")
+                table_headers_row()
+            }
+            for (row in range(5)) {
+                table_next_row()
+                for (col in range(3)) {
+                    table_set_column_index(col)
+                    if (row == 0) {
+                        let avail = GetContentRegionAvail().x
+                        text(TABLES_PAD1_AVAIL[col],
+                             (text = "Avail {avail}"))
+                    } else {
+                        let key = (row - 1) * 3 + col
+                        button(TABLES_PAD1_BTN[key],
+                               (text = "Hello {col},{row}",
+                                size = float2(-FLT_MIN, 0.0f)))
+                    }
+                }
+            }
+        }
+
+        // ----- Sub-table 2: explicit CellPadding style-var -----
+        // Sliderable CellPadding (0..10, %.0f) overrides ImGuiStyle for the
+        // wrapped data_table call. Optional FrameBg=0 push hides the per-
+        // InputText frame so the cell padding is visually unambiguous.
+        edit_checkbox_flags(safe_addr(TABLES_PAD2_FLAGS),
+            (id = "TBL_P2_F_BORDERS", text = "ImGuiTableFlags_Borders",
+             flags_value = int(ImGuiTableFlags.Borders)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD2_FLAGS),
+            (id = "TBL_P2_F_BORDERSH", text = "ImGuiTableFlags_BordersH",
+             flags_value = int(ImGuiTableFlags.BordersH)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD2_FLAGS),
+            (id = "TBL_P2_F_BORDERSV", text = "ImGuiTableFlags_BordersV",
+             flags_value = int(ImGuiTableFlags.BordersV)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD2_FLAGS),
+            (id = "TBL_P2_F_BORDERS_IN", text = "ImGuiTableFlags_BordersInner",
+             flags_value = int(ImGuiTableFlags.BordersInner)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD2_FLAGS),
+            (id = "TBL_P2_F_BORDERS_OUT", text = "ImGuiTableFlags_BordersOuter",
+             flags_value = int(ImGuiTableFlags.BordersOuter)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD2_FLAGS),
+            (id = "TBL_P2_F_ROWBG", text = "ImGuiTableFlags_RowBg",
+             flags_value = int(ImGuiTableFlags.RowBg)))
+        edit_checkbox_flags(safe_addr(TABLES_PAD2_FLAGS),
+            (id = "TBL_P2_F_RESIZABLE", text = "ImGuiTableFlags_Resizable",
+             flags_value = int(ImGuiTableFlags.Resizable)))
+        checkbox(TABLES_PAD2_SHOW_FRAMEBG, (text = "show_widget_frame_bg", init = true))
+        edit_slider_float2(safe_addr(TABLES_PAD2_CELL_PADDING),
+            (id = "TBL_P2_CELL_PAD", text = "CellPadding",
+             v_min = 0.0f, v_max = 10.0f, format = "%.0f"))
+
+        with_style((ImGuiStyleVar.CellPadding, TABLES_PAD2_CELL_PADDING)) {
+            data_table(TABLES_PAD2_T, (text = "##pad2", columns = 3,
+                                       flags = unsafe(reinterpret<ImGuiTableFlags>(TABLES_PAD2_FLAGS)),
+                                       outer_size = float2(0.0f, 0.0f),
+                                       inner_width = 0.0f)) {
+                if (!TABLES_PAD2_SHOW_FRAMEBG.value) {
+                    with_style((ImGuiCol.FrameBg, 0u)) {
+                        show_padding_inputtext_grid()
+                    }
+                } else {
+                    show_padding_inputtext_grid()
                 }
             }
         }

--- a/examples/imgui_demo/widgets.das
+++ b/examples/imgui_demo/widgets.das
@@ -59,9 +59,9 @@ var WIDGETS_DISABLE_ALL = false
 // `CheckboxFlags` (now `edit_checkbox_flags`) binds an `int?` form, so the
 // base-flags state is stored as `int` and converted back to
 // `ImGuiTreeNodeFlags` at the TreeNodeEx call site.
-var WIDGETS_TREE_BASE_FLAGS = (int(ImGuiTreeNodeFlags.OpenOnArrow) |
-                               int(ImGuiTreeNodeFlags.OpenOnDoubleClick) |
-                               int(ImGuiTreeNodeFlags.SpanAvailWidth))
+var WIDGETS_TREE_BASE_FLAGS = int(ImGuiTreeNodeFlags.OpenOnArrow |
+                                  ImGuiTreeNodeFlags.OpenOnDoubleClick |
+                                  ImGuiTreeNodeFlags.SpanAvailWidth)
 var WIDGETS_TREE_SELECTION_MASK = 1 << 2
 
 // ----- Basic/SliderAngle external-pointer -----
@@ -168,7 +168,7 @@ def private BasicSection() {
         align_text_to_frame_padding(WIDGETS_BASIC_ATFP)
         text("Hold to repeat:")
         same_line(WIDGETS_SL_4)
-        let spacing = unsafe(GetStyle()).ItemInnerSpacing.x
+        let spacing = GetStyle().ItemInnerSpacing.x
         with_button_repeat(true) {
             if (arrow_button(WIDGETS_BASIC_ARROW_L, (text = "##left", dir = ImGuiDir.Left))) {
                 WIDGETS_BASIC_ARROW_COUNTER--
@@ -429,13 +429,13 @@ def private TooltipsSection() {
                           flags = ImGuiHoveredFlags.DelayNone))
 
         button(WIDGETS_TIP_DELAY_SHORT, (text = "DelayShort"))
-        let delay_short = unsafe(GetStyle()).HoverDelayShort
+        let delay_short = GetStyle().HoverDelayShort
         set_item_tooltip(WIDGETS_TIP_DELAY_SHORT_TT,
                          (text = "I am a tooltip with a short delay ({delay_short} sec).",
                           flags = ImGuiHoveredFlags.DelayShort | ImGuiHoveredFlags.NoSharedDelay))
 
         button(WIDGETS_TIP_DELAY_LONG, (text = "DelayLong"))
-        let delay_long = unsafe(GetStyle()).HoverDelayNormal
+        let delay_long = GetStyle().HoverDelayNormal
         set_item_tooltip(WIDGETS_TIP_DELAY_LONG_TT,
                          (text = "I am a tooltip with a long delay ({delay_long} sec).",
                           flags = ImGuiHoveredFlags.DelayNormal | ImGuiHoveredFlags.NoSharedDelay))
@@ -609,8 +609,8 @@ def private TreeNodesSection() {
                         }
                     } else {
                         // Leaves: Leaf + NoTreePushOnOpen — no TreePop is paired.
-                        node_flags |= (int(ImGuiTreeNodeFlags.Leaf) |
-                                       int(ImGuiTreeNodeFlags.NoTreePushOnOpen))
+                        node_flags |= int(ImGuiTreeNodeFlags.Leaf |
+                                          ImGuiTreeNodeFlags.NoTreePushOnOpen)
                         tree_node_ex(WIDGETS_TREE_LOOP_LEAF[i],
                             (text = "Selectable Leaf {i}",
                              flags = unsafe(reinterpret<ImGuiTreeNodeFlags>(node_flags))))
@@ -628,7 +628,7 @@ def private TreeNodesSection() {
                 }
             }
             if (node_clicked != -1) {
-                if (unsafe(GetIO()).KeyCtrl) {
+                if (GetIO().KeyCtrl) {
                     WIDGETS_TREE_SELECTION_MASK ^= (1 << node_clicked)
                 } else {
                     WIDGETS_TREE_SELECTION_MASK = (1 << node_clicked)
@@ -785,9 +785,9 @@ def private ImagesSection() {
             "storage to pass pointers or identifier to your own texture data. " +
             "Hover the texture for a zoomed view!"))
 
-        let my_tex_id = unsafe(*io.Fonts).TexID
-        let my_tex_w = float(unsafe(*io.Fonts).TexWidth)
-        let my_tex_h = float(unsafe(*io.Fonts).TexHeight)
+        let my_tex_id = io.Fonts.TexID
+        let my_tex_w = float(io.Fonts.TexWidth)
+        let my_tex_h = float(io.Fonts.TexHeight)
 
         checkbox(WIDGETS_IMAGES_USE_TINT, (text = "Use Text Color for Tint"))
         text("{int(my_tex_w)}x{int(my_tex_h)}")

--- a/examples/tutorial/data_table.das
+++ b/examples/tutorial/data_table.das
@@ -42,9 +42,10 @@ require imgui/imgui_visual_aids
 //   }
 //
 // `TableState` echoes per-call config (columns / flags / outer_size /
-// inner_width). Sort-spec capture, multi-select hand-off, frozen-row
-// indicators belong to a future `tables.das` port and extend the state
-// additively.
+// inner_width). `sort_specs()` (block helper) yields the per-frame sort
+// spec list — see the Sortable tables section below. Multi-select
+// hand-off and custom row-bg callbacks extend the state additively in
+// the upcoming `tables.das` port.
 //
 // STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/data_table.das
 // LIVE:       daslang-live modules/dasImgui/examples/tutorial/data_table.das
@@ -58,6 +59,13 @@ struct private Row {
 
 var private ROWS : array<Row>
 
+// Stable column identifiers passed to table_setup_column(.., user_id=...).
+// The sort comparator dispatches on user_id (not column_index) so the
+// sort stays correct when the user reorders columns via drag.
+let private COL_NAME = 0x0001u
+let private COL_KIND = 0x0002u
+let private COL_VAL  = 0x0003u
+
 [init]
 def seed_rows() {
     ROWS <- [
@@ -68,6 +76,47 @@ def seed_rows() {
         Row(name = "epsilon", kind = "int", value = "-7"),
         Row(name = "zeta", kind = "float", value = "0.001")
     ]
+}
+
+def private compare_rows(spec : TableSortSpec; a : Row; b : Row) : int {
+    // Returns -1 / 0 / 1 for a-vs-b along the column the spec names.
+    var ord = 0
+    if (spec.column_user_id == COL_NAME) {
+        if (a.name < b.name) {
+            ord = -1
+        } elif (a.name > b.name) {
+            ord = 1
+        }
+    } elif (spec.column_user_id == COL_KIND) {
+        if (a.kind < b.kind) {
+            ord = -1
+        } elif (a.kind > b.kind) {
+            ord = 1
+        }
+    } elif (spec.column_user_id == COL_VAL) {
+        if (a.value < b.value) {
+            ord = -1
+        } elif (a.value > b.value) {
+            ord = 1
+        }
+    }
+    if (spec.sort_direction == ImGuiSortDirection.Descending) {
+        ord = -ord
+    }
+    return ord
+}
+
+def private sort_rows(specs : array<TableSortSpec>) {
+    // Multi-key comparator: walk specs in priority order; return on the
+    // first one that disambiguates a vs b. Final tiebreak on name keeps
+    // the order total.
+    ROWS |> sort() $(a, b) {
+        for (s in specs) {
+            let ord = compare_rows(s, a, b)
+            if (ord != 0) return ord < 0
+        }
+        return a.name < b.name
+    }
 }
 
 var DT_NAME : table<int; NarrativeState>
@@ -96,21 +145,30 @@ def update() {
     SetNextWindowSize(ImVec2(640.0f, 380.0f), ImGuiCond.FirstUseEver)
     window(DT_WIN, (text = "data_table", closable = false,
                     flags = ImGuiWindowFlags.None)) {
-        text(DT_HEADER, (text = "Three columns over six rows — frozen header."))
+        text(DT_HEADER, (text = "Three columns, six rows, frozen header. Click headers to sort; Shift+click for multi-column."))
 
-        let tflags = (int(ImGuiTableFlags.BordersOuter) |
-                      int(ImGuiTableFlags.RowBg) |
-                      int(ImGuiTableFlags.Resizable) |
-                      int(ImGuiTableFlags.ScrollY))
+        let tflags = int(ImGuiTableFlags.BordersOuter |
+                         ImGuiTableFlags.RowBg |
+                         ImGuiTableFlags.Resizable |
+                         ImGuiTableFlags.Reorderable |
+                         ImGuiTableFlags.Hideable |
+                         ImGuiTableFlags.Sortable |
+                         ImGuiTableFlags.SortMulti |
+                         ImGuiTableFlags.ScrollY)
         data_table(DT_TABLE, (text = "##rows", columns = 3,
                               flags = unsafe(reinterpret<ImGuiTableFlags>(tflags)),
                               outer_size = float2(0.0f, 0.0f),
                               inner_width = 0.0f)) {
             table_setup_scroll_freeze(0, 1)
-            table_setup_column("Name")
-            table_setup_column("Type")
-            table_setup_column("Value")
+            table_setup_column("Name",  ImGuiTableColumnFlags.DefaultSort, 0.0f, COL_NAME)
+            table_setup_column("Type",  ImGuiTableColumnFlags.None,        0.0f, COL_KIND)
+            table_setup_column("Value", ImGuiTableColumnFlags.None,        0.0f, COL_VAL)
             table_headers_row()
+
+            sort_specs() $(specs) {
+                sort_rows(specs)
+            }
+
             for (i in range(length(ROWS))) {
                 table_next_row()
                 table_set_column_index(0)

--- a/examples/tutorial/data_table.das
+++ b/examples/tutorial/data_table.das
@@ -44,8 +44,8 @@ require imgui/imgui_visual_aids
 // `TableState` echoes per-call config (columns / flags / outer_size /
 // inner_width). `sort_specs()` (block helper) yields the per-frame sort
 // spec list — see the Sortable tables section below. Multi-select
-// hand-off and custom row-bg callbacks extend the state additively in
-// the upcoming `tables.das` port.
+// hand-off and custom row-bg callbacks would extend the state
+// additively if added later.
 //
 // STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/data_table.das
 // LIVE:       daslang-live modules/dasImgui/examples/tutorial/data_table.das

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -46,7 +46,8 @@ namespace das {
     DAS_MOD_API void InsertChars(ImGuiInputTextCallbackData & data, int pos, const char* text );
     DAS_MOD_API void SetNextWindowSizeConstraints(vec4f snwscc, const ImVec2& size_min, const ImVec2& size_max, Context * context, LineInfoArg * at );
     DAS_MOD_API void SetNextWindowSizeConstraintsNoCallback(const ImVec2& size_min, const ImVec2& size_max);
-    DAS_MOD_API ImGuiSortDirection_ SortDirection ( const ImGuiTableColumnSortSpecs & specs );
+    DAS_MOD_API ImGuiSortDirection_ GetColumnSortDirection ( const ImGuiTableColumnSortSpecs * specs );
+    DAS_MOD_API const ImGuiTableColumnSortSpecs * GetSortSpec ( ImGuiTableSortSpecs * specs, int idx );
     DAS_MOD_API ImVec2 CalcTextSize(const char* text,bool hide_text_after_double_hash, float wrap_width);
     DAS_MOD_API bool Combo ( vec4f cg, const char * label, int * current_item, int items_count, int popup_max_height_in_items, Context * ctx, LineInfoArg * at );
     DAS_MOD_API void PlotLines ( vec4f igpg, const char* label, int values_count, int values_offset, const char* overlay_text,

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -383,8 +383,23 @@ namespace das {
         ImGui::SetNextWindowSizeConstraints(size_min, size_max);
     }
 
-    ImGuiSortDirection_ SortDirection ( const ImGuiTableColumnSortSpecs & specs ) {
-        return ImGuiSortDirection_(specs.SortDirection);
+    ImGuiSortDirection_ GetColumnSortDirection ( const ImGuiTableColumnSortSpecs * specs ) {
+        // Takes pointer (not reference) for daslang interop consistency with `GetSortSpec`.
+        // The bitfield-stored `SortDirection` is exposed as this free helper because
+        // `ImU8 SortDirection : 8` doesn't survive the generated struct-annotation binding.
+        // Renamed from bare `SortDirection` to avoid `decltype(&das::SortDirection)` ambiguity
+        // with the struct member `ImGuiTableColumnSortSpecs::SortDirection` under MSVC.
+        return ImGuiSortDirection_(specs->SortDirection);
+    }
+
+    const ImGuiTableColumnSortSpecs * GetSortSpec ( ImGuiTableSortSpecs * specs, int idx ) {
+        // Indexed access to ``ImGuiTableSortSpecs::Specs`` (a `const ImGuiTableColumnSortSpecs *`
+        // array) — daslang has no native C-pointer-arithmetic, so this small helper exposes
+        // per-index access via pointer. Returns pointer (not reference) because daslang's interop
+        // WrapType layer only handles `T*` cleanly for non-workhorse return types; `const T&`
+        // returns trigger "missing WrapType implementation" at runtime.
+        // Caller responsibility: specs != NULL && 0 <= idx < specs->SpecsCount.
+        return &specs->Specs[idx];
     }
 
     ImVec2 CalcTextSize(const char* text,bool hide_text_after_double_hash, float wrap_width) {
@@ -553,9 +568,11 @@ namespace das {
         addExtern<DAS_BIND_FUN(das::SetNextWindowSizeConstraintsNoCallback), SimNode_ExtFuncCall, imguiTempFn>(*this,lib,"SetNextWindowSizeConstraints",
             SideEffects::worstDefault,"das::SetNextWindowSizeConstraintsNoCallback")
                 ->args({"size_min","size_max"});
-        // ImGuiTableColumnSortSpecs
-        addExtern<DAS_BIND_FUN(das::SortDirection)>(*this,lib,"SortDirection",
-            SideEffects::none,"das::SortDirection");
+        // ImGuiTableColumnSortSpecs / ImGuiTableSortSpecs
+        addExtern<DAS_BIND_FUN(das::GetColumnSortDirection)>(*this,lib,"GetColumnSortDirection",
+            SideEffects::none,"das::GetColumnSortDirection");
+        addExtern<DAS_BIND_FUN(das::GetSortSpec)>(*this,lib,"GetSortSpec",
+            SideEffects::none,"das::GetSortSpec");
         // CalcTextSize
         addExtern<DAS_BIND_FUN(das::CalcTextSize)>(*this, lib, "CalcTextSize",SideEffects::worstDefault, "das::CalcTextSize")
         ->args({"text","hide_text_after_double_hash","wrap_width"})

--- a/tests/integration/record_data_table.das
+++ b/tests/integration/record_data_table.das
@@ -80,5 +80,23 @@ def main {
         )))
         move_to(app, p_val5)
         sleep(3500u)
+
+        // ---- Stage 5: sort_specs — single-column sort on Name ----
+        post_command(app, "imgui_narrate", JV((
+            text = "sort_specs() captures column user_ids on header clicks.",
+            target = T_NAME0,
+            frames = 180
+        )))
+        move_to(app, p_name0)
+        sleep(3500u)
+
+        // ---- Stage 6: SortMulti — Shift+click adds a secondary key ----
+        post_command(app, "imgui_narrate", JV((
+            text = "SortMulti + Shift+click appends a secondary sort key.",
+            target = T_KIND2,
+            frames = 180
+        )))
+        move_to(app, p_kind2)
+        sleep(3500u)
     }
 }

--- a/tests/integration/record_data_table.das
+++ b/tests/integration/record_data_table.das
@@ -81,18 +81,21 @@ def main {
         move_to(app, p_val5)
         sleep(3500u)
 
-        // ---- Stage 5: sort_specs — single-column sort on Name ----
+        // ---- Stage 5: sort_specs — point at the Name column ----
+        // Recorder only moves the cursor; no synthesized header click. The
+        // narration describes the API rather than demonstrating an actual
+        // sort interaction.
         post_command(app, "imgui_narrate", JV((
-            text = "sort_specs() captures column user_ids on header clicks.",
+            text = "sort_specs() captures column user_ids when ImGui reports SpecsDirty (try clicking a header live).",
             target = T_NAME0,
             frames = 180
         )))
         move_to(app, p_name0)
         sleep(3500u)
 
-        // ---- Stage 6: SortMulti — Shift+click adds a secondary key ----
+        // ---- Stage 6: SortMulti — point at a secondary column ----
         post_command(app, "imgui_narrate", JV((
-            text = "SortMulti + Shift+click appends a secondary sort key.",
+            text = "SortMulti lets Shift+click append a secondary sort key — try it live.",
             target = T_KIND2,
             frames = 180
         )))

--- a/tests/integration/test_imgui_demo_tables.das
+++ b/tests/integration/test_imgui_demo_tables.das
@@ -1,0 +1,29 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the imgui_demo `tables` scene. Boots the
+//! single-scene harness driver (which wraps ShowDemoWindowTables in
+//! MAIN_WIN since it doesn't open its own window) and waits for the
+//! host window + the TABLES_SECTION collapsing_header inside.
+
+let IMGUI_DEMO_TABLES_HARNESS = "modules/dasImgui/examples/imgui_demo/harness_tables.das"
+
+[test]
+def test_imgui_demo_tables_smoke(t : T?) {
+    with_imgui_app(IMGUI_DEMO_TABLES_HARNESS) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN", 15.0f)
+        t |> success(snap0 != null, "MAIN_WIN registers (host window renders)")
+        if (snap0 == null) return
+        t |> equal(find_widget(snap0, "MAIN_WIN")?["kind"] ?? "", "window",
+                   "MAIN_WIN.kind == 'window'")
+        var snap1 = wait_for_widget(d, "MAIN_WIN/TABLES_SECTION", 15.0f)
+        t |> success(snap1 != null, "TABLES_SECTION registers inside MAIN_WIN")
+    }
+}

--- a/tests/integration/test_sort_specs.das
+++ b/tests/integration/test_sort_specs.das
@@ -22,13 +22,18 @@ let SORT_FEATURE = "modules/dasImgui/examples/features/sort_specs.das"
 [test]
 def test_sort_specs_table_renders(t : T?) {
     with_imgui_app(SORT_FEATURE) $(d) {
-        var snap = wait_for_widget(d, "SORT_WIN/LEAD", 15.0f)
+        // Wait for the DEEPEST widget so the snapshot is taken AFTER the
+        // table has done its layout-then-render two-pass. Waiting on
+        // SORT_WIN/LEAD races on CI's headless framebuffer — LEAD appears
+        // on the first frame but the table body only drains on the second
+        // (ImGui computes column widths in pass 1, renders cells in pass 2).
+        var snap = wait_for_widget(d, "SORT_WIN/SORT_TABLE/SORT_ROW_ID/0", 15.0f)
         t |> success(snap != null,
-                     "SORT_WIN/LEAD renders (sort_specs feature reached the trailing text)")
+                     "SORT_WIN renders with first inventory row's ID cell (sort_specs feature drained through table_next_row + table_set_column_index)")
         if (snap == null) return
         t |> success(widget_exists(snap, "SORT_WIN/SORT_TABLE"),
                      "SORT_WIN/SORT_TABLE registers (data_table container with Sortable + SortMulti)")
-        t |> success(widget_exists(snap, "SORT_WIN/SORT_TABLE/SORT_ROW_ID/0"),
-                     "first inventory row's ID cell registers (rows drain through table_next_row + table_set_column_index)")
+        t |> success(widget_exists(snap, "SORT_WIN/LEAD"),
+                     "trailing text LEAD registers (sort_specs feature reached the post-table text)")
     }
 }

--- a/tests/integration/test_sort_specs.das
+++ b/tests/integration/test_sort_specs.das
@@ -27,7 +27,7 @@ def test_sort_specs_table_renders(t : T?) {
         // SORT_WIN/LEAD races on CI's headless framebuffer — LEAD appears
         // on the first frame but the table body only drains on the second
         // (ImGui computes column widths in pass 1, renders cells in pass 2).
-        var snap = wait_for_widget(d, "SORT_WIN/SORT_TABLE/SORT_ROW_ID/0", 15.0f)
+        var snap = wait_for_widget(d, "SORT_WIN/SORT_TABLE/SORT_ROW_ID[0]", 15.0f)
         t |> success(snap != null,
                      "SORT_WIN renders with first inventory row's ID cell (sort_specs feature drained through table_next_row + table_set_column_index)")
         if (snap == null) return

--- a/tests/integration/test_sort_specs.das
+++ b/tests/integration/test_sort_specs.das
@@ -1,0 +1,34 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the `sort_specs` block-arg helper on
+//! `data_table`. Asserts the sortable inventory feature file boots,
+//! the host window + LEAD register, and the data_table appears with the
+//! Sortable + SortMulti flags reaching the snapshot. The auto-sort
+//! lifecycle (specs dirty → comparator fires → array re-orders → dirty
+//! cleared) runs by the time the second frame's snapshot is taken;
+//! actually flipping a sort key requires a synth header click which
+//! belongs to a follow-up interactive test.
+
+let SORT_FEATURE = "modules/dasImgui/examples/features/sort_specs.das"
+
+[test]
+def test_sort_specs_table_renders(t : T?) {
+    with_imgui_app(SORT_FEATURE) $(d) {
+        var snap = wait_for_widget(d, "SORT_WIN/LEAD", 15.0f)
+        t |> success(snap != null,
+                     "SORT_WIN/LEAD renders (sort_specs feature reached the trailing text)")
+        if (snap == null) return
+        t |> success(widget_exists(snap, "SORT_WIN/SORT_TABLE"),
+                     "SORT_WIN/SORT_TABLE registers (data_table container with Sortable + SortMulti)")
+        t |> success(widget_exists(snap, "SORT_WIN/SORT_TABLE/SORT_ROW_ID/0"),
+                     "first inventory row's ID cell registers (rows drain through table_next_row + table_set_column_index)")
+    }
+}

--- a/widgets/imgui_boost.das
+++ b/widgets/imgui_boost.das
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_boost_v2 shared
 

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_boost_runtime shared
 
@@ -1145,7 +1144,7 @@ def private io_jv() : JsonValue? {
     tab |> insert("key_shift", JV(IsKeyDown(ImGuiKey.ImGuiMod_Shift)))
     tab |> insert("key_alt",   JV(IsKeyDown(ImGuiKey.ImGuiMod_Alt)))
     tab |> insert("key_super", JV(IsKeyDown(ImGuiKey.ImGuiMod_Super)))
-    tab |> insert("config_macos_behaviors", JV(unsafe(GetIO()).ConfigMacOSXBehaviors))
+    tab |> insert("config_macos_behaviors", JV(GetIO().ConfigMacOSXBehaviors))
     let active_id = GetActiveID()
     if (active_id != 0u) {
         tab |> insert("active_id", JV(active_id))

--- a/widgets/imgui_docking_builtin.das
+++ b/widgets/imgui_docking_builtin.das
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_docking_builtin shared
 

--- a/widgets/imgui_id_builtin.das
+++ b/widgets/imgui_id_builtin.das
@@ -1,7 +1,6 @@
 options gen2
 options indenting = 4
 options no_unused_block_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_id_builtin shared
 

--- a/widgets/imgui_live.das
+++ b/widgets/imgui_live.das
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_live shared public
 
@@ -77,7 +76,7 @@ def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#versi
     }
     load_daslang_font(14.0f * live_imgui_content_scale)
     apply_daslang_theme()
-    ScaleAllSizes(unsafe(GetStyle()), live_imgui_content_scale)
+    ScaleAllSizes(GetStyle(), live_imgui_content_scale)
     ImGui_ImplGlfw_InitForOpenGL(window, true)
     ImGui_ImplOpenGL3_Init(glsl_version)
     return live_imgui_ctx

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -1,7 +1,6 @@
 options gen2
 options indenting = 4
 options no_unused_block_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_scope_builtin shared
 

--- a/widgets/imgui_style_builtin.das
+++ b/widgets/imgui_style_builtin.das
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_style_builtin shared
 

--- a/widgets/imgui_table_builtin.das
+++ b/widgets/imgui_table_builtin.das
@@ -67,6 +67,23 @@ def public table_headers_row() {
     TableHeadersRow()
 }
 
+def public table_header(text : string) {
+    //! `TableHeader(label)` — submit a single custom header cell (instead of
+    //! the default `table_headers_row`). Pair with `table_next_row(Headers)`
+    //! / per-column `table_set_column_index` for full control over header
+    //! contents (e.g. checkbox + label, multi-line text, custom alignment).
+    TableHeader(text)
+}
+
+def public table_angled_headers_row() {
+    //! `TableAngledHeadersRow()` — submit a header row with column labels
+    //! rotated by `ImGuiStyle.TableAngledHeadersAngle` (default 35°). Useful
+    //! when narrow columns can't fit horizontal labels. Set the
+    //! `ImGuiTableColumnFlags.AngledHeader` flag on each column before
+    //! calling.
+    TableAngledHeadersRow()
+}
+
 def public table_next_row(flags : ImGuiTableRowFlags = ImGuiTableRowFlags.None;
                           min_row_height : float = 0.0f) {
     //! `TableNextRow(flags, min_row_height)` — append a new row; pairs with
@@ -84,6 +101,48 @@ def public table_set_column_index(col : int) : bool {
     //! `TableSetColumnIndex(col)` — jump to ``col`` in the current row; returns
     //! true when the column is visible.
     return TableSetColumnIndex(col)
+}
+
+def public table_set_bg_color(target : ImGuiTableBgTarget; color : uint;
+                              column_n : int = -1) {
+    //! `TableSetBgColor(target, color, column_n)` — paint a row/cell
+    //! background. ``target`` picks the layer (``RowBg0`` / ``RowBg1`` /
+    //! ``CellBg``); ``color`` is `pack_color`-packed; ``column_n = -1``
+    //! means the current column under ``CellBg``. Call after the row's
+    //! `table_next_row` (and the relevant `table_set_column_index` for
+    //! ``CellBg``).
+    TableSetBgColor(target, color, column_n)
+}
+
+def public table_get_column_count() : int {
+    //! `TableGetColumnCount()` — column count of the current table.
+    return TableGetColumnCount()
+}
+
+def public table_get_column_index() : int {
+    //! `TableGetColumnIndex()` — 0-based index of the column the cursor is
+    //! currently in.
+    return TableGetColumnIndex()
+}
+
+def public table_get_row_index() : int {
+    //! `TableGetRowIndex()` — 0-based index of the row the cursor is
+    //! currently in.
+    return TableGetRowIndex()
+}
+
+def public table_get_column_name(col : int = -1) : string {
+    //! `TableGetColumnName(column_n)` — label of column ``col`` (the value
+    //! passed to `table_setup_column`); ``-1`` means the current column.
+    return TableGetColumnName(col)
+}
+
+def public table_get_column_flags(col : int = -1) : ImGuiTableColumnFlags {
+    //! `TableGetColumnFlags(column_n)` — current per-column flags, including
+    //! status bits set at runtime (``IsHovered`` / ``IsSorted`` / ``IsEnabled``
+    //! / ``IsVisible``); ``-1`` means the current column. Mask with
+    //! ``ImGuiTableColumnFlags.StatusMask_`` to read just the status bits.
+    return TableGetColumnFlags(col)
 }
 
 struct public TableSortSpec {

--- a/widgets/imgui_table_builtin.das
+++ b/widgets/imgui_table_builtin.das
@@ -160,30 +160,37 @@ def public sort_specs(blk : block<(specs : array<TableSortSpec>) : void>) : bool
     //! `TableSortSpec`, and yield the array to ``blk``. Auto-clears the
     //! dirty flag on return.
     //!
-    //! Call inside a `data_table` body, after `table_headers_row()`, BEFORE
-    //! emitting rows. Pass `ImGuiTableFlags.Sortable` (and optionally
-    //! `ImGuiTableFlags.SortMulti` for multi-column sort) on the table.
+    //! Call inside a `data_table` body, BEFORE emitting rows. Header-row
+    //! placement is flexible — sort state is finalized by the input
+    //! event-queue drain at frame start, so calling before or after
+    //! `table_headers_row()` reads the same specs (cpp imgui_demo
+    //! ``ShowDemoWindowTablesAdvanced`` calls before headers). Pass
+    //! `ImGuiTableFlags.Sortable` (and optionally
+    //! `ImGuiTableFlags.SortMulti` for multi-column sort, or
+    //! `ImGuiTableFlags.SortTristate` to allow no-sort state) on the table.
     //!
     //! Returns true iff ``blk`` was invoked (specs non-null AND
-    //! ``SpecsDirty`` AND ``SpecsCount > 0``). When false, the caller should
-    //! reuse the most recent sort order — ImGui keeps headers visually in
-    //! sync without re-firing dirty until the user re-clicks.
+    //! ``SpecsDirty``). The ``specs`` array may be EMPTY — under
+    //! `ImGuiTableFlags.SortTristate` clearing the last sorted column
+    //! produces a dirty event with ``SpecsCount == 0``, signalling
+    //! "user reset to default order"; treat that as a real event so the
+    //! caller can restore its original sequence. When the return is false,
+    //! reuse the most recent sort order — ImGui keeps headers visually
+    //! in sync without re-firing dirty until the user re-clicks.
     var p = TableGetSortSpecs()
     if (p == null || !p.SpecsDirty) return false
     let n = p.SpecsCount
-    if (n == 0) {
-        unsafe { p.SpecsDirty = false; }
-        return false
-    }
     var arr : array<TableSortSpec>
-    arr |> reserve(n)
-    for (i in range(n)) {
-        let s = GetSortSpec(p, i)
-        arr |> push(TableSortSpec(
-            column_index = int(s.ColumnIndex),
-            column_user_id = uint(s.ColumnUserID),
-            sort_order = int(s.SortOrder),
-            sort_direction = GetColumnSortDirection(s)))
+    if (n > 0) {
+        arr |> reserve(n)
+        for (i in range(n)) {
+            let s = GetSortSpec(p, i)
+            arr |> push(TableSortSpec(
+                column_index = int(s.ColumnIndex),
+                column_user_id = uint(s.ColumnUserID),
+                sort_order = int(s.SortOrder),
+                sort_direction = GetColumnSortDirection(s)))
+        }
     }
     invoke(blk, arr)
     delete arr

--- a/widgets/imgui_table_builtin.das
+++ b/widgets/imgui_table_builtin.das
@@ -11,18 +11,20 @@ require imgui/imgui_boost_runtime public
 require imgui/imgui_boost_v2 public
 require imgui/imgui_containers_builtin public
 
-//! Tables family — `[container] table` + six body-internal cursor wrappers.
+//! Tables family — `[container] data_table` + cursor wrappers + sort-spec capture.
 //!
 //! ImGui's table API splits into chrome that fires once per `BeginTable`
 //! (the column-setup calls) and cursor primitives that step rows/columns
-//! inside the body loop. All seven members live behind proper daslang
+//! inside the body loop. All members live behind proper daslang
 //! wrappers in this module (rather than ALLOWED_IMGUI extensions) so the
-//! consumer surface stays uniform: `table { table_setup_column(...);
+//! consumer surface stays uniform: `data_table { table_setup_column(...);
 //! table_headers_row(); for (...) { table_next_row(); table_set_column_index(0); ... } }`.
 //!
-//! Sort-spec capture, multi-select hand-off, frozen-row indicators, and
-//! custom row-bg callbacks belong to the future `tables.das` port and
-//! extend `TableState` additively at that time.
+//! Sort-spec capture goes through `sort_specs` (block-arg helper that
+//! yields a daslang-friendly `array<TableSortSpec>` and auto-clears the
+//! dirty flag). Multi-select / frozen-row indicators / custom row-bg
+//! callbacks would extend `TableState` additively in future PRs; pinned
+//! ImGui 1.90.6 does not include the MultiSelect API.
 
 [container]
 def data_table(var state : TableState; text : string; columns : int;
@@ -82,4 +84,50 @@ def public table_set_column_index(col : int) : bool {
     //! `TableSetColumnIndex(col)` — jump to ``col`` in the current row; returns
     //! true when the column is visible.
     return TableSetColumnIndex(col)
+}
+
+struct public TableSortSpec {
+    //! Daslang-friendly mirror of one `ImGuiTableColumnSortSpecs` entry,
+    //! yielded by `sort_specs` inside a `data_table` body.
+    column_index   : int                //!< 0-based index of the column being sorted on (matches the order of `table_setup_column` calls).
+    column_user_id : uint               //!< The ``user_id`` you passed to `table_setup_column` for this column (or 0 if you didn't).
+    sort_order     : int                //!< Sort precedence: 0 = primary, 1 = secondary, ... Under `ImGuiTableFlags.SortMulti` multiple entries appear with increasing ``sort_order``.
+    sort_direction : ImGuiSortDirection //!< `Ascending` / `Descending` / `None`.
+}
+
+def public sort_specs(blk : block<(specs : array<TableSortSpec>) : void>) : bool {
+    //! Capture the current table's sort specs when ImGui reports them dirty,
+    //! convert each `ImGuiTableColumnSortSpecs` entry into a daslang-friendly
+    //! `TableSortSpec`, and yield the array to ``blk``. Auto-clears the
+    //! dirty flag on return.
+    //!
+    //! Call inside a `data_table` body, after `table_headers_row()`, BEFORE
+    //! emitting rows. Pass `ImGuiTableFlags.Sortable` (and optionally
+    //! `ImGuiTableFlags.SortMulti` for multi-column sort) on the table.
+    //!
+    //! Returns true iff ``blk`` was invoked (specs non-null AND
+    //! ``SpecsDirty`` AND ``SpecsCount > 0``). When false, the caller should
+    //! reuse the most recent sort order — ImGui keeps headers visually in
+    //! sync without re-firing dirty until the user re-clicks.
+    var p = TableGetSortSpecs()
+    if (p == null || !p.SpecsDirty) return false
+    let n = p.SpecsCount
+    if (n == 0) {
+        unsafe { p.SpecsDirty = false; }
+        return false
+    }
+    var arr : array<TableSortSpec>
+    arr |> reserve(n)
+    for (i in range(n)) {
+        let s = GetSortSpec(p, i)
+        arr |> push(TableSortSpec(
+            column_index = int(s.ColumnIndex),
+            column_user_id = uint(s.ColumnUserID),
+            sort_order = int(s.SortOrder),
+            sort_direction = GetColumnSortDirection(s)))
+    }
+    invoke(blk, arr)
+    delete arr
+    unsafe { p.SpecsDirty = false; }
+    return true
 }

--- a/widgets/imgui_visual_aids.das
+++ b/widgets/imgui_visual_aids.das
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_visual_aids shared public
 

--- a/widgets/imgui_window_constraints_builtin.das
+++ b/widgets/imgui_window_constraints_builtin.das
@@ -2,7 +2,6 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
-options _allow_imgui_legacy = true
 
 module imgui_window_constraints_builtin shared
 


### PR DESCRIPTION
## Summary

12 commits closing out the imgui_demo port milestone. The 14-line `tables.das` stub becomes a 2911-line full 1:1 port of `ShowDemoWindowTables` (cpp:4154-6044, 24 sub-sections), and `git grep _allow_imgui_legacy examples/imgui_demo/` now returns nothing.

1. **PR-D/0** (`4499b9e`) — Housekeeping: 9 lint nits in widgets.das + dead-opt-out audit across 15 wrapper modules (9 dropped) + CLAUDE.md checklist refresh.
2. **PR-D/1A** (`ad15368`) — `sort_specs` block-arg helper + data_table sortable triad (tutorial + RST + recorder + re-record APNG).
3. **PR-D/1B** (`3a98de1`) — 8 snake_case `table_*` pass-through wrappers (`table_header`, `table_angled_headers_row`, `table_set_bg_color`, 5 getters) + `examples/features/table_set_bg_color.das` feature.
4. **PR-D/2 (1)** (`ae62771`) — sections 1 Basic + 2 Borders, background + module shell.
5. **PR-D/2 (2)** (`cf49092`) — sections 3-6 Resizable family + Reorderable.
6. **PR-D/2 (3)** (`b4d14a4`) — section 7 Padding.
7. **PR-D/2 (4)** (`76c6833`) — sections 8-11 Sizing policies + Scrolling + Columns flags.
8. **PR-D/2 (5)** (`3f22ee0`) — sections 12-15 Widths + Nested + Row height + Outer size.
9. **PR-D/2 (6)** (`7de2a42`) — sections 16-19 Background color + Tree view + Item width + Custom headers.
10. **PR-D/2 (7)** (`c791118`) — sections 20-23 Angled headers + Context menus + Synced instances + Sorting.
11. **PR-D/2 (8)** (`a216bd7`) — section 24 Advanced (full 1:1, ~600 das lines).
12. **PR-D/3** (`fd9789e`) — `harness_tables.das` + `test_imgui_demo_tables.das` + CLAUDE.md final-delivery gate ACHIEVED.

23 files touched (19 `.das` + 1 `.rst` + 1 `.apng` + 1 `.cpp` + 1 `.md`); +~3500 lines / -~50 lines.

## What changed

### Section 1A — `sort_specs` block-arg helper

Two new C++ helpers in `src/dasIMGUI.main.cpp`:
- `GetSortSpec(specs, idx) -> const ImGuiTableColumnSortSpecs*` — returns a pointer (not a reference) because daslang's interop `WrapType` only handles `T*` cleanly for non-workhorse types.
- `GetColumnSortDirection(specs)` — named that way (not the natural `SortDirection`) to dodge an MSVC `decltype` ambiguity vs `ImGuiTableColumnSortSpecs::SortDirection`.

New `widgets/imgui_table_builtin.das` symbols:
- `struct TableSortSpec { column_index, column_user_id, sort_order, sort_direction }` — daslang-friendly mirror.
- `sort_specs(blk : block<(specs : array<TableSortSpec>) : void>) : bool` — captures `TableGetSortSpecs()`, converts each entry, invokes the block, auto-clears `SpecsDirty`. Returns true iff the block fired.

`examples/tutorial/data_table.das` extended in-place to be sortable end-to-end. `doc/source/tutorials/data_table.rst` gains a "Sortable tables" subsection. `data_table.apng` re-recorded with 2 new narration stages (17.3 → 27.8 MB, 6 stages × 3.5s = 21.3s).

### Section 1B — 8 snake_case `table_*` wrappers

| Wrapper | ImGui call | Anchors port section |
|---|---|---|
| `table_header(text)` | `TableHeader` | 19 Custom headers |
| `table_angled_headers_row()` | `TableAngledHeadersRow` | 20 Angled headers |
| `table_set_bg_color(target, color, column_n=-1)` | `TableSetBgColor` | 14, 16 |
| `table_get_column_count() : int` | `TableGetColumnCount` | 11 |
| `table_get_column_index() : int` | `TableGetColumnIndex` | 11 |
| `table_get_row_index() : int` | `TableGetRowIndex` | 8, 24 |
| `table_get_column_name(col=-1) : string` | `TableGetColumnName` | 21 |
| `table_get_column_flags(col=-1) : ImGuiTableColumnFlags` | `TableGetColumnFlags` | 11, 21 |

Plus `examples/features/table_set_bg_color.das` — server-status table demonstrating both RowBg0 (full-row tint by severity) and CellBg (per-cell overlay on Value threshold).

### Section 2 — `tables.das` full 1:1 port (24 sections)

Every cpp sub-section ported into a `def private show_<name>()`; top-level `ShowDemoWindowTables()` is a 24-line dispatcher inside a `collapsing_header(TABLES_SECTION, ...)`. Standard boost-surface conventions throughout:

- cpp `static` locals → module-scope `var private TABLES_*`.
- cpp `Expand all` / `Collapse all` driver → `g_open_action` gate with `apply_open_action()` before each `tree_node(...)`.
- cpp `PushID("Tables")` outer scope dropped — each `data_table(IDENT, ...)` auto-PushID's its unique IDENT.
- cpp `HelpMarker` bubbles (~40 instances) dropped per the app_dockspace precedent.
- cpp `PushStyleCompact` / `PopStyleCompact` cosmetic dropped.
- Per-cell state in `table<int; NarrativeState>` indexed by `row * cols + col`.

**Patterns introduced** beyond the existing widgets/inputs/layout/columns/popups precedent:

- `with_id("<scope>_{i}")` per-iter ID namespacing for loops where widget IDENTs must be literal strings.
- `implicit` on `var ptr : T?` helper params so `safe_addr(...)` temp pointers thread through.
- `with_indent(step * row)` block-scoped pushes for cpp's per-row Indent stacking (raw `Indent`/`Unindent` lint-forbidden).
- `SetNextItemWidth` per-cell over `PushItemWidth` per-column when the boost surface forbids the latter.
- Synced-instances ID-sharing via ONE shared `data_table(IDENT, ...)` in a loop — auto-PushID(IDENT) is identical per iter, so `BeginTable("Table")` hashes identically.
- `unsafe(addr(GetStyle().Field))` for in-place ImGuiStyle mutation via `edit_slider_*` (section 20).
- `with_button_repeat(true) { list_clipper(N) $(s, e) { ... } }` scope-wrapper composition (section 24).
- Multi-key sort comparator as a named `def private adv_compare(a, b, specs) : bool` rather than an inline lambda (section 24).
- Ctrl+click multi-select against `array<int>` selection holding stable IDs (section 24).

**Section 21 partial port** — per-column custom popups (cpp:5560-5582, raw `OpenPopup("MyPopup") + BeginPopup("MyPopup") + IsMouseReleased(1)` pattern) fell back to the default per-column context menu auto-emitted by `table_headers_row` plus a hovered-column readout. The boost surface doesn't expose a stateless `popup_window` wrapper for the manual-open shape; `popup_context_item` is trigger-bound. Documented in body comment.

**Section 24 Debug-details readout** (cpp:6019-6031) — drops the `Debug details` checkbox + `ImDrawList.CmdBuffer.Size` readout because `ImVector\`ImDrawCmd` has no `Size` accessor in the daslang binding. Documented in `show_advanced()` body comment + CLAUDE.md.

### Section 3 — Harness + test

- `examples/imgui_demo/harness_tables.das` — single-scene driver matching `harness_widgets.das` / `harness_layout.das` / `harness_inputs.das`.
- `tests/integration/test_imgui_demo_tables.das` — smoke matching `test_imgui_demo_widgets.das`: boots harness, waits for MAIN_WIN, asserts kind=="window", waits for TABLES_SECTION inside.
- `CLAUDE.md` — final-delivery gate declared ACHIEVED. Lists the 2 ALIVE opt-outs (`custom_widgets.das` + `widget_no_ident.das` — both intentional teaching artifacts).

### Phase 0 — Housekeeping carried in this PR

9 lint nits in `widgets.das` (2× PERF019 + 7× STYLE024). Wrapper-internal opt-out audit: 9 modules dropped `_allow_imgui_legacy = true` (alive in 6 — genuine raw-imgui consumers). 2 standing false positives in `imgui_boost_runtime.das:943/962` (STYLE024 on `unsafe(tab?[k])` + STYLE025 on nested-reinterpret block) — daslib lint-rule gaps tracked separately; documented in daslang's CLAUDE.md.

## Verification

- `mcp__daslang__lint --project-root=D:/IMGUI_DEMO` on all 19 changed `.das` files: 17 PASS + 2 known-pre-existing FPs.
- `mcp__daslang__format_file`: all `already_formatted`.
- `mcp__daslang__compile_check` on `tables.das` + `imgui_demo.das` (aggregator) + `harness_tables.das` + all changed wrapper modules: clean.
- `sphinx-build -W -b html doc/source`: `build succeeded`, no warnings (data_table.rst sortable subsection renders + APNG copies).
- Headless `EXIT=0` on `harness_tables.das` (60 frames), `examples/features/sort_specs.das`, `examples/features/table_set_bg_color.das`.

## Plan reference

Full plan in `C:\Users\Boris\.claude\plans\pr-d-tables.md` (approved before kickoff). Decisions locked there: Advanced section = full 1:1, sort_specs triad = extend existing data_table tutorial + APNG, wrapper opt-out audit = bundled.

## Test plan

- [ ] Per-OS CI matrix (Ubuntu / macOS / Windows) — Windows 7-test exclude continues for the libhv 16-POST stall.
- [ ] GitGuardian / build / sphinx jobs green.
- [ ] Manual smoke: `daslang-live examples/imgui_demo/harness_tables.das` → click `Expand all` → walk through all 24 sub-sections, verifying each renders without ImGui asserts.
- [ ] Manual smoke: open `Sorting` sub-section, click each header to verify single-column sort, hold shift + click second header to verify multi-column sort routing through `sort_specs()`.
- [ ] Manual smoke: open `Advanced` sub-section, exercise `Options` sub-tree (toggle every flag family), then exercise contents_type combo (Text / Button / SmallButton / FillButton / Selectable / SelectableSpanRow), then ctrl+click multiple rows to verify multi-select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)