### PR TITLE
imgui_demo: wire real menubar — Menu / Examples / Tools

### DIFF
--- a/examples/imgui_demo/imgui_demo.das
+++ b/examples/imgui_demo/imgui_demo.das
@@ -26,37 +26,103 @@ require app_dockspace public
 require app_documents public
 require app_small public
 
-// Module-scope toggles for the Example App panels. A full Examples menu
-// wiring (matching imgui_demo.cpp's `ImGui::ShowDemoWindow` Examples
-// submenu) waits for the remaining example-app stubs to be ported; for
-// now each gets its own checkbox at the bottom of the demo window.
-var private SHOW_APP_CONSOLE = false
-var private SHOW_APP_LOG = false
-var private SHOW_APP_LAYOUT = false
-var private SHOW_APP_PROPERTY_EDITOR = false
-var private SHOW_APP_LONG_TEXT = false
-var private SHOW_APP_AUTO_RESIZE = false
-var private SHOW_APP_CONSTRAINED_RESIZE = false
-var private SHOW_APP_SIMPLE_OVERLAY = false
-var private SHOW_APP_FULLSCREEN = false
-var private SHOW_APP_WINDOW_TITLES = false
-var private SHOW_APP_CUSTOM_RENDERING = false
-var private SHOW_APP_DOCKSPACE = false
-var private SHOW_APP_DOCUMENTS = false
-
 // Mirrors imgui_demo.cpp:275-6455 — void ImGui::ShowDemoWindow(bool* p_open).
 // Renamed to avoid collision with ImGui's built-in ShowDemoWindow binding.
