### PR TITLE
popup_window: stateless [container] for manual-trigger BeginPopup (closes PR-D §21 sub 2 partial port)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ imgui.ini
 libhv.*.log
 example/**/_*.png
 example/_aot_generated/
+build_msvc/
 # Visual-aids ad-hoc smoke screenshots dropped at repo root by the screenshot live_command
 tour_*.png
 decay_*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@
 
 ### Added
 
+- `popup_window(IDENT, str_id, flags) $blk` — stateless `[container]`
+  for the manual-trigger BeginPopup/EndPopup pattern. Caller drives
+  `open_popup(str_id, flags)` from any custom predicate (hover-region +
+  right-click, key press, …); the wrapper brackets the body while ImGui
+  reports the popup open. Closes the cpp ``imgui_demo.cpp`` Tables
+  "Context menus" section 2 partial-port deferred in PR-D (per-column
+  ``"MyPopup"`` shared-str_id pattern keyed by ``PushID(column)``). The
+  ``[container]`` macro injects ``widget_prelude → PushID(widget_ident)``
+  before the body — but the caller's ``OpenPopup`` ran one ID-stack
+  level higher, so ``BeginPopup`` hashed under a deeper stack and the
+  popup never visibly opened. Fix: ``popup_window`` peels its own
+  ``widget_ident`` PushID off just around ``BeginPopup`` (PopID before,
+  PushID after), so BeginPopup's hash matches the caller's OpenPopup.
+- `tests/integration/test_popup_window.das` — smoke + click-opens-popup
+  pair. Verifies both ``BTN_POPUP`` / ``REG_POPUP`` register under their
+  ``with_id`` scopes and that ``imgui_click`` on the trigger button
+  surfaces ``MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE`` in the next
+  snapshot.
+- `examples/features/popup_window.das` — feature demo of the
+  manual-trigger popup pattern with two scopes sharing the same
+  ``"fruit_picker"`` str_id (button-click trigger + hover-region
+  right-click trigger).
+- `examples/tutorial/popup_window.das` + `doc/source/tutorials/popup_window.rst`
+  — tutorial pairing with one-shell recorded
+  ``doc/source/_static/tutorials/popup_window.apng`` driven by
+  ``tests/integration/record_popup_window.das``.
+
+### Changed
+
+- `examples/imgui_demo/tables.das` — Section 21 "Context menus" sub 2
+  per-column popup loop restored to full cpp shape (3 real columns +
+  trailing-unused-space column), driven by the new ``popup_window``
+  surface plus the existing
+  ``IsMouseReleased(ImGuiMouseButton.Right) && !IsAnyItemHovered()``
+  hover predicate. Replaces the simplified "track hovered column,
+  no popup" fallback documented inline in the prior PR-D port.
+
+### Fixed
+
+- Two pre-existing lint hits surfaced while linting the modified files:
+  ``examples/imgui_demo/tables.das:1114`` LINT010 dead-store of
+  ``current`` (declare-then-unsafe-assign), and
+  ``widgets/imgui_boost_runtime.das:1137`` PERF020 redundant
+  ``string(...)`` cast on an already-string variant arm.
+
+
+
 - `imgui/imgui_harness` — canonical wrapper module for examples/tests. Hides
   GLFW/OpenGL backend boilerplate behind five helpers (`harness_init`,
   `harness_begin_frame`, `harness_new_frame`, `harness_end_frame`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,8 @@ Two example files keep ALIVE opt-outs that are intentional, not gaps:
 - `examples/tutorial/custom_widgets.das` — teaches building widgets from primitives; uses raw imgui by design.
 - `examples/features/widget_no_ident.das` — exercises the STYLE001-rejected `text((text=...))` form for didactic value.
 
-Two cpp constructs are deliberately partial in the port:
+One cpp construct remains deliberately partial in the port:
 
-- **Section 21 sub 2** (per-column manual-open popups, cpp:5560-5582) — falls back to the default per-column context menu auto-emitted by `table_headers_row` plus a hovered-column readout text. The cpp pattern wants a stateless `popup_window(str_id, flags)` wrapper to bracket raw `BeginPopup`/`EndPopup` while the caller drives `OpenPopup`/`CloseCurrentPopup` elsewhere; that wrapper doesn't exist yet (existing `popup_context_item` is trigger-bound, stateful `popup(IDENT)` requires per-IDENT state which doesn't map to the cpp's shared-string ID pattern). Documented inline in `tables.das show_context_menus()`. Backlogged for a small follow-up PR (~100-150 das lines including the new-component triad).
 - **Section 24 Advanced's cpp Debug-details readout** (cpp:6019-6031, `ImDrawList.CmdBuffer.Size + scroll cur/max`) — `ImVector\`ImDrawCmd` has no `Size` accessor exposed in the daslang binding. The checkbox + readout are dropped; re-add when an `ImVector` size binding lands. Documented inline in `tables.das show_advanced()`.
+
+Section 21 sub 2's per-column manual-open popups (formerly partial) shipped in the same PR as the new `popup_window` `[container]` — the cpp shape now runs 1:1 against the boost surface.

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -20,6 +20,7 @@ construction.
    with_id.rst
    state_telemetry.rst
    containers.rst
+   popup_window.rst
    drag_drop.rst
    live_reload.rst
    driving_outside.rst

--- a/doc/source/tutorials/popup_window.rst
+++ b/doc/source/tutorials/popup_window.rst
@@ -1,0 +1,124 @@
+.. _tutorial_popup_window:
+
+#######################
+Popup window
+#######################
+
+ImGui exposes three popup-opening patterns: auto-trigger from a preceding
+item (``BeginPopupContextItem``), auto-trigger from anywhere in the window
+(``BeginPopupContextWindow``), and **manual-trigger** — the caller decides
+when to open. The boost layer wraps each with a dedicated ``[container]``:
+
+* ``popup_context_item(IDENT, (str_id, flags))`` — right-click on the
+  previously-submitted item opens the popup.
+* ``popup_context_window(IDENT, (str_id, flags))`` — right-click anywhere
+  inside the enclosing window opens it.
+* ``popup_window(IDENT, (str_id, flags))`` — no auto-trigger; the caller
+  drives ``open_popup(str_id, flags)`` from any custom predicate.
+
+The manual form is what the cpp demo's per-column table-context section
+needs: one shared ``str_id`` across multiple ``PushID`` scopes, each
+deciding for itself when to ``OpenPopup`` based on hover state, key
+combinations, or any predicate that has no preceding "item" to attach to.
+
+Source: ``examples/tutorial/popup_window.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/popup_window.apng
+   :alt: popup_window recording
+
+.. literalinclude:: ../../../examples/tutorial/popup_window.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_containers_builtin`` — ``popup_window``, ``open_popup``,
+  ``close_current_popup``.
+* ``imgui/imgui_id_builtin`` — ``with_id`` for the per-scope ID-stack push.
+
+Two scopes, one ``str_id``
+==========================
+
+ImGui keys a popup's open state by ``str_id`` *under the current ID stack*.
+When two render sites want the same logical popup ("pick a fruit") but
+need independent open state, push a distinct ``with_id("scope") { ... }``
+around each:
+
+.. code-block:: das
+
+   with_id("via_button") {
+       if (button(OPEN_BTN, (text = "Open via button"))) {
+           open_popup("fruit_picker")
+       }
+       popup_window(BTN_POPUP, (str_id = "fruit_picker", flags = ImGuiWindowFlags.None)) {
+           // body
+       }
+   }
+
+   with_id("via_region") {
+       // ...custom hover/release trigger...
+       if (in_region && IsMouseReleased(ImGuiMouseButton.Right)) {
+           open_popup("fruit_picker")
+       }
+       popup_window(REG_POPUP, (str_id = "fruit_picker", flags = ImGuiWindowFlags.None)) {
+           // body
+       }
+   }
+
+The two scopes see the *same* ``str_id``, but ImGui's ID-stack push from
+``with_id`` mangles the open state per scope. The shared body factor lets
+both scopes call the same private ``draw_picker_body()`` helper.
+
+Custom predicates
+=================
+
+Because there's no auto-trigger, the caller is free to compose any
+predicate that should open the popup. The features demo combines a
+hover-region check with a right-release:
+
+.. code-block:: das
+
+   text(HINT, (text = "(hover this region, right-click)"))
+   let region_min = GetItemRectMin()
+   let region_max = GetItemRectMax()
+   let in_region = (IsMouseHoveringRect(region_min, region_max, true) &&
+                    !IsAnyItemHovered())
+   if (in_region && IsMouseReleased(ImGuiMouseButton.Right)) {
+       open_popup("fruit_picker")
+   }
+
+This shape is what the cpp ``imgui_demo``'s ``"Tables > Context menus"``
+section uses to open one ``"MyPopup"`` per column. The
+``examples/imgui_demo/tables.das`` port reuses ``popup_window`` for
+exactly that loop.
+
+State
+=====
+
+``PopupWindowState`` is empty — ImGui owns the open lifecycle by
+``str_id`` and the boost wrapper just brackets the body. The state
+global is what the registry walks to find the widget by IDENT; the
+snapshot reports ``kind="popup_window"`` for every registered instance
+regardless of whether the popup is currently visible.
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/popup_window.das <../../../examples/tutorial/popup_window.das>`
+
+   Features-side demo: ``examples/features/popup_window.das``.
+
+   Integration test: ``tests/integration/test_popup_window.das``.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/examples/features/popup_window.das
+++ b/examples/features/popup_window.das
@@ -29,6 +29,7 @@ def init() {
 [export]
 def update() {
     if (!harness_begin_frame()) return
+    harness_apply_synth_io()
     harness_new_frame()
 
     SetNextWindowSize(ImVec2(580.0, 420.0), ImGuiCond.Always)

--- a/examples/features/popup_window.das
+++ b/examples/features/popup_window.das
@@ -1,0 +1,111 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: popup_window — [container] for BeginPopup/EndPopup with manual open.
+//          Unlike popup_context_item (right-click on preceding item) or
+//          popup_context_window (right-click anywhere in window), popup_window
+//          has NO auto-trigger — the caller drives open_popup(str_id) on any
+//          custom predicate. Body runs only while ImGui reports the popup open.
+// SHOWS:   two buttons share str_id "fruit_picker"; each opens the same popup
+//          under its own with_id scope. The hover-region trigger demonstrates
+//          the cpp section 21 sub 2 pattern (IsMouseReleased(Right) +
+//          !IsAnyItemHovered, no preceding item involved).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/popup_window.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/popup_window.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/popup_window.das
+// =============================================================================
+
+var LAST_PICK : string = "(none yet)"
+
+[export]
+def init() {
+    harness_init("popup_window — container", 640, 480)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.5
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(580.0, 420.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "popup_window", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text("Two triggers share str_id \"fruit_picker\":")
+        bullet()
+        text("Left-click [Open via button] — explicit trigger.")
+        bullet()
+        text("Right-click the hover region — manual cpp-style trigger.")
+
+        // ----- Trigger 1: left-click button -----
+        with_id("via_button") {
+            if (button(OPEN_BTN, (text = "Open via button"))) {
+                open_popup("fruit_picker")
+            }
+            popup_window(BTN_POPUP, (str_id = "fruit_picker",
+                                     flags = ImGuiWindowFlags.None)) {
+                draw_picker_body()
+            }
+        }
+
+        separator()
+
+        // ----- Trigger 2: hover region + right-click (no preceding item) -----
+        with_id("via_region") {
+            text(HOVER_HINT, (text = "(hover this region, then right-click)"))
+            let region_min = GetItemRectMin()
+            let region_max = GetItemRectMax()
+            let in_region = (IsMouseHoveringRect(region_min, region_max, true) &&
+                             !IsAnyItemHovered())
+            if (in_region && IsMouseReleased(ImGuiMouseButton.Right)) {
+                open_popup("fruit_picker")
+            }
+            popup_window(REG_POPUP, (str_id = "fruit_picker",
+                                     flags = ImGuiWindowFlags.None)) {
+                draw_picker_body()
+            }
+        }
+
+        separator()
+        text("Last pick: {LAST_PICK}")
+    }
+
+    harness_end_frame()
+}
+
+def private draw_picker_body() {
+    text("Pick a fruit:")
+    if (menu_label(PICK_APPLE, (text = "Apple"))) {
+        LAST_PICK = "Apple"
+        close_current_popup()
+    }
+    if (menu_label(PICK_BANANA, (text = "Banana"))) {
+        LAST_PICK = "Banana"
+        close_current_popup()
+    }
+    if (menu_label(PICK_CHERRY, (text = "Cherry"))) {
+        LAST_PICK = "Cherry"
+        close_current_popup()
+    }
+    separator()
+    if (button(CLOSE_BTN, (text = "Close"))) {
+        close_current_popup()
+    }
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/imgui_demo/tables.das
+++ b/examples/imgui_demo/tables.das
@@ -363,6 +363,10 @@ var private TABLES_CM2_DOT_CLOSE : table<int; ClickState>
 var private TABLES_CM2_HOVERED_TEXT : NarrativeState
 // "MyPopup" string-id stateless popup variables — 4 columns (3 + 1 trailing-unused).
 var private TABLES_CM2_HOVERED_COLUMN : int = -1
+// Per-column popup_window state — shared str_id "MyPopup", disambiguated by with_id(column).
+var private TABLES_CM2_COL_POPUP : table<int; PopupWindowState>
+var private TABLES_CM2_COL_TEXT  : table<int; NarrativeState>
+var private TABLES_CM2_COL_CLOSE : table<int; ClickState>
 
 // ---- Section 22 Synced instances state ----
 var private TABLES_SYNCED_FLAGS : int = int(ImGuiTableFlags.Resizable |
@@ -1107,7 +1111,7 @@ def private edit_table_sizing_flags(var p_flags : int? implicit; id : string) {
                              int(ImGuiTableFlags.SizingFixedSame),
                              int(ImGuiTableFlags.SizingStretchProp),
                              int(ImGuiTableFlags.SizingStretchSame))
-    var current = 0
+    var current : int
     unsafe { current = *p_flags & policy_mask; }
     var idx = 0
     for (n in range(5)) {
@@ -2302,28 +2306,36 @@ def private show_context_menus() {
                 }
             }
 
-            // Per-column right-click popup. cpp iterates COLUMNS_COUNT + 1
-            // including the trailing unused space. The popup ID is a
-            // string-id ("MyPopup") shared across all per-column triggers —
-            // only one column is hovered at a time so they never overlap.
-            // PushID(column) keeps the popup's per-column ID disjoint.
-            // Status: simplified to track-hovered-column-only in das; the
-            // cpp manual `IsMouseReleased(1)` + `OpenPopup("MyPopup")` +
-            // `BeginPopup("MyPopup")` pattern doesn't lift to the boost
-            // surface without a stateless `popup_window` wrapper that we
-            // don't have. Falls back to the default per-column context
-            // menu (provided by table_headers_row above) plus a
-            // hovered-column readout below.
+            // Per-column right-click popup — cpp iterates COLUMNS_COUNT + 1
+            // (3 real columns + 1 trailing-unused space). All iterations
+            // share the str_id "MyPopup"; with_id(column) scopes ImGui's
+            // popup-id stack so each column owns its own open state.
+            // Trigger: hover-tracking + IsMouseReleased(Right) + !IsAnyItemHovered.
             var hovered = -1
-            for (column in range(column_count)) {
-                // cpp iterates COLUMNS_COUNT + 1 to special-case the
-                // trailing unused-space column; the das port simplified
-                // that away, so cap the loop at column_count —
-                // table_get_column_flags(column_count) asserts on a
-                // 3-column table (valid indices: -1 or 0..N-1).
-                if ((int(table_get_column_flags(column)) &
-                     int(ImGuiTableColumnFlags.IsHovered)) != 0) {
-                    hovered = column
+            for (column in range(column_count + 1)) {
+                with_id("cm2_col_{column}") {
+                    if ((int(table_get_column_flags(column)) &
+                         int(ImGuiTableColumnFlags.IsHovered)) != 0) {
+                        hovered = column
+                    }
+                    if (hovered == column && !IsAnyItemHovered() &&
+                        IsMouseReleased(ImGuiMouseButton.Right)) {
+                        open_popup("MyPopup")
+                    }
+                    popup_window(TABLES_CM2_COL_POPUP[column],
+                                 (str_id = "MyPopup",
+                                  flags = ImGuiWindowFlags.None)) {
+                        if (column == column_count) {
+                            text(TABLES_CM2_COL_TEXT[column],
+                                 (text = "This is a custom popup for unused space after the last column."))
+                        } else {
+                            text(TABLES_CM2_COL_TEXT[column],
+                                 (text = "This is a custom popup for Column {column}"))
+                        }
+                        if (button(TABLES_CM2_COL_CLOSE[column], (text = "Close"))) {
+                            close_current_popup()
+                        }
+                    }
                 }
             }
             TABLES_CM2_HOVERED_COLUMN = hovered

--- a/examples/tutorial/popup_window.das
+++ b/examples/tutorial/popup_window.das
@@ -1,0 +1,144 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_id_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: popup_window — stateless BeginPopup/EndPopup with manual trigger.
+//
+//   popup_window(IDENT, (str_id = "..", flags = ..)) { body }
+//
+// Distinct from the auto-triggered relatives:
+//
+//   popup_context_item    — right-click on the preceding item opens the popup.
+//   popup_context_window  — right-click anywhere in the window opens it.
+//   popup_window          — NO auto-trigger; caller drives open_popup(str_id).
+//
+// The manual form maps the cpp pattern from `imgui_demo.cpp`'s table-context
+// section: one shared str_id, multiple PushID-scoped instances, custom
+// hover/key/release predicates feeding the same OpenPopup call.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/popup_window.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/popup_window.das
+// =============================================================================
+
+var private LAST_PICK : string = "(none yet)"
+
+[export]
+def init() {
+    live_create_window("dasImgui popup_window tutorial", 640, 420)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(40.0f, 40.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(560.0f, 340.0f), ImGuiCond.Always)
+    window(PW_WIN, (text = "popup_window", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+        text("Two scopes share str_id \"fruit_picker\":")
+
+        // Scope A: explicit click trigger.
+        with_id("via_button") {
+            if (button(PW_BTN, (text = "Open via button"))) {
+                open_popup("fruit_picker")
+            }
+            popup_window(PW_BTN_POPUP, (str_id = "fruit_picker",
+                                        flags = ImGuiWindowFlags.None)) {
+                draw_picker_body()
+            }
+        }
+
+        separator()
+
+        // Scope B: hover-region + right-click — no preceding item involved.
+        with_id("via_region") {
+            text(PW_HOVER, (text = "(hover this region, right-click)"))
+            let region_min = GetItemRectMin()
+            let region_max = GetItemRectMax()
+            let in_region = (IsMouseHoveringRect(region_min, region_max, true) &&
+                             !IsAnyItemHovered())
+            if (in_region && IsMouseReleased(ImGuiMouseButton.Right)) {
+                open_popup("fruit_picker")
+            }
+            popup_window(PW_REG_POPUP, (str_id = "fruit_picker",
+                                        flags = ImGuiWindowFlags.None)) {
+                draw_picker_body()
+            }
+        }
+
+        separator()
+        text(PW_STATUS, (text = "Last pick: {LAST_PICK}"))
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+def private draw_picker_body() {
+    text("Pick a fruit:")
+    if (menu_label(PW_APPLE, (text = "Apple"))) {
+        LAST_PICK = "Apple"
+        close_current_popup()
+    }
+    if (menu_label(PW_BANANA, (text = "Banana"))) {
+        LAST_PICK = "Banana"
+        close_current_popup()
+    }
+    if (menu_label(PW_CHERRY, (text = "Cherry"))) {
+        LAST_PICK = "Cherry"
+        close_current_popup()
+    }
+    separator()
+    if (button(PW_CLOSE, (text = "Close"))) {
+        close_current_popup()
+    }
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/tests/integration/record_popup_window.das
+++ b/tests/integration/record_popup_window.das
@@ -1,0 +1,124 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``popup_window.apng``. One shell:
+//!
+//!     bin/Release/daslang.exe -project_root <dasimgui> \
+//!         <dasimgui>/tests/integration/record_popup_window.das
+
+let NARRATE_FRAMES = 200
+let READ_MS    = 3500u
+let SETTLE_MS  = 1500u
+let RESULT_MS  = 1500u
+let TAIL_MS    = 1500u
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/features/popup_window.das",
+                       "popup_window.apng", 35) $(app) {
+        let T_OPEN_BTN = "MAIN_WIN/via_button/OPEN_BTN"
+        let T_HINT     = "MAIN_WIN/via_region/HOVER_HINT"
+
+        var snap = wait_for_render(app, T_OPEN_BTN, 10.0f)
+        if (snap == null) {
+            panic("{T_OPEN_BTN} never rendered — wrong app running?")
+        }
+        let p_open  = widget_center(snap, T_OPEN_BTN)
+        let p_hint  = widget_center(snap, T_HINT)
+
+        // ---- Stage 1: introduce the manual-trigger pattern ----
+        post_command(app, "imgui_narrate", JV((
+            text = "popup_window has no auto-trigger — caller drives open_popup.",
+            target = T_OPEN_BTN,
+            frames = NARRATE_FRAMES
+        )))
+        move_to(app, p_open)
+        sleep(READ_MS)
+
+        // ---- Stage 2: left-click → BTN_POPUP opens ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Click fires open_popup(\"fruit_picker\"); popup_window brackets the body.",
+            target = T_OPEN_BTN,
+            frames = NARRATE_FRAMES
+        )))
+        var click_events : array<JsonValue?>
+        click_events |> click_at(0, p_open)
+        post_command(app, "imgui_mouse_play", JV((events = click_events)))
+        sleep(RESULT_MS)
+
+        // Re-snapshot to find the freshly-opened popup body widget bboxes.
+        var snap2 = wait_for_render(app,
+            "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE", 5.0f)
+        if (snap2 == null) {
+            panic("BTN_POPUP body never rendered — click didn't open the popup?")
+        }
+        let p_apple = widget_center(snap2, "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE")
+
+        // ---- Stage 3: pick a fruit → close_current_popup closes the popup ----
+        post_command(app, "imgui_narrate", JV((
+            text = "menu_label fires close_current_popup; popup closes, status updates.",
+            target = "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE",
+            frames = NARRATE_FRAMES
+        )))
+        var apple_events : array<JsonValue?>
+        apple_events |> click_at(0, p_apple)
+        post_command(app, "imgui_mouse_play", JV((events = apple_events)))
+        sleep(RESULT_MS)
+
+        // ---- Stage 4: highlight the hover-region scope ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Second scope shares the same str_id; with_id keeps each scope's open state distinct.",
+            target = T_HINT,
+            frames = NARRATE_FRAMES
+        )))
+        move_to(app, p_hint)
+        sleep(READ_MS)
+
+        // ---- Stage 5: right-click in the hover region → REG_POPUP opens ----
+        post_command(app, "imgui_narrate", JV((
+            text = "Right-click on the hover region — no preceding 'item' needed.",
+            target = T_HINT,
+            frames = NARRATE_FRAMES
+        )))
+        var rclick_events : array<JsonValue?>
+        rclick_events |> click_at(0, p_hint, 500, 1) //! button=1 → right
+        post_command(app, "imgui_mouse_play", JV((events = rclick_events)))
+        sleep(RESULT_MS)
+
+        var snap3 = wait_for_render(app,
+            "MAIN_WIN/via_region/REG_POPUP/PICK_BANANA", 5.0f)
+        if (snap3 == null) {
+            panic("REG_POPUP body never rendered — right-click didn't open the popup?")
+        }
+        let p_banana = widget_center(snap3,
+            "MAIN_WIN/via_region/REG_POPUP/PICK_BANANA")
+
+        var banana_events : array<JsonValue?>
+        banana_events |> click_at(0, p_banana)
+        post_command(app, "imgui_mouse_play", JV((events = banana_events)))
+        sleep(RESULT_MS)
+        sleep(TAIL_MS)
+    }
+}

--- a/tests/integration/record_popup_window.das
+++ b/tests/integration/record_popup_window.das
@@ -69,7 +69,9 @@ def main {
         sleep(RESULT_MS)
 
         // Re-snapshot to find the freshly-opened popup body widget bboxes.
-        var snap2 = wait_for_render(app,
+        // wait_for_widget gates on path EXISTENCE (vs wait_for_render's
+        // `?? true` which silently passes when the indexed-path is absent).
+        var snap2 = wait_for_widget(app,
             "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE", 5.0f)
         if (snap2 == null) {
             panic("BTN_POPUP body never rendered — click didn't open the popup?")
@@ -107,7 +109,7 @@ def main {
         post_command(app, "imgui_mouse_play", JV((events = rclick_events)))
         sleep(RESULT_MS)
 
-        var snap3 = wait_for_render(app,
+        var snap3 = wait_for_widget(app,
             "MAIN_WIN/via_region/REG_POPUP/PICK_BANANA", 5.0f)
         if (snap3 == null) {
             panic("REG_POPUP body never rendered — right-click didn't open the popup?")

--- a/tests/integration/test_popup_window.das
+++ b/tests/integration/test_popup_window.das
@@ -1,0 +1,54 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `popup_window` — stateless [container] for the
+//! manual-trigger BeginPopup/EndPopup pattern (caller drives open_popup,
+//! ImGui owns the open state by str_id). Verifies both shared-str_id popup
+//! instances register, and that clicking the explicit trigger surfaces the
+//! popup body widgets at the expected scoped path.
+
+let POPUP_WINDOW_FEATURE = "modules/dasImgui/examples/features/popup_window.das"
+
+[test]
+def test_popup_window_smoke(t : T?) {
+    with_imgui_app(POPUP_WINDOW_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN/via_button/OPEN_BTN", 15.0f)
+        t |> success(snap0 != null, "OPEN_BTN registers under with_id(via_button) scope")
+        if (snap0 == null) return
+
+        // Both popup_window instances register every frame via stateless_finalize,
+        // regardless of open/closed.
+        let btn_entry = find_widget(snap0, "MAIN_WIN/via_button/BTN_POPUP")
+        t |> equal(btn_entry?["kind"] ?? "", "popup_window",
+                   "BTN_POPUP.kind == 'popup_window'")
+        let reg_entry = find_widget(snap0, "MAIN_WIN/via_region/REG_POPUP")
+        t |> equal(reg_entry?["kind"] ?? "", "popup_window",
+                   "REG_POPUP.kind == 'popup_window'")
+    }
+}
+
+[test]
+def test_popup_window_button_opens(t : T?) {
+    with_imgui_app(POPUP_WINDOW_FEATURE) $(d) {
+        var snap0 = wait_for_widget(d, "MAIN_WIN/via_button/OPEN_BTN", 15.0f)
+        t |> success(snap0 != null, "feature ready")
+        if (snap0 == null) return
+
+        // Click OPEN_BTN. The button handler calls open_popup("fruit_picker");
+        // popup_window brackets the body on the next frame, so PICK_APPLE
+        // appears in the snapshot at the scoped path.
+        click(d, "MAIN_WIN/via_button/OPEN_BTN")
+        var snap_open = wait_until(d, 300) $(var snap) {
+            return widget_rendered(snap, "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE")
+        }
+        t |> success(snap_open != null,
+                     "click OPEN_BTN opens BTN_POPUP body (PICK_APPLE visible)")
+    }
+}

--- a/tests/integration/test_popup_window.das
+++ b/tests/integration/test_popup_window.das
@@ -45,8 +45,10 @@ def test_popup_window_button_opens(t : T?) {
         // popup_window brackets the body on the next frame, so PICK_APPLE
         // appears in the snapshot at the scoped path.
         click(d, "MAIN_WIN/via_button/OPEN_BTN")
+        // wait for path EXISTENCE — widget_rendered's `?? true` falsely
+        // passes when the indexed-path doesn't exist (popup still closed).
         var snap_open = wait_until(d, 300) $(var snap) {
-            return widget_rendered(snap, "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE")
+            return widget_exists(snap, "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE")
         }
         t |> success(snap_open != null,
                      "click OPEN_BTN opens BTN_POPUP body (PICK_APPLE visible)")

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -528,6 +528,15 @@ struct PopupContextWindowState {
     @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
 }
 
+struct PopupWindowState {
+    //! Backs `popup_window`. Stateless `BeginPopup`/`EndPopup` wrapper for
+    //! the manual-trigger pattern — caller drives `open_popup(str_id, flags)`
+    //! themselves (typically on hover + mouse-release), then `popup_window`
+    //! brackets the body when ImGui reports the popup as open. ImGui owns
+    //! the open/close lifecycle by `str_id`, so no pending flags here.
+    @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
+}
+
 struct TextFilterState {
     //! Backs `text_filter`. Holds the bound C++ `ImGuiTextFilter` value
     //! inline — zero-init is safe (empty `InputBuf`, empty `Filters`
@@ -1125,7 +1134,7 @@ def private with_await(input : JsonValue?; payload : auto(P)) : JsonValue? {
 def private extract_string_field(obj : JsonValue?; name : string) : string {
     let v = obj?[name]
     if (v == null || !(v.value is _string)) return ""
-    return string(v.value as _string)
+    return v.value as _string
 }
 
 def private widget_meta_jv(path_key : string; meta : WidgetMeta) : JsonValue? {

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -342,6 +342,38 @@ def popup_context_window(var state : PopupContextWindowState; str_id : string;
 }
 
 [container]
+def popup_window(var state : PopupWindowState; str_id : string;
+                 flags : ImGuiWindowFlags; blk : block) {
+    //! `BeginPopup(str_id, flags)` / `EndPopup()` — stateless manual-trigger
+    //! pairing. Unlike `popup_context_item`/`popup_context_window` (which
+    //! attach an auto-trigger to a preceding item or the enclosing window),
+    //! `popup_window` does NOT open itself. Caller drives opening via
+    //! `open_popup(str_id, flags)` — typically on a hover + mouse-release
+    //! check, or any other custom predicate. Body runs only while ImGui
+    //! reports the popup as open under `str_id`.
+    //!
+    //! When the same `str_id` is reused under different `PushID` scopes
+    //! (e.g. one logical popup per loop iteration with shared text), each
+    //! scope keeps its own open state — see `examples/features/popup_window.das`.
+    //!
+    //! IDENT-vs-str_id ID stacking: the boost ``[container]`` prelude
+    //! pushes ``widget_ident`` onto ImGui's ID stack before the body runs,
+    //! but ``OpenPopup(str_id)`` was called by the caller OUTSIDE that
+    //! push. To keep BeginPopup's hash matching the caller's OpenPopup
+    //! hash, ``popup_window`` peels ``widget_ident`` off the ID stack just
+    //! around ``BeginPopup``/``EndPopup`` — the body still renders under
+    //! the pushed IDENT so child widgets remain disambiguated.
+    PopID()
+    let im_open = BeginPopup(str_id, flags)
+    PushID(widget_ident)
+    if (im_open) {
+        invoke(blk)
+        EndPopup()
+    }
+    stateless_finalize(widget_ident, "popup_window", state)
+}
+
+[container]
 def popup_modal(var state : PopupState; text : string; closable : bool;
                 flags : ImGuiWindowFlags; blk : block) {
     //! `BeginPopupModal(name, p_open, flags)` / `EndPopup()`. Same lifecycle


### PR DESCRIPTION
## Summary

Closes cpp `imgui_demo.cpp` Tables "Context menus" section 2's partial-port deferred in PR-D (#52). The per-column `"MyPopup"` shared-str_id loop now runs 1:1 against the boost surface via a new stateless `popup_window` `[container]`.

### What landed

- `widgets/imgui_containers_builtin.das` — new `[container] popup_window(IDENT, str_id, flags) $blk` brackets `BeginPopup`/`EndPopup`. Stateless — caller drives `open_popup(str_id, flags)` from any custom predicate (hover-region + right-click, key press, …).
- `widgets/imgui_boost_runtime.das` — `PopupWindowState` (empty marker; ImGui owns the open lifecycle by str_id).
- `examples/imgui_demo/tables.das` — Section 21 "Context menus" sub 2 restored to full cpp shape (3 real columns + trailing-unused-space column).
- Triad: `examples/features/popup_window.das`, `examples/tutorial/popup_window.das`, `doc/source/tutorials/popup_window.rst` (+ toctree wire-up), `doc/source/_static/tutorials/popup_window.apng` (397 frames, 0 drops), `tests/integration/record_popup_window.das` driver, `tests/integration/test_popup_window.das` (registration + click-opens-popup gates).
- Two pre-existing lint hits surfaced on the touched files — fixed inline:
  - `examples/imgui_demo/tables.das:1114` LINT010 dead-store of `current` (declare-then-unsafe-assign).
  - `widgets/imgui_boost_runtime.das:1137` PERF020 redundant `string(...)` cast on a `_string` variant arm.

### Subtle bit worth flagging in review

The `[container]` macro injects `widget_prelude → PushID(widget_ident)` before the body runs. ImGui hashes popup IDs against the current ID stack, so a caller doing `open_popup("fruit_picker")` *outside* `popup_window` and a `BeginPopup("fruit_picker")` *inside* (after the prelude push) hash under different stacks — the popup never visibly opens. `popup_window` works around this by peeling `widget_ident` off just around `BeginPopup`:

```das
PopID()
let im_open = BeginPopup(str_id, flags)
PushID(widget_ident)        // restored for body widgets + container_finalize's PopID
if (im_open) { invoke(blk); EndPopup() }
stateless_finalize(...)
```

`EndPopup` doesn't read the ID stack, so the asymmetric brace is fine. Verified end-to-end via daslang-live + `imgui_click`:

- Click `MAIN_WIN/via_button/OPEN_BTN` → next snapshot shows `MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE` rendered with a real bbox.
- Click `MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE` → `MAIN_WIN/:73:8` text flips to `"Last pick: Apple"`, popup auto-closes via `close_current_popup()`.

## Test plan

- [x] All 7 changed/added `.das` files lint-clean (`mcp__daslang__lint`)
- [x] All changed files compile (`mcp__daslang__compile_check`)
- [x] `format_file` reports `already_formatted` on all 7 files
- [x] popup_window opens + closes verified via daslang-live + `imgui_click` snapshots
- [x] APNG recording produces 397 frames / 0 drops over 14.9s
- [x] `examples/imgui_demo/tables.das` §21 sub 2 still compiles after the rewrite
- [ ] CI integration suite green
- [ ] CI docs build green (with the new APNG referenced by `popup_window.rst`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)