-// Phase 2a skeleton: opens the demo window and calls the six Demo-Window
-// sub-sections via CollapsingHeader gates. Example-app / tool toggles
-// (Examples menu, Tools menu) are wired as section files come online.
+//
+// The window carries a MenuBar with three sub-menus:
+//   Menu     — calls ShowExampleMenuFile() (shared with the modals demos
+//              and ShowExampleAppMainMenuBar).
+//   Examples — toggles for the 13 mini-app / app windows (Main menu bar +
+//              8 small apps + 4 full apps).
+//   Tools    — toggles for Metrics / Debug Log / ID Stack / Style Editor /
+//              About; each pops its own ImGui-native window via the
+//              ShowMetricsWindow / ShowDebugLogWindow / etc. bindings.
+//
+// Beneath the menubar, the six demo-window section dispatchers render in
+// order (Widgets, Layout, Popups, Tables, Columns, Inputs).
+//
+// All toggle state lives in plain module-scope vars (NOT widget state) so
+// the dispatch can read them directly outside the window's body — the
+// `edit_menu_item` rail takes a `safe_addr`-owned `bool?` and the Show*
+// windows take `bool?` too, so the same address chains through both.
+
+// Examples-menu toggles — 13 entries (1 main menu bar + 8 small + 4 full).
+var SHOW_APP_MAIN_MENU_BAR = false
+var SHOW_APP_CONSOLE = false
+var SHOW_APP_CUSTOM_RENDERING = false
+var SHOW_APP_DOCKSPACE = false
+var SHOW_APP_DOCUMENTS = false
+var SHOW_APP_LOG = false
+var SHOW_APP_PROPERTY_EDITOR = false
+var SHOW_APP_LAYOUT = false
+var SHOW_APP_SIMPLE_OVERLAY = false
+var SHOW_APP_AUTO_RESIZE = false
+var SHOW_APP_CONSTRAINED_RESIZE = false
+var SHOW_APP_FULLSCREEN = false
+var SHOW_APP_LONG_TEXT = false
+var SHOW_APP_WINDOW_TITLES = false
+
+// Tools-menu toggles — 5 entries pointing at the ImGui-native windows.
+var SHOW_TOOL_METRICS = false
+var SHOW_TOOL_DEBUG_LOG = false
+var SHOW_TOOL_ID_STACK = false
+var SHOW_TOOL_STYLE_EDITOR = false
+var SHOW_TOOL_ABOUT = false
+
 def RunImGuiDemo() {
-    window(DEMO_WIN, (text = "Dear ImGui Demo (daslang port — Phase 2a skeleton)",
-                       closable = false, flags = ImGuiWindowFlags.None)) {
-        text("Phase 2a skeleton — 0/24 SECTION blocks ported + 5 example apps (Console, Log, Custom Rendering, DockSpace, Documents).")
-        text("Section stubs render below; example apps and meta windows are")
-        text("not yet wired into the menu — temporary checkboxes at the bottom")
-        text("toggle individual app windows.")
-        separator(DEMO_SEP_HEADER)
+    window(DEMO_WIN, (text = "Dear ImGui Demo (daslang port)",
+                      closable = false,
+                      flags = ImGuiWindowFlags.MenuBar)) {
+        menu_bar(DEMO_MENU_BAR) {
+            menu(DEMO_MENU_FILE, (text = "Menu", enabled = true)) {
+                ShowExampleMenuFile()
+            }
+            menu(DEMO_MENU_EXAMPLES, (text = "Examples", enabled = true)) {
+                edit_menu_item(safe_addr(SHOW_APP_MAIN_MENU_BAR),
+                    (id = "EX_MAIN_MENU_BAR", text = "Main menu bar"))
+                separator_text(DEMO_EX_SEP_MINI, "Mini apps")
+                edit_menu_item(safe_addr(SHOW_APP_CONSOLE),
+                    (id = "EX_CONSOLE", text = "Console"))
+                edit_menu_item(safe_addr(SHOW_APP_CUSTOM_RENDERING),
+                    (id = "EX_CUSTOM_RENDERING", text = "Custom rendering"))
+                edit_menu_item(safe_addr(SHOW_APP_DOCKSPACE),
+                    (id = "EX_DOCKSPACE", text = "Dockspace"))
+                edit_menu_item(safe_addr(SHOW_APP_DOCUMENTS),
+                    (id = "EX_DOCUMENTS", text = "Documents"))
+                edit_menu_item(safe_addr(SHOW_APP_LOG),
+                    (id = "EX_LOG", text = "Log"))
+                edit_menu_item(safe_addr(SHOW_APP_PROPERTY_EDITOR),
+                    (id = "EX_PROP_ED", text = "Property editor"))
+                edit_menu_item(safe_addr(SHOW_APP_LAYOUT),
+                    (id = "EX_LAYOUT", text = "Simple layout"))
+                edit_menu_item(safe_addr(SHOW_APP_SIMPLE_OVERLAY),
+                    (id = "EX_OVERLAY", text = "Simple overlay"))
+                separator_text(DEMO_EX_SEP_CONCEPTS, "Concepts")
+                edit_menu_item(safe_addr(SHOW_APP_AUTO_RESIZE),
+                    (id = "EX_AUTO_RESIZE", text = "Auto-resizing window"))
+                edit_menu_item(safe_addr(SHOW_APP_CONSTRAINED_RESIZE),
+                    (id = "EX_CONSTR_RESIZE", text = "Constrained-resizing window"))
+                edit_menu_item(safe_addr(SHOW_APP_FULLSCREEN),
+                    (id = "EX_FULLSCREEN", text = "Fullscreen window"))
+                edit_menu_item(safe_addr(SHOW_APP_LONG_TEXT),
+                    (id = "EX_LONG_TEXT", text = "Long text display"))
+                edit_menu_item(safe_addr(SHOW_APP_WINDOW_TITLES),
+                    (id = "EX_WIN_TITLES", text = "Manipulating window titles"))
+            }
+            menu(DEMO_MENU_TOOLS, (text = "Tools", enabled = true)) {
+                edit_menu_item(safe_addr(SHOW_TOOL_METRICS),
+                    (id = "TOOL_METRICS", text = "Metrics/Debugger"))
+                edit_menu_item(safe_addr(SHOW_TOOL_DEBUG_LOG),
+                    (id = "TOOL_DEBUG_LOG", text = "Debug Log"))
+                edit_menu_item(safe_addr(SHOW_TOOL_ID_STACK),
+                    (id = "TOOL_ID_STACK", text = "ID Stack Tool"))
+                edit_menu_item(safe_addr(SHOW_TOOL_STYLE_EDITOR),
+                    (id = "TOOL_STYLE_ED", text = "Style Editor"))
+                separator(DEMO_TOOLS_SEP)
+                edit_menu_item(safe_addr(SHOW_TOOL_ABOUT),
+                    (id = "TOOL_ABOUT", text = "About Dear ImGui"))
+            }
+        }
 
         ShowDemoWindowWidgets()
         ShowDemoWindowLayout()
@@ -64,37 +130,12 @@ def RunImGuiDemo() {
         ShowDemoWindowTables()
         ShowDemoWindowColumns()
         ShowDemoWindowInputs()
-
-        separator(DEMO_SEP_FOOTER)
-        edit_checkbox(safe_addr(SHOW_APP_CONSOLE),
-                      (id = "EXAMPLES_SHOW_CONSOLE", text = "Show Example: Console"))
-        edit_checkbox(safe_addr(SHOW_APP_LOG),
-                      (id = "EXAMPLES_SHOW_LOG", text = "Show Example: Log"))
-        edit_checkbox(safe_addr(SHOW_APP_LAYOUT),
-                      (id = "EXAMPLES_SHOW_LAYOUT", text = "Show Example: Simple Layout"))
-        edit_checkbox(safe_addr(SHOW_APP_PROPERTY_EDITOR),
-                      (id = "EXAMPLES_SHOW_PROPED", text = "Show Example: Property Editor"))
-        edit_checkbox(safe_addr(SHOW_APP_LONG_TEXT),
-                      (id = "EXAMPLES_SHOW_LONG_TEXT", text = "Show Example: Long Text"))
-        edit_checkbox(safe_addr(SHOW_APP_AUTO_RESIZE),
-                      (id = "EXAMPLES_SHOW_AUTO_RESIZE", text = "Show Example: Auto-resizing Window"))
-        edit_checkbox(safe_addr(SHOW_APP_CONSTRAINED_RESIZE),
-                      (id = "EXAMPLES_SHOW_CONSTR_RESIZE", text = "Show Example: Constrained Resize"))
-        edit_checkbox(safe_addr(SHOW_APP_SIMPLE_OVERLAY),
-                      (id = "EXAMPLES_SHOW_OVERLAY", text = "Show Example: Simple Overlay"))
-        edit_checkbox(safe_addr(SHOW_APP_FULLSCREEN),
-                      (id = "EXAMPLES_SHOW_FULLSCREEN", text = "Show Example: Fullscreen Window"))
-        edit_checkbox(safe_addr(SHOW_APP_WINDOW_TITLES),
-                      (id = "EXAMPLES_SHOW_TITLES", text = "Show Example: Manipulating Window Titles"))
-        edit_checkbox(safe_addr(SHOW_APP_CUSTOM_RENDERING),
-                      (id = "EXAMPLES_SHOW_CUSTOM_RENDERING", text = "Show Example: Custom Rendering"))
-        edit_checkbox(safe_addr(SHOW_APP_DOCKSPACE),
-                      (id = "EXAMPLES_SHOW_DOCKSPACE", text = "Show Example: DockSpace"))
-        edit_checkbox(safe_addr(SHOW_APP_DOCUMENTS),
-                      (id = "EXAMPLES_SHOW_DOCUMENTS", text = "Show Example: Documents"))
     }
 
     // Example-app windows live OUTSIDE the demo window — each opens its own.
+    if (SHOW_APP_MAIN_MENU_BAR) {
+        ShowExampleAppMainMenuBar()
+    }
     if (SHOW_APP_CONSOLE) {
         ShowExampleAppConsole()
         // Console's "Close Console" title-bar context menu sets an internal
@@ -109,7 +150,7 @@ def RunImGuiDemo() {
     }
     // app_small entries — each ShowExampleApp* returns true while open and
     // false when the user clicked X. Mirror the return value back to the
-    // toggle so the checkbox stays in sync.
+    // toggle so the menu check-mark stays in sync.
     if (SHOW_APP_LAYOUT && !ShowExampleAppLayout()) {
         SHOW_APP_LAYOUT = false
     }
@@ -135,8 +176,6 @@ def RunImGuiDemo() {
     if (SHOW_APP_WINDOW_TITLES) {
         ShowExampleAppWindowTitles()
     }
-    // PR-C/2: three example apps. All three return bool — false when the
-    // window's X-button or local menu close fires.
     if (SHOW_APP_CUSTOM_RENDERING && !ShowExampleAppCustomRendering()) {
         SHOW_APP_CUSTOM_RENDERING = false
     }
@@ -145,5 +184,33 @@ def RunImGuiDemo() {
     }
     if (SHOW_APP_DOCUMENTS && !ShowExampleAppDocuments()) {
         SHOW_APP_DOCUMENTS = false
+    }
+
+    // Tools menu — each Show*Window mutates its bool? when the user clicks X
+    // on the tool window's titlebar, so the menu check-mark auto-syncs.
+    if (SHOW_TOOL_METRICS) {
+        ShowMetricsWindow(safe_addr(SHOW_TOOL_METRICS))
+    }
+    if (SHOW_TOOL_DEBUG_LOG) {
+        ShowDebugLogWindow(safe_addr(SHOW_TOOL_DEBUG_LOG))
+    }
+    if (SHOW_TOOL_ID_STACK) {
+        ShowIDStackToolWindow(safe_addr(SHOW_TOOL_ID_STACK))
+    }
+    if (SHOW_TOOL_STYLE_EDITOR) {
+        window(DEMO_STYLE_ED_WIN, (text = "Dear ImGui Style Editor",
+                                    closable = true,
+                                    flags = ImGuiWindowFlags.None)) {
+            style_editor::ShowStyleEditor()
+        }
+        // Style Editor uses [container] WindowState — close via window's X
+        // flips DEMO_STYLE_ED_WIN.open false; mirror back to the toggle.
+        if (!DEMO_STYLE_ED_WIN.open) {
+            SHOW_TOOL_STYLE_EDITOR = false
+            DEMO_STYLE_ED_WIN.open = true
+        }
+    }
+    if (SHOW_TOOL_ABOUT) {
+        ShowAboutWindow(safe_addr(SHOW_TOOL_ABOUT))
     }
 }

--- a/examples/imgui_demo/layout.das
+++ b/examples/imgui_demo/layout.das
@@ -35,15 +35,11 @@ require math
 //   - HelpMarker(...) text inlined via item_tooltip on a "(?)" text_disabled,
 //     mirroring widgets.das.
 //
-// Skipped vs C++ (each cited at the relevant location below):
+// Workarounds vs C++ (each cited at the relevant location below):
 //   - cpp:3604: DragFloat2 on a `ImVec2 size` (struct field-pair). The
 //     edit_drag_float2 rail wants a `float2?`, and ImVec2's float-pair layout
 //     matches float2's, but addressing a stack ImVec2 as float2? would need
 //     a reinterpret bounce-buffer. Workaround: edit two separate floats.
-//   - cpp:3631-3656: the per-clip-region DrawList calls — AddRectFilled /
-//     AddText to the WindowDrawList. These render as InvisibleButton-only
-//     stubs; the drawlist rail (PR-B1) doesn't carry the per-region clip-rect
-//     overrides the C++ branch uses (PushClipRect-then-AddText). TODO Phase 3.
 //   - cpp:3392-3398: BeginChild("scrolling") re-entry trick to nudge scroll
 //     state from outside the child body. The `child_scroll_reenter(IDENT,
 //     text) { ... }` wrapper replicates the original `child(IDENT)` container's

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -1855,6 +1855,16 @@ def edit_checkbox(var ptr : bool? implicit; text : string = "") : bool {
 }
 
 [edit_widget]
+def edit_menu_item(var ptr : bool? implicit; text : string = "";
+                   shortcut : string = ""; enabled : bool = true) : bool {
+    //! ``MenuItem(label, shortcut, ptr, enabled)`` against a caller-owned ``bool?``. Mirrors ``edit_checkbox`` shape for menu contexts — the menu item shows a check mark while ``*ptr`` is true and toggles it on click. Caller owns persistence; no ``@live`` preservation. Required ``id="..."`` at the call site keys the telemetry path.
+    let lbl = empty(text) ? widget_ident : text
+    let changed = MenuItem(lbl, shortcut, ptr, enabled)
+    edit_finalize(widget_ident, "edit_menu_item", ptr)
+    return changed
+}
+
+[edit_widget]
 def edit_radio_button(var ptr : bool? implicit; text : string = "") : bool {
     //! Bool-form ``RadioButton`` against a caller-owned ``bool?``; the widget flips ``*ptr`` on click (ImGui's RadioButton-bool doesn't mutate). For grouped int-form radios, declare a ``RadioIntState`` and use ``radio_button_int``.
     let lbl = empty(text) ? widget_ident : text


### PR DESCRIPTION
## Summary

Replaces the temporary "13 checkboxes at the bottom of the demo window" shape with the cpp-parity menubar that `ShowDemoWindow` has carried since day one. Three menus live under the `DEMO_WIN` MenuBar:

- **Menu** — calls `ShowExampleMenuFile()` (shared with modals demos and the standalone `ShowExampleAppMainMenuBar`)
- **Examples** — 14 menu_items toggling the example-app windows. Adds **"Main menu bar"** (previously not wired) + `SeparatorText` dividers ("Mini apps" / "Concepts") matching cpp's layout.
- **Tools** — 5 menu_items hitting ImGui's native debug windows: Metrics / Debug Log / ID Stack / Style Editor / About. Each `bool?` flows through both `edit_menu_item` AND the `ShowMetricsWindow`/etc. binding, so closing a tool window via its X auto-syncs the menu check-mark.

## New rail

[widgets/imgui_widgets_builtin.das](widgets/imgui_widgets_builtin.das) — `edit_menu_item(var ptr : bool? implicit; text; shortcut=""; enabled=true)` — caller-owned bool? form of `menu_item`. Mirrors `edit_checkbox` shape; works with `safe_addr` against plain vars.

## Style Editor wiring

Wraps `style_editor::ShowStyleEditor()` inside a `[container] window(DEMO_STYLE_ED_WIN, closable=true)` so the user can close via X; mirrors `LAYOUT_HSZ_WIN`'s pattern. Module-qualified call disambiguates from the `imgui::ShowStyleEditor` binding.

## Stale-comment cleanup

- [imgui_demo.das](examples/imgui_demo/imgui_demo.das) header text `"Phase 2a skeleton — 0/24 SECTION blocks ported + 5 example apps"` gone (24/24 + 13/13 since PR #60)
- [layout.das](examples/imgui_demo/layout.das) header lost the "cpp:3631-3656 ... TODO Phase 3" entry — the drawlist clip-rect canvases landed in PR #61

## Verification

- `mcp__daslang__compile_check` / `lint` / `format_file` clean on all 3 files
- daslang-live boot 120 fps, `has_error=false`
- Snapshot confirms `DEMO_MENU_BAR / DEMO_MENU_{FILE,EXAMPLES,TOOLS}` register at `DEMO_WIN/DEMO_MENU_BAR/*`
- Screenshot shows the Menu / Examples / Tools labels rendering below the title bar and the bottom-of-window checkbox column gone

## Test plan

- [ ] CI green
- [ ] Smoke run `daslang-live modules/dasImgui/examples/imgui_demo/main.das` — title bar + menubar + 6 section headers, no bottom checkboxes
- [ ] Menu → File submenu opens (recursive — same code path as `ShowExampleAppMainMenuBar`)
- [ ] Examples → Main menu bar → standalone main menu bar window appears
- [ ] Examples → Console / Custom rendering / Log / Layout / Property editor / etc. each toggle a window
- [ ] Tools → Metrics/Debugger → ImGui Metrics window appears; close via X clears menu check
- [ ] Tools → Debug Log / ID Stack Tool / About → each opens
- [ ] Tools → Style Editor → window with style controls; close via X clears menu check

🤖 Generated with [Claude Code](https://claude.com/claude-code)