### PR TITLE
tutorials: 6 new container tutorials — Phase 3 backfill

### DIFF
--- a/doc/source/tutorials/child.rst
+++ b/doc/source/tutorials/child.rst
@@ -119,9 +119,13 @@ The B child uses ``AutoResizeY | FrameStyle``:
 
 Size's Y is ``0.0f`` — required when ``AutoResizeY`` is active so ImGui
 treats the slot as auto. The height grows to fit the body each frame.
-The recorded height (visible after the frame) lives at
-``AUTO_B.scroll_max.y + AUTO_B.scroll.y`` because ``scroll_max`` excludes
-the visible portion.
+
+``scroll`` and ``scroll_max`` both report (0, 0) for an AutoResize child:
+no overflow means no scroll range. To check the rendered height, read
+``AUTO_B.size.y`` after the frame — the wrapper writes it from the
+caller's input. (Content extent itself isn't directly exposed by
+ImGui's child API; if you need it, take a snapshot from inside the body
+via a sentinel widget at the end.)
 
 Horizontal scroll
 =================

--- a/doc/source/tutorials/child.rst
+++ b/doc/source/tutorials/child.rst
@@ -1,0 +1,176 @@
+.. _tutorial_child:
+
+#######################
+Child windows
+#######################
+
+``child`` brackets ``BeginChild``/``EndChild`` into a block-arg container —
+a sub-window that can be sized, bordered, scrolled, and addressed in the
+registry hierarchy. The wrapper's signature:
+
+.. code-block:: das
+
+   child(IDENT, (text = "...",
+                 size = float2(w, h),
+                 child_flags = ImGuiChildFlags....,
+                 window_flags = ImGuiWindowFlags....)) {
+       // body — leaves register under <window>/IDENT
+   }
+
+Three knobs do most of the work — ``size``, ``child_flags``, ``window_flags``
+— and the boost layer captures ``scroll`` / ``scroll_max`` each frame so a
+snapshot reports the current scroll position without polling.
+
+Source: ``examples/tutorial/child.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/child.apng
+   :alt: child recording
+
+.. literalinclude:: ../../../examples/tutorial/child.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_containers_builtin`` — defines ``child``,
+  ``child_scroll_reenter``.
+* ``imgui/imgui_widgets_builtin`` — ``text``, ``checkbox``, ``slider_int``.
+
+size — three sizing modes
+=========================
+
+The ``size : float2(w, h)`` argument has three flavors:
+
+* **Explicit positive** — ``size = float2(360.0f, 140.0f)`` — fixed
+  pixel size. The body's content is clipped to that region and scrollbars
+  appear if it overflows.
+* **Zero** — ``size = float2(0.0f, 0.0f)`` — auto-fit to the available
+  column/row. Pair with ``ImGuiChildFlags.AutoResizeX/Y`` to let the body
+  grow to the content extent instead.
+* **Negative** — ``size = float2(-FLT_MIN, 0.0f)`` — "fill the remaining
+  space minus that many pixels". Useful for stretchy panes that should fit
+  the parent.
+
+child_flags vs window_flags
+===========================
+
+``ImGuiChildFlags`` (the third arg) is child-specific:
+
+* ``Border`` — draw a one-pixel border around the region.
+* ``AutoResizeX`` / ``AutoResizeY`` — height/width tracks content extent.
+* ``AlwaysAutoResize`` — combine both axes and re-measure every frame.
+* ``FrameStyle`` — frame-style chrome (like input groups). Implies a
+  background and rounded corners drawn from the active style.
+* ``NavFlattened`` — keyboard nav treats the child as part of the parent.
+
+``ImGuiWindowFlags`` (the fourth arg) governs the child's scrollbar
+policy and window-level behavior:
+
+* ``HorizontalScrollbar`` — enable the bottom scroll track when content
+  overflows horizontally (default = none).
+* ``AlwaysVerticalScrollbar`` / ``AlwaysHorizontalScrollbar`` — keep
+  the bar visible even when the content fits.
+* ``NoMove`` / ``NoResize`` / ``NoBackground`` — standard window knobs.
+
+The two flag sets compose freely; pick from each based on the child's
+chrome and scroll needs.
+
+ChildState — what the snapshot reports
+======================================
+
+``ChildState`` captures four floats:
+
+.. code-block:: das
+
+   var SCROLL_A : ChildState
+   // After the frame renders:
+   //   SCROLL_A.size       : float2  // sticky — what was passed in
+   //   SCROLL_A.scroll     : float2  // current scroll (GetScrollX/Y)
+   //   SCROLL_A.scroll_max : float2  // GetScrollMaxX/Y for this content
+   //   SCROLL_A.child_flags / SCROLL_A.window_flags  // sticky
+
+Snapshot reports them under ``<window>/SCROLL_A``. Drivers that want to
+verify "the user scrolled to row 12" compare ``scroll.y`` against a
+known threshold. ``scroll_max`` is read AFTER the body invoke — it
+depends on the content extent, which the body just emitted.
+
+Auto-resize variants
+====================
+
+The B child uses ``AutoResizeY | FrameStyle``:
+
+.. code-block:: das
+
+   child(AUTO_B, (text = "auto_b",
+                  size = float2(360.0f, 0.0f),
+                  child_flags = ImGuiChildFlags.AutoResizeY | ImGuiChildFlags.FrameStyle,
+                  window_flags = ImGuiWindowFlags.None)) {
+       text("Three rows of input chrome")
+       checkbox(B_VSYNC, (text = "VSync"))
+       slider_int(B_LIMIT, (text = "frame limit"))
+   }
+
+Size's Y is ``0.0f`` — required when ``AutoResizeY`` is active so ImGui
+treats the slot as auto. The height grows to fit the body each frame.
+The recorded height (visible after the frame) lives at
+``AUTO_B.scroll_max.y + AUTO_B.scroll.y`` because ``scroll_max`` excludes
+the visible portion.
+
+Horizontal scroll
+=================
+
+``window_flags.HorizontalScrollbar`` enables the bottom track:
+
+.. code-block:: das
+
+   child(SCROLL_C, (text = "scroll_c",
+                   size = float2(720.0f, 90.0f),
+                   child_flags = ImGuiChildFlags.Border,
+                   window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+       text(LONG_LINE, (text = "very wide content: lorem ipsum..."))
+   }
+
+Without the flag, overlong single-line text would be clipped. With it,
+the user drags the bottom bar and ``SCROLL_C.scroll.x`` mirrors the
+position.
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials.
+
+Driving from outside
+====================
+
+External drivers can wheel-scroll the active child by posting an
+``imgui_mouse_scroll`` command (the live counterpart to
+``ImGui_ImplGlfw``'s wheel events):
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_mouse_scroll","args":{"x":0.0,"y":-3.0}}' \
+        localhost:9090/command
+
+The cursor must be over the child window for ImGui to attribute the
+scroll. The recording driver uses this exact channel to nudge
+``SCROLL_A`` between narration stages.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/child.das <../../../examples/tutorial/child.das>`
+
+   Features-side demo: ``examples/features/child_scroll_reenter.das`` — the
+   ``child_scroll_reenter`` helper for nudging an existing child's scroll
+   from outside its block.
+
+   Sibling: :ref:`tutorial_containers` — the umbrella tour of container
+   rails.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/child.rst
+++ b/doc/source/tutorials/child.rst
@@ -121,11 +121,12 @@ Size's Y is ``0.0f`` — required when ``AutoResizeY`` is active so ImGui
 treats the slot as auto. The height grows to fit the body each frame.
 
 ``scroll`` and ``scroll_max`` both report (0, 0) for an AutoResize child:
-no overflow means no scroll range. To check the rendered height, read
-``AUTO_B.size.y`` after the frame — the wrapper writes it from the
-caller's input. (Content extent itself isn't directly exposed by
-ImGui's child API; if you need it, take a snapshot from inside the body
-via a sentinel widget at the end.)
+no overflow means no scroll range. ``ChildState.size`` is the
+caller-provided input — for AutoResizeY it stays at ``(360.0f, 0.0f)``,
+so it does NOT tell you the rendered height. The wrapper does not
+currently expose the auto-computed extent; if you need it, call
+``GetWindowSize()`` inside the child body, or place a sentinel widget
+at the end and read its bbox bottom from the snapshot.
 
 Horizontal scroll
 =================

--- a/doc/source/tutorials/collapsing_header.rst
+++ b/doc/source/tutorials/collapsing_header.rst
@@ -14,9 +14,13 @@ close lifecycle. Two distinct gates govern visibility:
   sets ``state.open=false``. While ``state.open`` is false, **the whole
   header strip is hidden** (not just its body).
 
-The boost wrapper exposes both gates via the standard
-``pending_open`` / ``pending_close`` flags, so the live commands
-``imgui_open`` / ``imgui_close`` work on either dimension.
+The boost wrapper exposes one channel — ``pending_open`` /
+``pending_close`` — that drives the **chevron** (expanded gate). The
+live commands ``imgui_open`` / ``imgui_close`` ride that channel.
+``imgui_open`` additionally re-sets ``state.open=true`` so a previously
+X-hidden strip becomes visible again. ``imgui_close`` does NOT touch
+``state.open`` — to hide the strip, click the X-button or write
+``state.open=false`` from app code.
 
 Source: ``examples/tutorial/collapsing_header.das``.
 
@@ -122,23 +126,28 @@ Same convention as the other tutorials.
 Driving from outside
 ====================
 
-Both gates are driveable. To collapse-and-hide the closable header:
+To collapse the chevron (body stops rendering; the header strip stays
+visible):
 
 .. code-block:: bash
 
    curl -X POST -d '{"name":"imgui_close","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
         localhost:9090/command
 
-To bring it back:
+To re-expand the chevron — and, for a closable header that had been
+X-hidden, re-show the whole strip:
 
 .. code-block:: bash
 
    curl -X POST -d '{"name":"imgui_open","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
         localhost:9090/command
 
-A non-closable header treats ``imgui_open`` / ``imgui_close`` as
-"set the chevron state" — ``state.open`` is ignored, only
-``state.pending_open`` / ``pending_close`` (the chevron channel) fire.
+``imgui_open`` writes both ``state.pending_open`` AND ``state.open=true``
+so a previously X-hidden header re-appears. ``imgui_close``, by
+contrast, only writes ``state.pending_close`` — there's no path that
+hides the strip via live commands. To hide the strip programmatically,
+write ``state.open=false`` from app code (the X-button is the only
+user-driven path).
 
 .. seealso::
 

--- a/doc/source/tutorials/collapsing_header.rst
+++ b/doc/source/tutorials/collapsing_header.rst
@@ -1,0 +1,152 @@
+.. _tutorial_collapsing_header:
+
+#######################
+Collapsing header
+#######################
+
+``collapsing_header`` is the section-fold sibling of ``tree_node``: same
+expand/collapse chevron, but **no** ``TreePop`` pair — ImGui owns the
+close lifecycle. Two distinct gates govern visibility:
+
+* **Expanded** — the chevron click toggles the body. ``state.opened`` is
+  the per-frame ``CollapsingHeader`` return value.
+* **Closable** — with ``closable=true``, ImGui adds an X-button that
+  sets ``state.open=false``. While ``state.open`` is false, **the whole
+  header strip is hidden** (not just its body).
+
+The boost wrapper exposes both gates via the standard
+``pending_open`` / ``pending_close`` flags, so the live commands
+``imgui_open`` / ``imgui_close`` work on either dimension.
+
+Source: ``examples/tutorial/collapsing_header.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/collapsing_header.apng
+   :alt: collapsing_header recording
+
+.. literalinclude:: ../../../examples/tutorial/collapsing_header.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_containers_builtin`` — ``collapsing_header``.
+* ``imgui/imgui_widgets_builtin`` — ``text``, ``checkbox``, ``slider_int``.
+
+Two visibility dimensions
+=========================
+
+``CollapsingHeaderState`` carries both gates:
+
+.. code-block:: das
+
+   var CLOSABLE_CH : CollapsingHeaderState
+   // After the frame renders:
+   //   CLOSABLE_CH.open    : bool   // X-button gate (visible at all?)
+   //   CLOSABLE_CH.opened  : bool   // chevron gate (body expanded?)
+   //   CLOSABLE_CH.flags   : ImGuiTreeNodeFlags   // sticky
+
+``open`` is the X-button channel. ``opened`` is the chevron channel.
+Both surface in the snapshot. Tests that want to verify "the user
+expanded the section but didn't close it" check ``opened==true &&
+open==true``.
+
+The closable form
+=================
+
+When ``closable=true``, ``ImGui::CollapsingHeader`` takes a
+``bool* p_visible`` and renders an X-button on the right of the header
+strip. The boost wrapper feeds ``&state.open`` to that pointer:
+
+.. code-block:: das
+
+   collapsing_header(CLOSABLE_CH, (text = "Closable header",
+                                   closable = true,
+                                   flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+       text("X-button on the right of the header strip closes this section.")
+       // body
+   }
+
+Click the X — ImGui sets ``state.open=false``. Next frame, the
+wrapper sees ``open==false`` and **skips the ImGui call entirely**.
+The header row is gone until something flips ``open`` back to true.
+That something is either app code (``CLOSABLE_CH.open = true``) or a
+live driver (``imgui_open`` against the path).
+
+The pending-flag channel
+========================
+
+Two channels feed open/close from outside:
+
+* ``state.pending_open = true`` — set anywhere in app code, then the
+  next frame's call to the container clears it and applies
+  ``SetNextItemOpen(true, Always)``.
+* ``imgui_open`` — the live command. The dispatcher walks the
+  ``ImguiPathRegistry`` and sets ``pending_open`` on the matching state.
+
+Same shape for ``pending_close`` / ``imgui_close``. The closable form
+also clears ``state.open=false`` from the X-button — three control
+surfaces flow through one struct.
+
+DefaultOpen flag
+================
+
+``ImGuiTreeNodeFlags.DefaultOpen`` makes the chevron expanded on first
+render only. Subsequent frames respect whatever the user clicked.
+Useful for "show me the important section by default" without
+remembering open-state across runs.
+
+.. code-block:: das
+
+   collapsing_header(STARTUP_CH, (text = "Starts open",
+                                  closable = false,
+                                  flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+       text("Body visible on first render.")
+   }
+
+Other ``ImGuiTreeNodeFlags`` compose: ``OpenOnArrow``, ``OpenOnDoubleClick``,
+``Bullet``, ``Framed``, ``Leaf`` — same flag enum as ``tree_node`` (the
+two rails share semantics intentionally).
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials.
+
+Driving from outside
+====================
+
+Both gates are driveable. To collapse-and-hide the closable header:
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_close","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
+        localhost:9090/command
+
+To bring it back:
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_open","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
+        localhost:9090/command
+
+A non-closable header treats ``imgui_open`` / ``imgui_close`` as
+"set the chevron state" — ``state.open`` is ignored, only
+``state.pending_open`` / ``pending_close`` (the chevron channel) fire.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/collapsing_header.das <../../../examples/tutorial/collapsing_header.das>`
+
+   Features-side demo: ``examples/features/collapsing_header_closable.das`` —
+   minimal closable-X-button repro with integration test.
+
+   Sibling: :ref:`tutorial_containers` — umbrella container tour.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/group.rst
+++ b/doc/source/tutorials/group.rst
@@ -70,7 +70,7 @@ Hit-testing a cluster
 =====================
 
 ``IsItemHovered`` after ``EndGroup`` applies to the whole group's bbox.
-The tutorial uses it to gate an ``item_tooltip``:
+The tutorial uses it to gate a manual ``tooltip``:
 
 .. code-block:: das
 

--- a/doc/source/tutorials/group.rst
+++ b/doc/source/tutorials/group.rst
@@ -1,0 +1,154 @@
+.. _tutorial_group:
+
+#######################
+Group
+#######################
+
+``group`` brackets ``BeginGroup``/``EndGroup`` — a pure layout container
+with no chrome, no flags, and no observable state. What it *does* is
+combine its children into a single layout unit so that:
+
+* **same_line** after the closing brace continues from the group's
+  right edge, not the last widget's. Two stacked column blocks share a
+  row by sandwiching ``same_line()`` between two groups.
+* **IsItemHovered** / ``IsItemActive`` / ``GetItemRect*`` after the
+  group report against the **combined bbox** of every widget inside.
+  Lets a tooltip attach to "anywhere in the icon-plus-label cluster"
+  with no manual rectangle math.
+
+``GroupState`` is empty. The path push still happens, so widgets inside
+``group(LEFT_GRP)`` register under ``<window>/LEFT_GRP/<leaf>``.
+
+Source: ``examples/tutorial/group.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/group.apng
+   :alt: group recording
+
+.. literalinclude:: ../../../examples/tutorial/group.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_containers_builtin`` — ``group`` plus ``tooltip``,
+  ``same_line``, ``separator``.
+* ``imgui/imgui_widgets_builtin`` — leaves used inside the group.
+
+Two columns via same_line
+=========================
+
+The classic use: stack two column blocks side by side without manually
+computing column widths.
+
+.. code-block:: das
+
+   group(LEFT_GRP) {
+       text("Left block")
+       checkbox(L_WIRE, (text = "Wireframe"))
+       slider_int(L_FRAMES, (text = "frame limit"))
+   }
+   same_line((spacing = 24.0f))
+   group(RIGHT_GRP) {
+       text("Right block")
+       checkbox(R_VSYNC, (text = "VSync"))
+       small_button(R_APPLY, (text = "Apply"))
+   }
+
+Without the groups, ``same_line`` would only join the previous *widget*
+(the slider) to the next, leaving the rest of the right block to
+overlap. The group treats four widgets as one item for ``same_line``'s
+"continue from the right edge" semantics.
+
+Hit-testing a cluster
+=====================
+
+``IsItemHovered`` after ``EndGroup`` applies to the whole group's bbox.
+The tutorial uses it to gate an ``item_tooltip``:
+
+.. code-block:: das
+
+   group(HOVER_GRP) {
+       text("[i] Info")
+       same_line()
+       text("hover me anywhere in this row")
+       same_line()
+       small_button(HOVER_BTN, (text = "Action"))
+   }
+   if (IsItemHovered(ImGuiHoveredFlags.None)) {
+       tooltip(GRP_TIP) {
+           text("BeginTooltip while the whole group is hovered.")
+       }
+   }
+
+Hovering the icon, the label, the button — any of them — fires the
+tooltip. No need for ``IsItemHovered`` on each child or for ``Set...``
+rectangle hacks. The group's bbox subsumes everything.
+
+Note that ``HOVER_BTN`` is still independently clickable. Group hit-test
+*reads* over the cluster but does NOT *block* child events.
+
+The (label | value | button) row
+================================
+
+Compose three primitives into a logical row:
+
+.. code-block:: das
+
+   group(ROW_GRP) {
+       text("Speed:")
+       same_line()
+       slider_float(ROW_SPEED, (text = "##speed"))
+       same_line()
+       small_button(ROW_RESET, (text = "Reset"))
+   }
+
+The group keeps the three on one line if it fits; even if a wider label
+later forces a wrap, the group stays cohesive — subsequent ``same_line``
+calls outside the group treat it as one unit. ``ROW_SPEED.value`` and
+``ROW_RESET.click_count`` register under their respective paths
+(``ROW_GRP/ROW_SPEED``, ``ROW_GRP/ROW_RESET``) for driver access.
+
+Why no flags?
+=============
+
+ImGui's ``BeginGroup``/``EndGroup`` take no parameters. The wrapper's
+only argument is the IDENT. ``GroupState`` carries an
+``@optional _placeholder`` field so the ``[container]`` auto-emitter
+has *something* to serialize — the field is unused and the JV payload
+is ``{}``.
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials.
+
+Driving from outside
+====================
+
+The group itself isn't open/close-driveable (nothing to open). Its
+*children* are reachable at the composed path:
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"GRP_WIN/ROW_GRP/ROW_SPEED","value":0.75}}' \
+        localhost:9090/command
+   curl -X POST -d '{"name":"imgui_click","args":{"target":"GRP_WIN/ROW_GRP/ROW_RESET"}}' \
+        localhost:9090/command
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/group.das <../../../examples/tutorial/group.das>`
+
+   Features-side demo: ``examples/features/containers_window.das`` — uses
+   ``group`` alongside ``child`` to lay out a window's right pane.
+
+   Sibling: :ref:`tutorial_containers` — umbrella container tour.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -24,6 +24,12 @@ construction.
    with_disabled.rst
    state_telemetry.rst
    containers.rst
+   child.rst
+   group.rst
+   tree_node.rst
+   collapsing_header.rst
+   tab_bar.rst
+   popup_modal.rst
    main_menu_bar.rst
    popup_window.rst
    flat_tooltips.rst

--- a/doc/source/tutorials/popup_modal.rst
+++ b/doc/source/tutorials/popup_modal.rst
@@ -71,10 +71,12 @@ The classic "Yes/No before destructive action":
        }
    }
 
-``closable=false`` means there's no X-button. The body's Yes/No buttons
-are the only exits — both write to ``CONFIRM_RESULT`` and set
-``pending_close``. Without a way to dismiss the modal, the user is
-trapped on this question until they answer.
+``closable=false`` means there's no X-button — but ESC still closes the
+modal (ImGui's built-in popup keybinding, unaffected by ``closable``).
+The body's Yes/No buttons are the explicit answer paths: both write to
+``CONFIRM_RESULT`` and set ``pending_close``. To make the modal truly
+non-dismissable, pass ``ImGuiWindowFlags.NoMove | NoSavedSettings`` and
+intercept the ESC key in app code — outside the scope of this tutorial.
 
 The ``AlwaysAutoResize`` flag (passed via ``flags``) sizes the modal to
 its content — saves the caller from picking width/height by hand.
@@ -115,9 +117,9 @@ Same machinery, different UX:
   resolve the modal before doing anything else. Use for destructive
   confirms, multi-step wizards, blocking error dialogs.
 
-The two share ``PopupState`` exactly — same ``open`` / ``opened`` /
+The two share ``PopupState`` exactly — same ``open`` / ``flags`` /
 ``pending_open`` / ``pending_close`` fields. Switching between forms
-is one-word edit.
+is a one-word edit.
 
 Pending-flag channels
 =====================

--- a/doc/source/tutorials/popup_modal.rst
+++ b/doc/source/tutorials/popup_modal.rst
@@ -1,0 +1,172 @@
+.. _tutorial_popup_modal:
+
+#######################
+Modal popups
+#######################
+
+``popup_modal`` is the **blocking** sibling of ``popup``: ImGui dims the
+parent window, absorbs every click outside the modal, and routes ESC to
+the close path. The wrapper's signature:
+
+.. code-block:: das
+
+   popup_modal(IDENT, (text = "title",
+                       closable = bool,
+                       flags = ImGuiWindowFlags....)) {
+       // body — runs only while ImGui has the modal open
+   }
+
+Lifecycle is identical to ``popup`` — ``OpenPopup`` + ``BeginPopupModal``
++ ``EndPopup``, driven by ``state.pending_open`` / ``pending_close``.
+The differences are entirely visual + input-blocking, both handled by
+ImGui.
+
+``closable=true`` adds an X-button on the title bar wired to
+``state.open``. The wrapper feeds ``&state.open`` to
+``BeginPopupModal``'s ``p_open`` parameter, so an X-click sets
+``state.open=false`` and ImGui closes the modal on the next frame.
+
+Source: ``examples/tutorial/popup_modal.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/popup_modal.apng
+   :alt: popup_modal recording
+
+.. literalinclude:: ../../../examples/tutorial/popup_modal.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_containers_builtin`` — ``popup_modal`` plus ``window``.
+* ``imgui/imgui_widgets_builtin`` — ``button``, ``checkbox``, ``slider_int``,
+  ``text``.
+
+Confirm dialog (non-closable)
+=============================
+
+The classic "Yes/No before destructive action":
+
+.. code-block:: das
+
+   popup_modal(CONFIRM_MODAL, (text = "Confirm delete",
+                               closable = false,
+                               flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+       text("Are you sure you want to delete the selected file?")
+       separator()
+       if (button(CONFIRM_YES, (text = "Yes"))) {
+           CONFIRM_RESULT = "Yes"
+           CONFIRM_MODAL.pending_close = true
+       }
+       same_line()
+       if (button(CONFIRM_NO, (text = "No"))) {
+           CONFIRM_RESULT = "No"
+           CONFIRM_MODAL.pending_close = true
+       }
+   }
+
+``closable=false`` means there's no X-button. The body's Yes/No buttons
+are the only exits — both write to ``CONFIRM_RESULT`` and set
+``pending_close``. Without a way to dismiss the modal, the user is
+trapped on this question until they answer.
+
+The ``AlwaysAutoResize`` flag (passed via ``flags``) sizes the modal to
+its content — saves the caller from picking width/height by hand.
+
+Closable settings modal
+=======================
+
+When the user might want to close without "saving":
+
+.. code-block:: das
+
+   popup_modal(SETTINGS_MODAL, (text = "Settings",
+                                closable = true,
+                                flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+       checkbox(S_AUTOSAVE, (text = "Auto-save every 5 minutes"))
+       checkbox(S_TELEMETRY, (text = "Send anonymous telemetry"))
+       slider_int(S_MAX_FPS, (text = "Max FPS cap"))
+       separator()
+       if (button(S_APPLY, (text = "Apply"))) {
+           SETTINGS_MODAL.pending_close = true
+       }
+   }
+
+``closable=true`` activates the X-button. The wrapper passes
+``&state.open`` to ImGui as ``p_open``; ImGui flips it false on
+X-click or ESC, the next frame's ``BeginPopupModal`` returns false,
+and the wrapper finalizes the close. ``SETTINGS_MODAL.open`` mirrors
+ImGui's view so the snapshot reports whether the modal is currently up.
+
+popup vs popup_modal
+====================
+
+Same machinery, different UX:
+
+* ``popup`` — clicks outside the popup close it (auto-close behavior).
+  Useful for dropdowns, context menus, transient widgets.
+* ``popup_modal`` — clicks outside are **absorbed**. The user MUST
+  resolve the modal before doing anything else. Use for destructive
+  confirms, multi-step wizards, blocking error dialogs.
+
+The two share ``PopupState`` exactly — same ``open`` / ``opened`` /
+``pending_open`` / ``pending_close`` fields. Switching between forms
+is one-word edit.
+
+Pending-flag channels
+=====================
+
+Three control surfaces converge on the same state:
+
+* **App code** — ``MODAL.pending_open = true`` from a button handler
+  or any event.
+* **Live commands** — ``imgui_open`` / ``imgui_close`` against the
+  registered path.
+* **Close button / ESC** (closable only) — ImGui flips ``state.open``,
+  the next frame's wrapper applies the close.
+
+The wrapper bridges them: ``pending_open=true`` triggers ``OpenPopup``,
+``pending_close=true`` triggers ``CloseCurrentPopup`` inside the active
+modal body, X-click flips ``open=false`` and the wrapper closes on
+next frame.
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials.
+
+Driving from outside
+====================
+
+The modal opens / closes from any control surface:
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_open","args":{"target":"PM_WIN/CONFIRM_MODAL"}}' \
+        localhost:9090/command
+   curl -X POST -d '{"name":"imgui_click","args":{"target":"PM_WIN/CONFIRM_MODAL/CONFIRM_YES"}}' \
+        localhost:9090/command
+   curl -X POST -d '{"name":"imgui_close","args":{"target":"PM_WIN/CONFIRM_MODAL"}}' \
+        localhost:9090/command
+
+The path for body widgets composes off the modal IDENT — clicks against
+``PM_WIN/CONFIRM_MODAL/CONFIRM_YES`` resolve correctly only while the
+modal is open (the body's widgets aren't in the registry otherwise).
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/popup_modal.das <../../../examples/tutorial/popup_modal.das>`
+
+   Features-side demo: ``examples/features/containers_overlay.das`` —
+   ``popup`` + ``popup_modal`` + ``tooltip`` overlay family showcase.
+
+   Sibling: :ref:`tutorial_popup_window` — manual-trigger popup pattern
+   for shared-str_id under PushID scopes.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/popup_modal.rst
+++ b/doc/source/tutorials/popup_modal.rst
@@ -72,11 +72,12 @@ The classic "Yes/No before destructive action":
    }
 
 ``closable=false`` means there's no X-button — but ESC still closes the
-modal (ImGui's built-in popup keybinding, unaffected by ``closable``).
-The body's Yes/No buttons are the explicit answer paths: both write to
-``CONFIRM_RESULT`` and set ``pending_close``. To make the modal truly
-non-dismissable, pass ``ImGuiWindowFlags.NoMove | NoSavedSettings`` and
-intercept the ESC key in app code — outside the scope of this tutorial.
+modal (ImGui's built-in popup keybinding, unaffected by ``closable`` or
+any ``ImGuiWindowFlags`` bit). The body's Yes/No buttons are the
+explicit answer paths: both write to ``CONFIRM_RESULT`` and set
+``pending_close``. To make the modal truly non-dismissable, the app must
+intercept the ESC key before ``NewFrame()`` and avoid issuing any
+``pending_close`` from app code — outside the scope of this tutorial.
 
 The ``AlwaysAutoResize`` flag (passed via ``flags``) sizes the modal to
 its content — saves the caller from picking width/height by hand.

--- a/doc/source/tutorials/tab_bar.rst
+++ b/doc/source/tutorials/tab_bar.rst
@@ -1,0 +1,168 @@
+.. _tutorial_tab_bar:
+
+#######################
+Tab bar
+#######################
+
+``tab_bar`` hosts one or more ``tab_item`` blocks under a strip of
+clickable headers. ImGui owns active-tab selection internally — the
+boost wrapper just observes — and routes click events to the right
+body. Three things make tabs subtle:
+
+* **Only the active tab's body runs each frame.** Widgets inside
+  inactive tabs are NOT in the snapshot — paths under non-active tabs
+  return 404 to drivers. The container's state (TabBarState /
+  TabItemState) lives outside the body and persists.
+* **There is no ``pending_select`` channel.** ImGui owns selection;
+  ``imgui_click`` against a tab_item path is how external drivers switch
+  tabs.
+* **Closable tabs** add an X-button. The wrapper feeds ``&state.open``
+  to BeginTabItem's ``p_open`` parameter; ImGui flips it false on
+  X-click and the wrapper skips the tab next frame.
+
+Source: ``examples/tutorial/tab_bar.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/tab_bar.apng
+   :alt: tab_bar recording
+
+.. literalinclude:: ../../../examples/tutorial/tab_bar.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_containers_builtin`` — ``tab_bar``, ``tab_item``,
+  ``edit_tab_item``.
+* ``imgui/imgui_widgets_builtin`` — leaves used inside each tab body.
+
+Active tab + body gating
+========================
+
+ImGui drives active-tab selection internally. Each ``tab_item``'s body
+only runs while that tab is active:
+
+.. code-block:: das
+
+   tab_bar(MAIN_TABS, (text = "MainTabs",
+                       flags = ImGuiTabBarFlags.Reorderable)) {
+       tab_item(GENERAL_TAB, (text = "General", closable = false,
+                              flags = ImGuiTabItemFlags.None)) {
+           checkbox(G_WIRE, (text = "Wireframe"))   // only registered while active
+       }
+       tab_item(AUDIO_TAB, ...) { ... }
+       tab_item(INFO_TAB,  ...) { ... }
+   }
+
+A snapshot taken while ``AUDIO_TAB`` is active will not list
+``G_WIRE`` under ``GENERAL_TAB`` — the leaf wasn't submitted to ImGui
+that frame. Drivers must switch the active tab first before reading
+or writing leaves underneath.
+
+Switching tabs from outside
+===========================
+
+``imgui_click`` against a tab_item path hits the tab strip header (the
+boost wrapper captures the header bbox separately so click resolves to
+the strip, not the body):
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_click","args":{"target":"TB_WIN/MAIN_TABS/AUDIO_TAB"}}' \
+        localhost:9090/command
+
+This is the only programmatic way to switch tabs — there's no
+``imgui_set_active`` because ImGui's internal selection isn't exposed
+as a struct field. ``imgui_click`` is enough: it produces a real ImGui
+mouse event against the header, which is exactly what manual user
+interaction does.
+
+Closable tabs
+=============
+
+``closable=true`` makes the X-button appear:
+
+.. code-block:: das
+
+   tab_item(DRAFT_TAB, (text = "Draft", closable = true,
+                        flags = ImGuiTabItemFlags.None)) {
+       text("DRAFT_TAB.open = {DRAFT_TAB.open}")
+   }
+
+The wrapper threads ``&state.open`` into BeginTabItem's ``p_open``.
+When the user clicks X, ImGui flips ``state.open=false``. Next frame
+the wrapper sees ``!state.open`` and **skips BeginTabItem entirely** —
+the tab disappears from the strip. Bring it back with
+``DRAFT_TAB.pending_open = true`` from app code or ``imgui_open``
+from a driver.
+
+``state.open`` defaults to true so closable tabs appear from frame 1.
+``@live open : bool = true`` in TabItemState carries the value across
+live reload — the user's "I closed this tab" state survives a recompile.
+
+Sharing open state across two surfaces
+======================================
+
+For the canonical "the same flag lives in a checkbox and a tab's X"
+case, use ``edit_tab_item`` against a caller-owned bool pointer:
+
+.. code-block:: das
+
+   var private DRAFT_TAB_OPEN : bool = true
+
+   // Checkbox row mirrors the X-button flag.
+   edit_checkbox(safe_addr(DRAFT_TAB_OPEN), (id = "TAB_VISIBLE",
+                                              text = "Show Draft tab"))
+   // ...
+   edit_tab_item(safe_addr(DRAFT_TAB_OPEN), "Draft",
+                 ImGuiTabItemFlags.None) {
+       text("Draft body — same flag the checkbox flips")
+   }
+
+The two rails share one ``bool`` — flip via either control surface and
+the other auto-mirrors. Internal-only ``tab_item.open`` doesn't expose
+this; ``edit_tab_item`` is the bidir-bind variant.
+
+ImGuiTabBarFlags
+================
+
+Bar-level chrome:
+
+* ``Reorderable`` — drag tab headers to reorder them.
+* ``AutoSelectNewTabs`` — newly-submitted tabs become the active selection.
+* ``TabListPopupButton`` — adds a ▼ menu on the right with all tabs as
+  a list (useful when there are many tabs).
+* ``NoCloseWithMiddleMouseButton`` — disable the middle-mouse
+  shortcut for closable tabs.
+* ``NoTooltip`` — suppress hover tooltips on tab headers.
+* ``FittingPolicyResizeDown`` / ``FittingPolicyScroll`` — what happens
+  when the strip doesn't fit horizontally.
+
+Per-tab flags via ``ImGuiTabItemFlags``: ``UnsavedDocument`` (marks the
+header with a dot), ``SetSelected`` (a one-shot select-this-tab nudge),
+``NoCloseButton`` (closable=true but no X), ``Leading``/``Trailing``
+(pin to bar edges), ``NoReorder``.
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/tab_bar.das <../../../examples/tutorial/tab_bar.das>`
+
+   Features-side demos: ``examples/features/containers_layout.das`` —
+   tab_bar + tree_node + collapsing_header composition;
+   ``examples/features/tab_item_button.das`` — the ``tab_item_button``
+   widget for an action-button styled as a tab.
+
+   Sibling: :ref:`tutorial_containers` — umbrella container tour.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/tree_node.rst
+++ b/doc/source/tutorials/tree_node.rst
@@ -1,0 +1,172 @@
+.. _tutorial_tree_node:
+
+#######################
+Tree node
+#######################
+
+``tree_node`` is the block-arg ``[container]`` form of ImGui's
+``TreeNodeEx``: branch headers that fold-and-expand with an auto-paired
+``TreePop``. The wrapper's signature:
+
+.. code-block:: das
+
+   tree_node(IDENT, (text = "...",
+                     flags = ImGuiTreeNodeFlags....)) {
+       // body — runs only while the chevron is expanded (TreeNodeEx == true)
+   }
+
+Body invocation gated on ImGui returning ``true`` for ``TreeNodeEx``;
+``TreePop`` only fires when the body was invoked. ``TreeNodeState``
+mirrors the per-frame open status (``opened``) and exposes the
+``pending_open`` / ``pending_close`` flags so ``imgui_open`` /
+``imgui_close`` can drive the chevron from outside.
+
+Source: ``examples/tutorial/tree_node.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/tree_node.apng
+   :alt: tree_node recording
+
+.. literalinclude:: ../../../examples/tutorial/tree_node.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_containers_builtin`` — ``tree_node`` container.
+* ``imgui/imgui_widgets_builtin`` — ``slider_float``, ``checkbox``,
+  ``text``, plus the leaf ``tree_node_ex``.
+
+Nesting and path composition
+============================
+
+Tree nodes nest naturally. Each level's IDENT pushes onto the path
+hash, so a slider three levels deep registers at
+``TN_WIN/RENDER_TREE/CAMERA_SUBTREE/RENDER_FOV``:
+
+.. code-block:: das
+
+   tree_node(RENDER_TREE, (text = "Render", flags = ImGuiTreeNodeFlags.None)) {
+       tree_node(CAMERA_SUBTREE, (text = "Camera",
+                                  flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+           slider_float(RENDER_FOV, (text = "fov"))
+       }
+       tree_node(MESH_SUBTREE, (text = "Mesh",
+                                flags = ImGuiTreeNodeFlags.None)) {
+           checkbox(MESH_WIRE, (text = "Wireframe"))
+       }
+   }
+
+When ``RENDER_TREE`` is collapsed, neither subtree's body runs — the
+sliders/checkboxes aren't in the snapshot until the user expands
+``RENDER_TREE``. The state structs themselves (``CAMERA_SUBTREE``,
+``MESH_SUBTREE``) still exist; their ``opened`` field is false.
+
+Open / close from outside
+=========================
+
+Two channels feed open/close into the wrapper:
+
+* ``state.pending_open = true`` — app code anywhere. Next frame the
+  wrapper applies ``SetNextItemOpen(true, Always)`` before TreeNodeEx
+  runs. Cleared on consume.
+* ``imgui_open`` / ``imgui_close`` — live commands routed by path.
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_open","args":{"target":"TN_WIN/PHYSICS_TREE"}}' \
+        localhost:9090/command
+   curl -X POST -d '{"name":"imgui_close","args":{"target":"TN_WIN/PHYSICS_TREE"}}' \
+        localhost:9090/command
+
+Both flow through ``state.pending_open`` / ``state.pending_close`` —
+the dispatcher just walks the registry and flips the flag. ``Always``
+in the ``SetNextItemOpen`` call means the override wins over ImGui's
+stored chevron state for that one frame.
+
+Reading state.opened
+====================
+
+``state.opened`` is a per-frame mirror of TreeNodeEx's bool return.
+A snapshot reports it under ``opened``:
+
+.. code-block:: das
+
+   var PHYSICS_TREE : TreeNodeState
+   // After the frame:
+   //   PHYSICS_TREE.opened : bool   // chevron expanded this frame?
+   //   PHYSICS_TREE.flags  : ImGuiTreeNodeFlags   // sticky
+
+Drivers verify "user expanded this tree" by reading ``opened==true``.
+Note that ``opened`` is set to ``im_open`` BEFORE the body runs — the
+wrapper writes it as soon as TreeNodeEx returns, so even a body that
+panics still leaves a correct ``opened`` for the snapshot.
+
+ImGuiTreeNodeFlags
+==================
+
+The third arg's bitfield. Most useful:
+
+* ``DefaultOpen`` — first-render expansion; subsequent frames respect
+  user input. The Render-Camera example uses this so the sub-tree is
+  open by default after a clean launch.
+* ``OpenOnArrow`` — only the chevron click toggles; clicking the label
+  itself doesn't expand. Pair with a Selectable-row pattern.
+* ``OpenOnDoubleClick`` — single click selects, double click toggles.
+* ``Leaf`` — render the row without a chevron. The body is required to
+  not exist (or be empty); use ``tree_node_ex`` (the [widget] leaf form)
+  for nodes that should be selectable rows without children. See
+  ``examples/features/tree_node_ex.das``.
+* ``Bullet`` — bullet point instead of chevron. Pair with ``Leaf``.
+* ``Framed`` — solid background under the header strip.
+* ``NoTreePushOnOpen`` — open the node WITHOUT indenting the body. Used
+  by ``tree_node_ex`` rails where the body lives outside the conditional.
+* ``SpanAllColumns`` / ``SpanAvailWidth`` / ``SpanFullWidth`` — hit-test
+  region tweaks for trees inside tables.
+
+tree_node vs tree_node_ex
+=========================
+
+Same backing struct, different ergonomics:
+
+* ``tree_node(IDENT, (...)) { body }`` (this tutorial) — ``[container]``
+  block-arg. Body runs gated on the open chevron; wrapper handles
+  ``TreePop``.
+* ``tree_node_ex(IDENT, (...))`` — ``[widget]`` leaf. Returns a bool;
+  caller pairs ``tree_pop()`` (the rail) manually, *outside* an
+  ``if (open)`` if needed. The escape hatch for "header has a sibling
+  ``same_line()`` widget" or "Leaf node with selectable behavior" —
+  see ``examples/features/tree_node_ex.das`` for the rail-side demo and
+  ``examples/features/tree_node_open_manual.das`` for the sibling
+  same_line pattern.
+
+When in doubt, use ``tree_node`` — block-arg auto-pairing is harder to
+get wrong.
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/tree_node.das <../../../examples/tutorial/tree_node.das>`
+
+   Features-side demos:
+   ``examples/features/containers_layout.das`` — tree_node alongside
+   tab_bar + collapsing_header;
+   ``examples/features/tree_node_open_manual.das`` — leaf-form manual
+   ``tree_pop`` pairing with a sibling button on the header row;
+   ``examples/features/tree_node_ex.das`` — Leaf / Bullet / OpenOnArrow
+   variations against the [widget] leaf form.
+
+   Sibling: :ref:`tutorial_collapsing_header` — same flags-and-state shape
+   without the chevron / TreePop dance.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/examples/tutorial/child.das
+++ b/examples/tutorial/child.das
@@ -17,6 +17,8 @@ require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 require imgui/imgui_visual_aids
 
+var private SCROLL_ROW : table<int; NarrativeState>
+
 // =============================================================================
 // TUTORIAL: child — BeginChild/EndChild sub-windows.
 //
@@ -77,7 +79,7 @@ def update() {
                          child_flags = ImGuiChildFlags.Border,
                          window_flags = ImGuiWindowFlags.None)) {
             for (i in range(20)) {
-                text("row {i} — content overflows the visible region")
+                text(SCROLL_ROW[i], (text = "row {i} — content overflows the visible region"))
             }
         }
         text("scroll.y = {SCROLL_A.scroll.y} / {SCROLL_A.scroll_max.y}")

--- a/examples/tutorial/child.das
+++ b/examples/tutorial/child.das
@@ -95,7 +95,10 @@ def update() {
             checkbox(B_VSYNC, (text = "VSync"))
             slider_int(B_LIMIT, (text = "frame limit"))
         }
-        text("auto height = {AUTO_B.scroll_max.y + AUTO_B.scroll.y}px")
+        // AutoResizeY trims overflow to zero, so scroll = (0,0) and
+        // scroll_max = (0,0). The child's actual size lives in size.y;
+        // print scroll fields directly to show "no overflow".
+        text("AUTO_B.scroll = ({AUTO_B.scroll.x}, {AUTO_B.scroll.y}); scroll_max = ({AUTO_B.scroll_max.x}, {AUTO_B.scroll_max.y})")
         spacing()
 
         // ---- C: bordered, horizontal scroll ----

--- a/examples/tutorial/child.das
+++ b/examples/tutorial/child.das
@@ -1,0 +1,137 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: child — BeginChild/EndChild sub-windows.
+//
+//   child(IDENT, (text = "..", size = float2(w, h),
+//                 child_flags = ..., window_flags = ...)) { body }
+//
+// child is the workhorse for nesting a scrollable, optionally-bordered region
+// inside another window. Three knobs:
+//
+//   1. size — float2(w, h). (0,0) auto-fits to the available row/column
+//      depending on flags. Positive = explicit pixels. Negative = "fill the
+//      remainder, minus N pixels".
+//
+//   2. child_flags — ImGui's child-specific bitfield: Border, AlwaysAutoResize,
+//      AutoResizeX/Y, FrameStyle, NavFlattened, ResizeX/Y.
+//
+//   3. window_flags — same flags every other window takes. Scrollbar control
+//      lives here: HorizontalScrollbar, AlwaysVerticalScrollbar, etc.
+//
+// ChildState observed each frame: scroll (float2 current), scroll_max (float2
+// max). The body's render runs only while BeginChild returned true; scroll is
+// captured INSIDE that gate so a hidden child reports the last-known values.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/child.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/child.das
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui child tutorial", 800, 540)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(760.0f, 500.0f), ImGuiCond.Always)
+    window(CHILD_WIN, (text = "child tutorial", closable = false,
+                       flags = ImGuiWindowFlags.None)) {
+
+        text("Three child variants — one each for borders, autosize, and h-scroll.")
+        separator()
+
+        // ---- A: bordered, fixed-size, vertical scroll ----
+        text("A) Bordered fixed-size with vertical scroll")
+        child(SCROLL_A, (text = "scroll_a",
+                         size = float2(360.0f, 140.0f),
+                         child_flags = ImGuiChildFlags.Border,
+                         window_flags = ImGuiWindowFlags.None)) {
+            for (i in range(20)) {
+                text("row {i} — content overflows the visible region")
+            }
+        }
+        text("scroll.y = {SCROLL_A.scroll.y} / {SCROLL_A.scroll_max.y}")
+        spacing()
+
+        // ---- B: auto-resize Y, FrameStyle (input-group look) ----
+        text("B) AutoResizeY + FrameStyle — height tracks content")
+        child(AUTO_B, (text = "auto_b",
+                       size = float2(360.0f, 0.0f),
+                       child_flags = ImGuiChildFlags.AutoResizeY | ImGuiChildFlags.FrameStyle,
+                       window_flags = ImGuiWindowFlags.None)) {
+            text("Three rows of input chrome")
+            checkbox(B_VSYNC, (text = "VSync"))
+            slider_int(B_LIMIT, (text = "frame limit"))
+        }
+        text("auto height = {AUTO_B.scroll_max.y + AUTO_B.scroll.y}px")
+        spacing()
+
+        // ---- C: bordered, horizontal scroll ----
+        text("C) Border + horizontal scroll — wide content")
+        child(SCROLL_C, (text = "scroll_c",
+                        size = float2(720.0f, 90.0f),
+                        child_flags = ImGuiChildFlags.Border,
+                        window_flags = ImGuiWindowFlags.HorizontalScrollbar)) {
+            // One long line — forces horizontal scroll because no wrap.
+            text(LONG_LINE, (text = "very wide content: lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"))
+            text("(scroll horizontally to read; scroll.x mirrors below)")
+        }
+        text("scroll.x = {SCROLL_C.scroll.x} / {SCROLL_C.scroll_max.x}")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/collapsing_header.das
+++ b/examples/tutorial/collapsing_header.das
@@ -24,26 +24,33 @@ require imgui/imgui_visual_aids
 //                             flags = ImGuiTreeNodeFlags....)) { body }
 //
 // Same shape as tree_node BUT no TreePop pair — ImGui owns the close lifecycle.
-// Two distinct gates control whether the body runs:
+// Two distinct gates control visibility, each on its own field:
 //
-//   1. EXPANDED (chevron) — user toggles via the disclosure arrow. The boost
-//      wrapper mirrors this in state.opened (per-frame, from CollapsingHeader's
-//      return). pending_open / pending_close (driven by imgui_open / imgui_close)
-//      flip the expansion via SetNextItemOpen.
+//   1. EXPANDED (chevron) — controls whether the BODY runs. state.opened
+//      mirrors CollapsingHeader's per-frame return. pending_open /
+//      pending_close (driven by imgui_open / imgui_close) override the
+//      chevron via SetNextItemOpen on the next frame.
 //
-//   2. CLOSABLE (X-button) — if closable=true, ImGui adds an X-button that
-//      sets state.open=false. While state.open is false the section is hidden
-//      entirely (not even a header strip renders). Open-channel flipping needs
-//      both gates: pending_open sets state.open back to true AND SetNextItemOpen.
+//   2. CLOSABLE (X-button) — controls whether the entire HEADER STRIP
+//      renders. Only active when closable=true. ImGui flips state.open=false
+//      on X-click; the wrapper then skips BeginCollapsingHeader entirely so
+//      the strip vanishes. imgui_open re-sets state.open=true; imgui_close
+//      does NOT — it only collapses the chevron via the expanded channel.
+//      To programmatically hide the strip, write state.open=false from app
+//      code.
 //
 // STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/collapsing_header.das
 // LIVE:       daslang-live modules/dasImgui/examples/tutorial/collapsing_header.das
 //
 // DRIVE (when running live):
-//   curl -X POST -d '{"name":"imgui_open","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
-//        localhost:9090/command
+//   # Collapse the chevron (body stops rendering; header strip stays):
 //   curl -X POST -d '{"name":"imgui_close","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
 //        localhost:9090/command
+//   # Re-expand the chevron AND re-show the strip if X-button hid it:
+//   curl -X POST -d '{"name":"imgui_open","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
+//        localhost:9090/command
+//   # To HIDE the strip, click the X-button or write CLOSABLE_CH.open=false
+//   # from app code — there's no imgui_close path that does this.
 // =============================================================================
 
 [export]

--- a/examples/tutorial/collapsing_header.das
+++ b/examples/tutorial/collapsing_header.das
@@ -1,0 +1,129 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: collapsing_header — expandable section header with optional X-button.
+//
+//   collapsing_header(IDENT, (text = "..", closable = bool,
+//                             flags = ImGuiTreeNodeFlags....)) { body }
+//
+// Same shape as tree_node BUT no TreePop pair — ImGui owns the close lifecycle.
+// Two distinct gates control whether the body runs:
+//
+//   1. EXPANDED (chevron) — user toggles via the disclosure arrow. The boost
+//      wrapper mirrors this in state.opened (per-frame, from CollapsingHeader's
+//      return). pending_open / pending_close (driven by imgui_open / imgui_close)
+//      flip the expansion via SetNextItemOpen.
+//
+//   2. CLOSABLE (X-button) — if closable=true, ImGui adds an X-button that
+//      sets state.open=false. While state.open is false the section is hidden
+//      entirely (not even a header strip renders). Open-channel flipping needs
+//      both gates: pending_open sets state.open back to true AND SetNextItemOpen.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/collapsing_header.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/collapsing_header.das
+//
+// DRIVE (when running live):
+//   curl -X POST -d '{"name":"imgui_open","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
+//        localhost:9090/command
+//   curl -X POST -d '{"name":"imgui_close","args":{"target":"CH_WIN/CLOSABLE_CH"}}' \
+//        localhost:9090/command
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui collapsing_header tutorial", 760, 520)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(720.0f, 480.0f), ImGuiCond.Always)
+    window(CH_WIN, (text = "collapsing_header tutorial", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        text("Three collapsing_header variants — basic, closable, default-open.")
+        separator()
+
+        // ---- A: basic (non-closable) ----
+        collapsing_header(BASIC_CH, (text = "Basic header", closable = false,
+                                     flags = ImGuiTreeNodeFlags.None)) {
+            text("Click the chevron to fold this section.")
+            checkbox(BASIC_LIVE, (text = "Receive updates"))
+            text("opened = {BASIC_CH.opened}")
+        }
+
+        // ---- B: closable (renders an X-button) ----
+        collapsing_header(CLOSABLE_CH, (text = "Closable header",
+                                        closable = true,
+                                        flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+            text("X-button on the right of the header strip closes this section.")
+            text("Once closed, the whole row disappears — flip back via")
+            text("imgui_open against CH_WIN/CLOSABLE_CH.")
+            slider_int(VOLUME, (text = "volume"))
+        }
+        text("CLOSABLE_CH.open = {CLOSABLE_CH.open}, opened = {CLOSABLE_CH.opened}")
+        separator()
+
+        // ---- C: DefaultOpen flag (chevron already down on first frame) ----
+        collapsing_header(STARTUP_CH, (text = "Starts open (DefaultOpen flag)",
+                                       closable = false,
+                                       flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+            text("ImGuiTreeNodeFlags.DefaultOpen makes the chevron expanded")
+            text("on first render — subsequent frames respect user input.")
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/collapsing_header.das
+++ b/examples/tutorial/collapsing_header.das
@@ -96,7 +96,7 @@ def update() {
         collapsing_header(STARTUP_CH, (text = "Starts open (DefaultOpen flag)",
                                        closable = false,
                                        flags = ImGuiTreeNodeFlags.DefaultOpen)) {
-            text("ImGuiTreeNodeFlags.DefaultOpen makes the chevron expanded")
+            text(STARTUP_HINT, (text = "ImGuiTreeNodeFlags.DefaultOpen makes the chevron expanded"))
             text("on first render — subsequent frames respect user input.")
         }
     }

--- a/examples/tutorial/group.das
+++ b/examples/tutorial/group.das
@@ -1,0 +1,141 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: group — BeginGroup/EndGroup pure layout grouping.
+//
+//   group(IDENT) { body }
+//
+// Treats several widgets as a single layout unit. Two effects:
+//
+//   1. Same-line stacking — same_line() after the group's closing brace
+//      continues from the group's right edge, not the last widget's. Useful
+//      for laying out (label-block | value-block | edit-block) rows.
+//
+//   2. Hit-test the whole group — IsItemHovered() / IsItemActive() called
+//      after EndGroup() report against the group's combined bbox. Lets a
+//      tooltip attach to "anywhere inside the icon-plus-label cluster".
+//
+// GroupState is empty — no flags, no observables. Pure structural marker.
+// The path push still happens, so a button inside group(LEFT_GRP) is
+// reachable at MAIN_WIN/LEFT_GRP/SAVE_BTN.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/group.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/group.das
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui group tutorial", 720, 480)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(680.0f, 440.0f), ImGuiCond.Always)
+    window(GRP_WIN, (text = "group tutorial", closable = false,
+                     flags = ImGuiWindowFlags.None)) {
+
+        text("group(IDENT) takes a block and treats its widgets as one layout unit.")
+        separator()
+
+        // ---- A: two side-by-side groups via same_line ----
+        text("A) Two groups + same_line: each block stacks vertically; same_line")
+        text("   between them keeps the right block's top aligned with the left.")
+        group(LEFT_GRP) {
+            text("Left block")
+            checkbox(L_WIRE, (text = "Wireframe"))
+            checkbox(L_GRID, (text = "Show grid"))
+            slider_int(L_FRAMES, (text = "frame limit"))
+        }
+        same_line((spacing = 24.0f))
+        group(RIGHT_GRP) {
+            text("Right block")
+            checkbox(R_VSYNC, (text = "VSync"))
+            checkbox(R_FULL, (text = "Fullscreen"))
+            small_button(R_APPLY, (text = "Apply"))
+        }
+        separator()
+
+        // ---- B: group as a tooltip hit-test surface ----
+        text("B) Hit-test a whole cluster — hover anywhere in the row below.")
+        group(HOVER_GRP) {
+            text("[i] Info")
+            same_line()
+            text("hover me anywhere in this row")
+            same_line()
+            small_button(HOVER_BTN, (text = "Action"))
+        }
+        if (IsItemHovered(ImGuiHoveredFlags.None)) {
+            tooltip(GRP_TIP) {
+                text("BeginTooltip while the whole group is hovered.")
+                text("IsItemHovered() after EndGroup() reports against the combined bbox.")
+            }
+        }
+        separator()
+
+        // ---- C: group used as a "row" with right-aligned status ----
+        text("C) The (label | value | button) row pattern.")
+        group(ROW_GRP) {
+            text("Speed:")
+            same_line()
+            slider_float(ROW_SPEED, (text = "##speed"))
+            same_line()
+            small_button(ROW_RESET, (text = "Reset"))
+        }
+        text("ROW_SPEED.value = {ROW_SPEED.value}")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/group.das
+++ b/examples/tutorial/group.das
@@ -33,8 +33,8 @@ require imgui/imgui_visual_aids
 //      tooltip attach to "anywhere inside the icon-plus-label cluster".
 //
 // GroupState is empty — no flags, no observables. Pure structural marker.
-// The path push still happens, so a button inside group(LEFT_GRP) is
-// reachable at MAIN_WIN/LEFT_GRP/SAVE_BTN.
+// The path push still happens, so a checkbox inside group(LEFT_GRP) is
+// reachable at GRP_WIN/LEFT_GRP/L_WIRE.
 //
 // STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/group.das
 // LIVE:       daslang-live modules/dasImgui/examples/tutorial/group.das

--- a/examples/tutorial/popup_modal.das
+++ b/examples/tutorial/popup_modal.das
@@ -86,7 +86,9 @@ def update() {
         text("SETTINGS_MODAL.open (closable) = {SETTINGS_MODAL.open}")
 
         // ---- Modal A: Yes/No confirm ----
-        // closable=false → no X-button; only the Yes/No buttons can close it.
+        // closable=false → no X-button. Yes/No buttons + ESC are the close
+        // paths (ESC is an ImGui built-in for popups; to disable it the app
+        // would need to intercept the keystroke before NewFrame()).
         popup_modal(CONFIRM_MODAL, (text = "Confirm delete",
                                     closable = false,
                                     flags = ImGuiWindowFlags.AlwaysAutoResize)) {

--- a/examples/tutorial/popup_modal.das
+++ b/examples/tutorial/popup_modal.das
@@ -1,0 +1,148 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: popup_modal — blocking modal dialog with optional X-button.
+//
+//   popup_modal(IDENT, (text = "title", closable = bool,
+//                       flags = ImGuiWindowFlags....)) { body }
+//
+// Lifecycle is identical to popup() — OpenPopup + BeginPopupModal/EndPopup,
+// driven by state.pending_open / pending_close — but ImGui ALSO:
+//
+//   1. Dims the parent window — visual backdrop says "deal with this first".
+//   2. Blocks input outside the modal — clicks elsewhere are absorbed, not
+//      passed through. ESC closes the modal (vanilla ImGui behavior).
+//   3. With closable=true, renders an X-button wired to state.open.
+//
+// The boost wrapper threads three control surfaces through state.pending_*:
+//   - app code        — `MODAL_X.pending_open = true`
+//   - live commands   — imgui_open / imgui_close
+//   - close-button    — ImGui flips state.open when X clicked or ESC pressed
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/popup_modal.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/popup_modal.das
+//
+// DRIVE (when running live):
+//   curl -X POST -d '{"name":"imgui_open","args":{"target":"PM_WIN/CONFIRM_MODAL"}}' \
+//        localhost:9090/command
+// =============================================================================
+
+var private CONFIRM_RESULT : string = "(no answer yet)"
+
+[export]
+def init() {
+    live_create_window("dasImgui popup_modal tutorial", 720, 480)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(680.0f, 440.0f), ImGuiCond.Always)
+    window(PM_WIN, (text = "popup_modal tutorial", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        text("Two modals — a Yes/No confirm and a closable settings dialog.")
+        separator()
+
+        // ---- A: trigger the confirm modal ----
+        if (button(OPEN_CONFIRM, (text = "Delete file..."))) {
+            CONFIRM_MODAL.pending_open = true
+        }
+        same_line((spacing = 12.0f))
+        if (button(OPEN_SETTINGS, (text = "Open settings (X-button)"))) {
+            SETTINGS_MODAL.pending_open = true
+        }
+
+        separator()
+        text(STATUS_LINE, (text = "Last confirm answer: {CONFIRM_RESULT}"))
+        text("SETTINGS_MODAL.open (closable) = {SETTINGS_MODAL.open}")
+
+        // ---- Modal A: Yes/No confirm ----
+        // closable=false → no X-button; only the Yes/No buttons can close it.
+        popup_modal(CONFIRM_MODAL, (text = "Confirm delete",
+                                    closable = false,
+                                    flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+            text("Are you sure you want to delete the selected file?")
+            separator()
+            if (button(CONFIRM_YES, (text = "Yes"))) {
+                CONFIRM_RESULT = "Yes"
+                CONFIRM_MODAL.pending_close = true
+            }
+            same_line((spacing = 12.0f))
+            if (button(CONFIRM_NO, (text = "No"))) {
+                CONFIRM_RESULT = "No"
+                CONFIRM_MODAL.pending_close = true
+            }
+        }
+
+        // ---- Modal B: closable settings ----
+        // closable=true → X-button on the title bar wired to state.open.
+        popup_modal(SETTINGS_MODAL, (text = "Settings",
+                                     closable = true,
+                                     flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+            text("Background tasks")
+            separator()
+            checkbox(S_AUTOSAVE, (text = "Auto-save every 5 minutes"))
+            checkbox(S_TELEMETRY, (text = "Send anonymous telemetry"))
+            slider_int(S_MAX_FPS, (text = "Max FPS cap"))
+            separator()
+            if (button(S_APPLY, (text = "Apply"))) {
+                SETTINGS_MODAL.pending_close = true
+            }
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/tab_bar.das
+++ b/examples/tutorial/tab_bar.das
@@ -1,0 +1,149 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: tab_bar — BeginTabBar / EndTabBar with nested tab_item blocks.
+//
+//   tab_bar(IDENT, (text = "...", flags = ImGuiTabBarFlags....)) {
+//       tab_item(TAB_A, (text = "A", closable = false, flags = ...)) { ... }
+//       tab_item(TAB_B, (text = "B", closable = true,  flags = ...)) { ... }
+//   }
+//
+// Key behaviors:
+//
+//   1. Only the ACTIVE tab's body block runs each frame — widgets inside
+//      inactive tabs are NOT in the registry that frame. A driver doing
+//      imgui_set against an inactive tab's child path gets a 404.
+//
+//   2. Closable tabs (closable=true) render an X-button. ImGui flips
+//      state.open=false; the wrapper then skips BeginTabItem entirely so
+//      the tab disappears from the strip until pending_open is set true
+//      again.
+//
+//   3. ImGui owns active-tab selection — there is NO state.pending_select.
+//      Drive it from outside by imgui_click against the tab_item path
+//      (the click hits the tab strip header).
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/tab_bar.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/tab_bar.das
+//
+// DRIVE (when running live):
+//   curl -X POST -d '{"name":"imgui_click","args":{"target":"TB_WIN/MAIN_TABS/AUDIO_TAB"}}' \
+//        localhost:9090/command
+//   curl -X POST -d '{"name":"imgui_close","args":{"target":"TB_WIN/MAIN_TABS/DRAFT_TAB"}}' \
+//        localhost:9090/command
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui tab_bar tutorial", 760, 540)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(720.0f, 500.0f), ImGuiCond.Always)
+    window(TB_WIN, (text = "tab_bar tutorial", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        text("Three tab_items + one closable draft tab — drag the strip to reorder.")
+        separator()
+
+        // Reorderable + TabListPopupButton (the ▼ menu on the right).
+        tab_bar(MAIN_TABS, (text = "MainTabs",
+                            flags = ImGuiTabBarFlags.Reorderable |
+                                    ImGuiTabBarFlags.TabListPopupButton)) {
+
+            // ---- General tab (non-closable, default selection) ----
+            tab_item(GENERAL_TAB, (text = "General", closable = false,
+                                   flags = ImGuiTabItemFlags.None)) {
+                text("Only the active tab's body block runs each frame.")
+                text("Switch tabs — checkbox state below survives because the")
+                text("[container] state lives outside the body.")
+                checkbox(G_WIRE, (text = "Wireframe"))
+                checkbox(G_LIVE, (text = "Live preview"))
+            }
+
+            // ---- Audio tab ----
+            tab_item(AUDIO_TAB, (text = "Audio", closable = false,
+                                 flags = ImGuiTabItemFlags.None)) {
+                slider_int(A_VOLUME, (text = "Volume"))
+                checkbox(A_MUTE, (text = "Mute"))
+                text("VOLUME = {A_VOLUME.value}  MUTE = {A_MUTE.value}")
+            }
+
+            // ---- Info tab ----
+            tab_item(INFO_TAB, (text = "Info", closable = false,
+                                flags = ImGuiTabItemFlags.None)) {
+                text("Tab metadata — read-only.")
+                text("MAIN_TABS.flags = Reorderable | TabListPopupButton")
+                text("Inactive tab bodies do NOT register child widgets.")
+            }
+
+            // ---- Draft tab (closable, has X-button) ----
+            tab_item(DRAFT_TAB, (text = "Draft", closable = true,
+                                 flags = ImGuiTabItemFlags.None)) {
+                text("Draft. Click the X to close. Re-open via imgui_open.")
+                text("DRAFT_TAB.open = {DRAFT_TAB.open}")
+                slider_int(D_LINE_LEN, (text = "Line length"))
+            }
+        }
+
+        separator()
+        text("Outside the tab_bar — runs every frame regardless of active tab.")
+        text("DRAFT_TAB.open is observable from out here: {DRAFT_TAB.open}")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/tree_node.das
+++ b/examples/tutorial/tree_node.das
@@ -1,0 +1,144 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: tree_node — expandable branch with auto-paired TreePop.
+//
+//   tree_node(IDENT, (text = "..", flags = ImGuiTreeNodeFlags....)) { body }
+//
+// The [container] form. Body runs only while ImGui reports the node open
+// (chevron expanded). The wrapper handles TreePop automatically when the
+// body's been invoked. Three distinct knobs:
+//
+//   1. flags — ImGuiTreeNodeFlags bitfield. DefaultOpen, OpenOnArrow,
+//      OpenOnDoubleClick, Leaf, Bullet, Framed, NoTreePushOnOpen.
+//
+//   2. state.pending_open / pending_close — flips SetNextItemOpen(true/false,
+//      Always) on the NEXT frame's TreeNodeEx call. The live commands
+//      imgui_open / imgui_close ride this channel.
+//
+//   3. state.opened — per-frame read-only mirror of TreeNodeEx's bool
+//      return. A driver checks "did the user actually expand this?" by
+//      reading state.opened on the snapshot.
+//
+// tree_node vs tree_node_ex:
+//   - tree_node (this tutorial) — [container] block-arg, auto-pairs TreePop.
+//   - tree_node_ex — [widget] leaf form, caller drives TreePop manually
+//     (see examples/features/tree_node_ex.das). Use it when the body needs
+//     to render OUTSIDE the open conditional, e.g. same_line() with a
+//     sibling button on the header row.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/tree_node.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/tree_node.das
+//
+// DRIVE (when running live):
+//   curl -X POST -d '{"name":"imgui_open","args":{"target":"TN_WIN/PHYSICS_TREE"}}' \
+//        localhost:9090/command
+//   curl -X POST -d '{"name":"imgui_close","args":{"target":"TN_WIN/PHYSICS_TREE"}}' \
+//        localhost:9090/command
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui tree_node tutorial", 720, 540)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    PHYSICS_GRAVITY.bounds = (0.0f, 50.0f)
+    PHYSICS_DENSITY.bounds = (0.0f, 10.0f)
+    RENDER_FOV.bounds = (30.0f, 120.0f)
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(680.0f, 500.0f), ImGuiCond.Always)
+    window(TN_WIN, (text = "tree_node tutorial", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        text("Three patterns — DefaultOpen, nested tree_nodes, and OpenOnArrow.")
+        separator()
+
+        // ---- A: DefaultOpen (chevron down from frame 1) ----
+        tree_node(PHYSICS_TREE, (text = "Physics",
+                                 flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+            slider_float(PHYSICS_GRAVITY, (text = "gravity"))
+            slider_float(PHYSICS_DENSITY, (text = "density"))
+            text("PHYSICS_TREE.opened = {PHYSICS_TREE.opened}")
+        }
+
+        // ---- B: nested tree_nodes — Render > [Camera | Mesh] ----
+        tree_node(RENDER_TREE, (text = "Render",
+                                flags = ImGuiTreeNodeFlags.None)) {
+            tree_node(CAMERA_SUBTREE, (text = "Camera",
+                                       flags = ImGuiTreeNodeFlags.DefaultOpen)) {
+                slider_float(RENDER_FOV, (text = "fov"))
+                checkbox(CAMERA_ORTHO, (text = "Orthographic"))
+            }
+            tree_node(MESH_SUBTREE, (text = "Mesh",
+                                     flags = ImGuiTreeNodeFlags.None)) {
+                checkbox(MESH_WIRE, (text = "Wireframe"))
+                checkbox(MESH_NORMALS, (text = "Show normals"))
+            }
+        }
+
+        // ---- C: OpenOnArrow — clicking the label doesn't expand ----
+        tree_node(ASSETS_TREE, (text = "Assets (OpenOnArrow)",
+                                flags = ImGuiTreeNodeFlags.OpenOnArrow)) {
+            text("OpenOnArrow flag — clicking the LABEL doesn't toggle.")
+            text("Click the arrow chevron specifically. Useful for")
+            text("selectable-row trees where the label is the selection.")
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/tree_node.das
+++ b/examples/tutorial/tree_node.das
@@ -110,7 +110,7 @@ def update() {
         // ---- C: OpenOnArrow — clicking the label doesn't expand ----
         tree_node(ASSETS_TREE, (text = "Assets (OpenOnArrow)",
                                 flags = ImGuiTreeNodeFlags.OpenOnArrow)) {
-            text("OpenOnArrow flag — clicking the LABEL doesn't toggle.")
+            text(ASSETS_HINT, (text = "OpenOnArrow flag — clicking the LABEL doesn't toggle."))
             text("Click the arrow chevron specifically. Useful for")
             text("selectable-row trees where the label is the selection.")
         }

--- a/examples/tutorial/tree_node.das
+++ b/examples/tutorial/tree_node.das
@@ -108,8 +108,12 @@ def update() {
         }
 
         // ---- C: OpenOnArrow — clicking the label doesn't expand ----
-        tree_node(ASSETS_TREE, (text = "Assets (OpenOnArrow)",
-                                flags = ImGuiTreeNodeFlags.OpenOnArrow)) {
+        // DefaultOpen so ASSETS_HINT is in the registry from frame 1 (the
+        // recording driver narrates against it). The OpenOnArrow flag is
+        // still demonstrated: collapse via chevron, then try clicking the
+        // label — it stays collapsed. Only the arrow toggles.
+        tree_node(ASSETS_TREE, (text = "Assets (OpenOnArrow + DefaultOpen)",
+                                flags = ImGuiTreeNodeFlags.OpenOnArrow | ImGuiTreeNodeFlags.DefaultOpen)) {
             text(ASSETS_HINT, (text = "OpenOnArrow flag — clicking the LABEL doesn't toggle."))
             text("Click the arrow chevron specifically. Useful for")
             text("selectable-row trees where the label is the selection.")

--- a/tests/integration/record_child.das
+++ b/tests/integration/record_child.das
@@ -46,9 +46,12 @@ def main {
         let T_B_LEAF = "CHILD_WIN/AUTO_B/B_VSYNC"
         let T_C_LEAF = "CHILD_WIN/SCROLL_C/LONG_LINE"
 
-        var snap = wait_for_render(app, T_A_ROW, 10.0f)
+        // wait_for_widget gates on path EXISTENCE; wait_for_render's
+        // widget_rendered defaults to true for absent paths, so a typoed
+        // target would slip past and bboxes would silently be (0,0).
+        var snap = wait_for_widget(app, T_A_ROW, 10.0f)
         if (snap == null) {
-            panic("{T_A_ROW} never rendered — wrong app running?")
+            panic("{T_A_ROW} never registered — wrong app running?")
         }
         let p_a = widget_center(snap, T_A_ROW)
         let p_a_mid = widget_center(snap, T_A_MID)

--- a/tests/integration/record_child.das
+++ b/tests/integration/record_child.das
@@ -1,0 +1,101 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``child.apng`` against
+//! ``examples/tutorial/child.das``. Tours three ``child`` variants —
+//! bordered + scrolled, AutoResizeY + FrameStyle, and horizontal-scroll.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS    = 5000u          //! 5s read window before next stage
+let SETTLE_MS  = 1500u          //! 1.5s cursor settle
+let SCROLL_DWELL_MS = 1800u     //! 1.8s post-scroll dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/child.das",
+                       "child.apng", 60) $(app) {
+        let T_A = "CHILD_WIN/SCROLL_A"
+        let T_B = "CHILD_WIN/AUTO_B"
+        let T_C = "CHILD_WIN/SCROLL_C"
+        let T_WIN = "CHILD_WIN"
+
+        var snap = wait_for_render(app, T_A, 10.0f)
+        if (snap == null) {
+            panic("{T_A} never rendered — wrong app running?")
+        }
+        let p_a = widget_center(snap, T_A)
+        let p_b = widget_center(snap, T_B)
+        let p_c = widget_center(snap, T_C)
+        let p_win = widget_center(snap, T_WIN)
+
+        //! Initial cursor placement — flips synth_cursor_owned.
+        move_to(app, p_win, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: bordered, scrolled child ----
+        move_to(app, p_a, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "child(IDENT, (size, child_flags, window_flags)) — bordered fixed-size with vertical scroll. ChildState.scroll mirrors the visible position.",
+            target = T_A,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: wheel-scroll the bordered child via imgui_mouse_scroll ----
+        post_command(app, "imgui_mouse_scroll", JV((x = 0.0f, y = -3.0f)))
+        sleep(400u)
+        post_command(app, "imgui_mouse_scroll", JV((x = 0.0f, y = -3.0f)))
+        sleep(400u)
+        post_command(app, "imgui_mouse_scroll", JV((x = 0.0f, y = -3.0f)))
+        sleep(SCROLL_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "scroll.y updates after the wheel scrolls the bordered region — the boost wrapper captures GetScrollY() each frame.",
+            target = T_A,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: AutoResizeY + FrameStyle ----
+        move_to(app, p_b, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "AutoResizeY + FrameStyle — height tracks the body's content extent; FrameStyle gives an input-group chrome border.",
+            target = T_B,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: horizontal scroll ----
+        move_to(app, p_c, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "window_flags.HorizontalScrollbar + a wide single line — drag the bottom scroller. scroll.x mirrors the value.",
+            target = T_C,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}

--- a/tests/integration/record_child.das
+++ b/tests/integration/record_child.das
@@ -36,22 +36,27 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 def main {
     with_recording_app("examples/tutorial/child.das",
                        "child.apng", 60) $(app) {
-        let T_A = "CHILD_WIN/SCROLL_A"
-        let T_B = "CHILD_WIN/AUTO_B"
-        let T_C = "CHILD_WIN/SCROLL_C"
-        let T_WIN = "CHILD_WIN"
+        // Anchor every cursor + narration target at a LEAF widget inside each
+        // child — container [container] wrappers (child/group/window/etc.)
+        // don't capture a bbox on finalize, so addressing the container path
+        // resolves to (0,0). Leaves have a real bbox via the per-widget
+        // current_item_bbox snapshot. See PR #67 Copilot review round 1.
+        let T_A_ROW = "CHILD_WIN/SCROLL_A/SCROLL_ROW[0]"
+        let T_A_MID = "CHILD_WIN/SCROLL_A/SCROLL_ROW[5]"
+        let T_B_LEAF = "CHILD_WIN/AUTO_B/B_VSYNC"
+        let T_C_LEAF = "CHILD_WIN/SCROLL_C/LONG_LINE"
 
-        var snap = wait_for_render(app, T_A, 10.0f)
+        var snap = wait_for_render(app, T_A_ROW, 10.0f)
         if (snap == null) {
-            panic("{T_A} never rendered — wrong app running?")
+            panic("{T_A_ROW} never rendered — wrong app running?")
         }
-        let p_a = widget_center(snap, T_A)
-        let p_b = widget_center(snap, T_B)
-        let p_c = widget_center(snap, T_C)
-        let p_win = widget_center(snap, T_WIN)
+        let p_a = widget_center(snap, T_A_ROW)
+        let p_a_mid = widget_center(snap, T_A_MID)
+        let p_b = widget_center(snap, T_B_LEAF)
+        let p_c = widget_center(snap, T_C_LEAF)
 
         //! Initial cursor placement — flips synth_cursor_owned.
-        move_to(app, p_win, 600)
+        move_to(app, p_b, 600)
         sleep(SETTLE_MS)
 
         // ---- Stage 1: bordered, scrolled child ----
@@ -59,12 +64,15 @@ def main {
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
             text = "child(IDENT, (size, child_flags, window_flags)) — bordered fixed-size with vertical scroll. ChildState.scroll mirrors the visible position.",
-            target = T_A,
+            target = T_A_ROW,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
 
         // ---- Stage 2: wheel-scroll the bordered child via imgui_mouse_scroll ----
+        // Park the cursor mid-child so ImGui attributes the wheel event to SCROLL_A.
+        move_to(app, p_a_mid, 600)
+        sleep(SETTLE_MS)
         post_command(app, "imgui_mouse_scroll", JV((x = 0.0f, y = -3.0f)))
         sleep(400u)
         post_command(app, "imgui_mouse_scroll", JV((x = 0.0f, y = -3.0f)))
@@ -73,7 +81,7 @@ def main {
         sleep(SCROLL_DWELL_MS)
         post_command(app, "imgui_narrate", JV((
             text = "scroll.y updates after the wheel scrolls the bordered region — the boost wrapper captures GetScrollY() each frame.",
-            target = T_A,
+            target = T_A_MID,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
@@ -83,7 +91,7 @@ def main {
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
             text = "AutoResizeY + FrameStyle — height tracks the body's content extent; FrameStyle gives an input-group chrome border.",
-            target = T_B,
+            target = T_B_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
@@ -93,7 +101,7 @@ def main {
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
             text = "window_flags.HorizontalScrollbar + a wide single line — drag the bottom scroller. scroll.x mirrors the value.",
-            target = T_C,
+            target = T_C_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)

--- a/tests/integration/record_collapsing_header.das
+++ b/tests/integration/record_collapsing_header.das
@@ -41,19 +41,29 @@ def main {
         // Anchor cursor + narration at LEAF widgets inside each section —
         // collapsing_header finalizes without a bbox. See PR #67 Copilot
         // round 1.
+        let T_BASIC_PATH = "CH_WIN/BASIC_CH"
         let T_BASIC_LEAF = "CH_WIN/BASIC_CH/BASIC_LIVE"
         let T_CLOSABLE_LEAF = "CH_WIN/CLOSABLE_CH/VOLUME"
         let T_CLOSABLE_PATH = "CH_WIN/CLOSABLE_CH"
         let T_STARTUP_LEAF = "CH_WIN/STARTUP_CH/STARTUP_HINT"
 
-        // wait_for_widget gates on existence; wait_for_render passes
-        // through for absent paths.
-        var snap = wait_for_widget(app, T_BASIC_LEAF, 10.0f)
+        // Startup gate on STARTUP_HINT — STARTUP_CH and CLOSABLE_CH are
+        // DefaultOpen so their leaves register frame 1, but BASIC_CH is NOT
+        // DefaultOpen and its body stays unrendered until we imgui_open it.
+        var snap = wait_for_widget(app, T_STARTUP_LEAF, 10.0f)
         if (snap == null) {
-            panic("{T_BASIC_LEAF} never registered — wrong app running?")
+            panic("{T_STARTUP_LEAF} never registered — wrong app running?")
         }
-        let p_basic = widget_center(snap, T_BASIC_LEAF)
         let p_closable = widget_center(snap, T_CLOSABLE_LEAF)
+
+        // Open BASIC_CH so its body widgets exist for Stage 1 narration.
+        post_command(app, "imgui_open", JV((target = T_BASIC_PATH)))
+        sleep(TOGGLE_DWELL_MS)
+        var snap_basic = wait_for_widget(app, T_BASIC_LEAF, 5.0f)
+        if (snap_basic == null) {
+            panic("{T_BASIC_LEAF} never registered after imgui_open {T_BASIC_PATH}")
+        }
+        let p_basic = widget_center(snap_basic, T_BASIC_LEAF)
 
         //! Initial cursor placement.
         move_to(app, p_basic, 600)

--- a/tests/integration/record_collapsing_header.das
+++ b/tests/integration/record_collapsing_header.das
@@ -1,0 +1,123 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``collapsing_header.apng`` against
+//! ``examples/tutorial/collapsing_header.das``. Tours three variants —
+//! basic, closable (X-button), and DefaultOpen.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS    = 5000u          //! 5s read window
+let SETTLE_MS  = 1500u          //! 1.5s cursor settle
+let CHEVRON_DWELL_MS = 2200u    //! 2.2s post-chevron-click dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+def widget_left_edge(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    // Chevron sits in the first ~16px of the header row.
+    return (b.x + 10.0f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/collapsing_header.das",
+                       "collapsing_header.apng", 60) $(app) {
+        let T_BASIC = "CH_WIN/BASIC_CH"
+        let T_CLOSABLE = "CH_WIN/CLOSABLE_CH"
+        let T_STARTUP = "CH_WIN/STARTUP_CH"
+        let T_WIN = "CH_WIN"
+
+        var snap = wait_for_render(app, T_BASIC, 10.0f)
+        if (snap == null) {
+            panic("{T_BASIC} never rendered — wrong app running?")
+        }
+        let p_basic = widget_center(snap, T_BASIC)
+        let p_basic_chevron = widget_left_edge(snap, T_BASIC)
+        let p_closable = widget_center(snap, T_CLOSABLE)
+        let p_startup = widget_center(snap, T_STARTUP)
+        let p_win = widget_center(snap, T_WIN)
+
+        //! Initial cursor placement.
+        move_to(app, p_win, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: hover the basic header, narrate ----
+        move_to(app, p_basic, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "collapsing_header(IDENT, (text, closable, flags)) — section header that folds via the chevron on the left. Unlike tree_node there's no TreePop pair.",
+            target = T_BASIC,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: click the basic chevron to collapse ----
+        var collapse_events : array<JsonValue?>
+        collapse_events |> click_at(0, p_basic_chevron, 200)
+        post_command(app, "imgui_mouse_play", JV((events = collapse_events)))
+        sleep(CHEVRON_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "Chevron click toggles opened — the body stops rendering until reopened. State.opened mirrors the per-frame fold.",
+            target = T_BASIC,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        var expand_events : array<JsonValue?>
+        expand_events |> click_at(0, p_basic_chevron, 200)
+        post_command(app, "imgui_mouse_play", JV((events = expand_events)))
+        sleep(1500u)
+
+        // ---- Stage 3: closable header ----
+        move_to(app, p_closable, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "closable=true adds an X-button on the right of the header strip. Click X to set state.open=false; the whole row disappears.",
+            target = T_CLOSABLE,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: drive imgui_close on closable header ----
+        post_command(app, "imgui_close", JV((target = T_CLOSABLE)))
+        sleep(1800u)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_close flips pending_close; next frame the closable header is hidden entirely. Re-open via imgui_open against the same target.",
+            target = T_WIN,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        post_command(app, "imgui_open", JV((target = T_CLOSABLE)))
+        sleep(1500u)
+
+        // ---- Stage 5: DefaultOpen ----
+        move_to(app, p_startup, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "ImGuiTreeNodeFlags.DefaultOpen — first-render expansion; user input afterwards. Same flag enum as tree_node.",
+            target = T_STARTUP,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}
+

--- a/tests/integration/record_collapsing_header.das
+++ b/tests/integration/record_collapsing_header.das
@@ -46,9 +46,11 @@ def main {
         let T_CLOSABLE_PATH = "CH_WIN/CLOSABLE_CH"
         let T_STARTUP_LEAF = "CH_WIN/STARTUP_CH/STARTUP_HINT"
 
-        var snap = wait_for_render(app, T_BASIC_LEAF, 10.0f)
+        // wait_for_widget gates on existence; wait_for_render passes
+        // through for absent paths.
+        var snap = wait_for_widget(app, T_BASIC_LEAF, 10.0f)
         if (snap == null) {
-            panic("{T_BASIC_LEAF} never rendered — wrong app running?")
+            panic("{T_BASIC_LEAF} never registered — wrong app running?")
         }
         let p_basic = widget_center(snap, T_BASIC_LEAF)
         let p_closable = widget_center(snap, T_CLOSABLE_LEAF)

--- a/tests/integration/record_collapsing_header.das
+++ b/tests/integration/record_collapsing_header.das
@@ -81,7 +81,7 @@ def main {
         post_command(app, "imgui_close", JV((target = T_CLOSABLE_PATH)))
         sleep(TOGGLE_DWELL_MS)
         post_command(app, "imgui_narrate", JV((
-            text = "imgui_close flips pending_close; next frame the closable header is hidden entirely. Re-open via imgui_open against the same target.",
+            text = "imgui_close flips pending_close; next frame the chevron collapses and the body stops rendering. The header STRIP stays visible — only the X-button (or app code setting state.open=false) hides the whole row.",
             target = T_BASIC_LEAF,
             frames = NARRATE_FRAMES
         )))
@@ -90,8 +90,6 @@ def main {
         sleep(1500u)
 
         // ---- Stage 4: DefaultOpen flag — narrate via STARTUP_CH path ----
-        // Re-snapshot so we see the now-reopened CLOSABLE section's leaf
-        // and grab STARTUP_CH for a final narration anchor.
         post_command(app, "imgui_narrate", JV((
             text = "ImGuiTreeNodeFlags.DefaultOpen — first-render expansion; user input afterwards. Same flag enum as tree_node.",
             target = T_STARTUP_LEAF,

--- a/tests/integration/record_collapsing_header.das
+++ b/tests/integration/record_collapsing_header.das
@@ -10,12 +10,14 @@ require daslib/json_boost public
 
 //! Driver script: record ``collapsing_header.apng`` against
 //! ``examples/tutorial/collapsing_header.das``. Tours three variants —
-//! basic, closable (X-button), and DefaultOpen.
+//! basic, closable (X-button), and DefaultOpen. Open/close is driven
+//! via imgui_open / imgui_close because collapsing_header's [container]
+//! wrapper doesn't capture a header bbox (chevron click would need one).
 
 let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
 let READ_MS    = 5000u          //! 5s read window
 let SETTLE_MS  = 1500u          //! 1.5s cursor settle
-let CHEVRON_DWELL_MS = 2200u    //! 2.2s post-chevron-click dwell
+let TOGGLE_DWELL_MS = 2200u     //! 2.2s post-toggle dwell
 
 def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
     var b = snap?["globals"]?[ident]?["bbox"]
@@ -32,92 +34,69 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
     return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
 }
 
-def widget_left_edge(var snap : JsonValue?; ident : string) : tuple<float; float> {
-    let b = widget_bbox(snap, ident)
-    // Chevron sits in the first ~16px of the header row.
-    return (b.x + 10.0f, (b.y + b.w) * 0.5f)
-}
-
 [export]
 def main {
     with_recording_app("examples/tutorial/collapsing_header.das",
                        "collapsing_header.apng", 60) $(app) {
-        let T_BASIC = "CH_WIN/BASIC_CH"
-        let T_CLOSABLE = "CH_WIN/CLOSABLE_CH"
-        let T_STARTUP = "CH_WIN/STARTUP_CH"
-        let T_WIN = "CH_WIN"
+        // Anchor cursor + narration at LEAF widgets inside each section —
+        // collapsing_header finalizes without a bbox. See PR #67 Copilot
+        // round 1.
+        let T_BASIC_LEAF = "CH_WIN/BASIC_CH/BASIC_LIVE"
+        let T_CLOSABLE_LEAF = "CH_WIN/CLOSABLE_CH/VOLUME"
+        let T_CLOSABLE_PATH = "CH_WIN/CLOSABLE_CH"
+        let T_STARTUP_LEAF = "CH_WIN/STARTUP_CH/STARTUP_HINT"
 
-        var snap = wait_for_render(app, T_BASIC, 10.0f)
+        var snap = wait_for_render(app, T_BASIC_LEAF, 10.0f)
         if (snap == null) {
-            panic("{T_BASIC} never rendered — wrong app running?")
+            panic("{T_BASIC_LEAF} never rendered — wrong app running?")
         }
-        let p_basic = widget_center(snap, T_BASIC)
-        let p_basic_chevron = widget_left_edge(snap, T_BASIC)
-        let p_closable = widget_center(snap, T_CLOSABLE)
-        let p_startup = widget_center(snap, T_STARTUP)
-        let p_win = widget_center(snap, T_WIN)
+        let p_basic = widget_center(snap, T_BASIC_LEAF)
+        let p_closable = widget_center(snap, T_CLOSABLE_LEAF)
 
         //! Initial cursor placement.
-        move_to(app, p_win, 600)
+        move_to(app, p_basic, 600)
         sleep(SETTLE_MS)
 
-        // ---- Stage 1: hover the basic header, narrate ----
+        // ---- Stage 1: narrate the basic section ----
         move_to(app, p_basic, 900)
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
-            text = "collapsing_header(IDENT, (text, closable, flags)) — section header that folds via the chevron on the left. Unlike tree_node there's no TreePop pair.",
-            target = T_BASIC,
+            text = "collapsing_header(IDENT, (text, closable, flags)) — section header that folds via the chevron. Unlike tree_node there's no TreePop pair.",
+            target = T_BASIC_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
 
-        // ---- Stage 2: click the basic chevron to collapse ----
-        var collapse_events : array<JsonValue?>
-        collapse_events |> click_at(0, p_basic_chevron, 200)
-        post_command(app, "imgui_mouse_play", JV((events = collapse_events)))
-        sleep(CHEVRON_DWELL_MS)
-        post_command(app, "imgui_narrate", JV((
-            text = "Chevron click toggles opened — the body stops rendering until reopened. State.opened mirrors the per-frame fold.",
-            target = T_BASIC,
-            frames = NARRATE_FRAMES
-        )))
-        sleep(READ_MS)
-        var expand_events : array<JsonValue?>
-        expand_events |> click_at(0, p_basic_chevron, 200)
-        post_command(app, "imgui_mouse_play", JV((events = expand_events)))
-        sleep(1500u)
-
-        // ---- Stage 3: closable header ----
+        // ---- Stage 2: hover the closable section's slider ----
         move_to(app, p_closable, 900)
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
             text = "closable=true adds an X-button on the right of the header strip. Click X to set state.open=false; the whole row disappears.",
-            target = T_CLOSABLE,
+            target = T_CLOSABLE_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
 
-        // ---- Stage 4: drive imgui_close on closable header ----
-        post_command(app, "imgui_close", JV((target = T_CLOSABLE)))
-        sleep(1800u)
+        // ---- Stage 3: drive imgui_close on closable header ----
+        post_command(app, "imgui_close", JV((target = T_CLOSABLE_PATH)))
+        sleep(TOGGLE_DWELL_MS)
         post_command(app, "imgui_narrate", JV((
             text = "imgui_close flips pending_close; next frame the closable header is hidden entirely. Re-open via imgui_open against the same target.",
-            target = T_WIN,
+            target = T_BASIC_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
-        post_command(app, "imgui_open", JV((target = T_CLOSABLE)))
+        post_command(app, "imgui_open", JV((target = T_CLOSABLE_PATH)))
         sleep(1500u)
 
-        // ---- Stage 5: DefaultOpen ----
-        move_to(app, p_startup, 900)
-        sleep(SETTLE_MS)
+        // ---- Stage 4: DefaultOpen flag — narrate via STARTUP_CH path ----
+        // Re-snapshot so we see the now-reopened CLOSABLE section's leaf
+        // and grab STARTUP_CH for a final narration anchor.
         post_command(app, "imgui_narrate", JV((
             text = "ImGuiTreeNodeFlags.DefaultOpen — first-render expansion; user input afterwards. Same flag enum as tree_node.",
-            target = T_STARTUP,
+            target = T_STARTUP_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
     }
 }
-

--- a/tests/integration/record_group.das
+++ b/tests/integration/record_group.das
@@ -45,9 +45,11 @@ def main {
         let T_HOVER = "GRP_WIN/HOVER_GRP/HOVER_BTN"
         let T_ROW = "GRP_WIN/ROW_GRP/ROW_RESET"
 
-        var snap = wait_for_render(app, T_LEFT, 10.0f)
+        // wait_for_widget gates on existence; wait_for_render passes
+        // through for absent paths (widget_rendered defaults to true).
+        var snap = wait_for_widget(app, T_LEFT, 10.0f)
         if (snap == null) {
-            panic("{T_LEFT} never rendered — wrong app running?")
+            panic("{T_LEFT} never registered — wrong app running?")
         }
         let p_left = widget_center(snap, T_LEFT)
         let p_right = widget_center(snap, T_RIGHT)

--- a/tests/integration/record_group.das
+++ b/tests/integration/record_group.das
@@ -37,11 +37,13 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 def main {
     with_recording_app("examples/tutorial/group.das",
                        "group.apng", 60) $(app) {
-        let T_LEFT = "GRP_WIN/LEFT_GRP"
-        let T_RIGHT = "GRP_WIN/RIGHT_GRP"
-        let T_HOVER = "GRP_WIN/HOVER_GRP"
-        let T_ROW = "GRP_WIN/ROW_GRP"
-        let T_WIN = "GRP_WIN"
+        // Anchor cursor + narration at LEAF widgets inside each group —
+        // group's [container] wrapper finalizes without a bbox. See PR #67
+        // Copilot round 1.
+        let T_LEFT = "GRP_WIN/LEFT_GRP/L_WIRE"
+        let T_RIGHT = "GRP_WIN/RIGHT_GRP/R_VSYNC"
+        let T_HOVER = "GRP_WIN/HOVER_GRP/HOVER_BTN"
+        let T_ROW = "GRP_WIN/ROW_GRP/ROW_RESET"
 
         var snap = wait_for_render(app, T_LEFT, 10.0f)
         if (snap == null) {
@@ -51,10 +53,9 @@ def main {
         let p_right = widget_center(snap, T_RIGHT)
         let p_hover = widget_center(snap, T_HOVER)
         let p_row = widget_center(snap, T_ROW)
-        let p_win = widget_center(snap, T_WIN)
 
         //! Initial cursor placement.
-        move_to(app, p_win, 600)
+        move_to(app, p_left, 600)
         sleep(SETTLE_MS)
 
         // ---- Stage 1: side-by-side groups ----

--- a/tests/integration/record_group.das
+++ b/tests/integration/record_group.das
@@ -1,0 +1,99 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``group.apng`` against
+//! ``examples/tutorial/group.das``. Tours three group patterns —
+//! side-by-side via same_line, group-as-hit-target with tooltip, and
+//! the (label | value | button) row composition.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS    = 5000u          //! 5s read window
+let SETTLE_MS  = 1500u          //! 1.5s cursor settle
+let HOVER_DWELL_MS = 2200u      //! 2.2s tooltip dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/group.das",
+                       "group.apng", 60) $(app) {
+        let T_LEFT = "GRP_WIN/LEFT_GRP"
+        let T_RIGHT = "GRP_WIN/RIGHT_GRP"
+        let T_HOVER = "GRP_WIN/HOVER_GRP"
+        let T_ROW = "GRP_WIN/ROW_GRP"
+        let T_WIN = "GRP_WIN"
+
+        var snap = wait_for_render(app, T_LEFT, 10.0f)
+        if (snap == null) {
+            panic("{T_LEFT} never rendered — wrong app running?")
+        }
+        let p_left = widget_center(snap, T_LEFT)
+        let p_right = widget_center(snap, T_RIGHT)
+        let p_hover = widget_center(snap, T_HOVER)
+        let p_row = widget_center(snap, T_ROW)
+        let p_win = widget_center(snap, T_WIN)
+
+        //! Initial cursor placement.
+        move_to(app, p_win, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: side-by-side groups ----
+        move_to(app, p_left, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "group(IDENT) wraps BeginGroup/EndGroup. same_line() after a closed group continues from the group's right edge — that's how two stacked column blocks share a row.",
+            target = T_LEFT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        move_to(app, p_right, 700)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "Right group's first text line aligns with the left's — same_line preserved the row baseline. The path push still happens: LEFT_GRP/L_WIRE vs RIGHT_GRP/R_VSYNC.",
+            target = T_RIGHT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: hover the group to fire the combined-bbox tooltip ----
+        move_to(app, p_hover, 900)
+        sleep(HOVER_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "IsItemHovered() after EndGroup() reports against the combined bbox — hover anywhere in the [i] Info ... Action row to fire the tooltip.",
+            target = T_HOVER,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: the row pattern ----
+        move_to(app, p_row, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "(label | value | button) — common pattern. The group keeps Speed/slider/Reset on one logical row even if the body grows.",
+            target = T_ROW,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}

--- a/tests/integration/record_popup_modal.das
+++ b/tests/integration/record_popup_modal.das
@@ -70,8 +70,12 @@ def main {
         // ---- Stage 2: open the confirm modal via imgui_open ----
         post_command(app, "imgui_open", JV((target = "PM_WIN/CONFIRM_MODAL")))
         sleep(MODAL_DWELL_MS)
-        // Once the modal is up, its CONFIRM_YES button is a registered leaf.
-        // Anchor narration there for a stable position over the modal.
+        // Gate narration on CONFIRM_YES actually being registered — otherwise
+        // a slow modal open silently lands the overlay at (0,0).
+        var ack_snap = wait_for_widget(app, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES", 5.0f)
+        if (ack_snap == null) {
+            panic("PM_WIN/CONFIRM_MODAL/CONFIRM_YES never registered — imgui_open didn't take")
+        }
         post_command(app, "imgui_narrate", JV((
             text = "imgui_open flips pending_open; next frame the modal opens via OpenPopup. The Yes/No buttons fall through to state.pending_close on click.",
             target = "PM_WIN/CONFIRM_MODAL/CONFIRM_YES",
@@ -80,14 +84,10 @@ def main {
         sleep(READ_MS)
 
         // ---- Stage 3: close the confirm modal via Yes-button click ----
-        // After the modal is open, CONFIRM_YES is registered.
-        var ack_snap = wait_for_widget(app, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES", 5.0f)
-        if (ack_snap != null) {
-            let p_yes = widget_center(ack_snap, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES")
-            var yes_events : array<JsonValue?>
-            yes_events |> click_at(0, p_yes, 200)
-            post_command(app, "imgui_mouse_play", JV((events = yes_events)))
-        }
+        let p_yes = widget_center(ack_snap, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES")
+        var yes_events : array<JsonValue?>
+        yes_events |> click_at(0, p_yes, 200)
+        post_command(app, "imgui_mouse_play", JV((events = yes_events)))
         sleep(MODAL_DWELL_MS)
         move_to(app, p_status, 700)
         sleep(SETTLE_MS)
@@ -103,6 +103,12 @@ def main {
         sleep(SETTLE_MS)
         post_command(app, "imgui_open", JV((target = "PM_WIN/SETTINGS_MODAL")))
         sleep(MODAL_DWELL_MS)
+        // Gate on S_APPLY existing — S_AUTOSAVE registers in the same frame
+        // (same modal body), so the narrate target is safe once S_APPLY is up.
+        var apply_snap = wait_for_widget(app, "PM_WIN/SETTINGS_MODAL/S_APPLY", 5.0f)
+        if (apply_snap == null) {
+            panic("PM_WIN/SETTINGS_MODAL body never registered — imgui_open didn't take")
+        }
         post_command(app, "imgui_narrate", JV((
             text = "closable=true adds an X-button on the title bar. ImGui wires it to state.open — click X (or press ESC) to flip open=false and dismiss.",
             target = "PM_WIN/SETTINGS_MODAL/S_AUTOSAVE",
@@ -111,13 +117,10 @@ def main {
         sleep(READ_MS)
 
         // ---- Stage 5: dismiss via Apply button ----
-        var apply_snap = wait_for_widget(app, "PM_WIN/SETTINGS_MODAL/S_APPLY", 5.0f)
-        if (apply_snap != null) {
-            let p_apply = widget_center(apply_snap, "PM_WIN/SETTINGS_MODAL/S_APPLY")
-            var apply_events : array<JsonValue?>
-            apply_events |> click_at(0, p_apply, 200)
-            post_command(app, "imgui_mouse_play", JV((events = apply_events)))
-        }
+        let p_apply = widget_center(apply_snap, "PM_WIN/SETTINGS_MODAL/S_APPLY")
+        var apply_events : array<JsonValue?>
+        apply_events |> click_at(0, p_apply, 200)
+        post_command(app, "imgui_mouse_play", JV((events = apply_events)))
         sleep(MODAL_DWELL_MS)
     }
 }

--- a/tests/integration/record_popup_modal.das
+++ b/tests/integration/record_popup_modal.das
@@ -36,10 +36,12 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 def main {
     with_recording_app("examples/tutorial/popup_modal.das",
                        "popup_modal.apng", 60) $(app) {
+        // window/popup_modal containers finalize without a bbox — anchor
+        // every cursor + narration target at a button or text leaf. See
+        // PR #67 Copilot round 1.
         let T_OPEN_CONFIRM = "PM_WIN/OPEN_CONFIRM"
         let T_OPEN_SETTINGS = "PM_WIN/OPEN_SETTINGS"
         let T_STATUS = "PM_WIN/STATUS_LINE"
-        let T_WIN = "PM_WIN"
 
         var snap = wait_for_render(app, T_OPEN_CONFIRM, 10.0f)
         if (snap == null) {
@@ -48,10 +50,9 @@ def main {
         let p_confirm_btn = widget_center(snap, T_OPEN_CONFIRM)
         let p_settings_btn = widget_center(snap, T_OPEN_SETTINGS)
         let p_status = widget_center(snap, T_STATUS)
-        let p_win = widget_center(snap, T_WIN)
 
         //! Initial cursor placement.
-        move_to(app, p_win, 600)
+        move_to(app, p_confirm_btn, 600)
         sleep(SETTLE_MS)
 
         // ---- Stage 1: narrate the confirm trigger ----
@@ -67,9 +68,11 @@ def main {
         // ---- Stage 2: open the confirm modal via imgui_open ----
         post_command(app, "imgui_open", JV((target = "PM_WIN/CONFIRM_MODAL")))
         sleep(MODAL_DWELL_MS)
+        // Once the modal is up, its CONFIRM_YES button is a registered leaf.
+        // Anchor narration there for a stable position over the modal.
         post_command(app, "imgui_narrate", JV((
             text = "imgui_open flips pending_open; next frame the modal opens via OpenPopup. The Yes/No buttons fall through to state.pending_close on click.",
-            target = T_WIN,
+            target = "PM_WIN/CONFIRM_MODAL/CONFIRM_YES",
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
@@ -100,7 +103,7 @@ def main {
         sleep(MODAL_DWELL_MS)
         post_command(app, "imgui_narrate", JV((
             text = "closable=true adds an X-button on the title bar. ImGui wires it to state.open — click X (or press ESC) to flip open=false and dismiss.",
-            target = T_WIN,
+            target = "PM_WIN/SETTINGS_MODAL/S_AUTOSAVE",
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)

--- a/tests/integration/record_popup_modal.das
+++ b/tests/integration/record_popup_modal.das
@@ -1,0 +1,118 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``popup_modal.apng`` against
+//! ``examples/tutorial/popup_modal.das``. Tours a Yes/No confirm modal
+//! (non-closable) and an X-button settings modal.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS    = 5000u          //! 5s read window
+let SETTLE_MS  = 1500u          //! 1.5s cursor settle
+let MODAL_DWELL_MS = 2200u      //! 2.2s post-modal-open dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/popup_modal.das",
+                       "popup_modal.apng", 60) $(app) {
+        let T_OPEN_CONFIRM = "PM_WIN/OPEN_CONFIRM"
+        let T_OPEN_SETTINGS = "PM_WIN/OPEN_SETTINGS"
+        let T_STATUS = "PM_WIN/STATUS_LINE"
+        let T_WIN = "PM_WIN"
+
+        var snap = wait_for_render(app, T_OPEN_CONFIRM, 10.0f)
+        if (snap == null) {
+            panic("{T_OPEN_CONFIRM} never rendered — wrong app running?")
+        }
+        let p_confirm_btn = widget_center(snap, T_OPEN_CONFIRM)
+        let p_settings_btn = widget_center(snap, T_OPEN_SETTINGS)
+        let p_status = widget_center(snap, T_STATUS)
+        let p_win = widget_center(snap, T_WIN)
+
+        //! Initial cursor placement.
+        move_to(app, p_win, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: narrate the confirm trigger ----
+        move_to(app, p_confirm_btn, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "popup_modal(IDENT, (closable, flags)) — blocking dialog. ImGui dims the parent window and absorbs clicks outside the modal until it closes.",
+            target = T_OPEN_CONFIRM,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: open the confirm modal via imgui_open ----
+        post_command(app, "imgui_open", JV((target = "PM_WIN/CONFIRM_MODAL")))
+        sleep(MODAL_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_open flips pending_open; next frame the modal opens via OpenPopup. The Yes/No buttons fall through to state.pending_close on click.",
+            target = T_WIN,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: close the confirm modal via Yes-button click ----
+        // After the modal is open, CONFIRM_YES is registered.
+        var ack_snap = wait_for_render(app, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES", 5.0f)
+        if (ack_snap != null) {
+            let p_yes = widget_center(ack_snap, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES")
+            var yes_events : array<JsonValue?>
+            yes_events |> click_at(0, p_yes, 200)
+            post_command(app, "imgui_mouse_play", JV((events = yes_events)))
+        }
+        sleep(MODAL_DWELL_MS)
+        move_to(app, p_status, 700)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "Modal closed via Yes click — CONFIRM_RESULT updated, modal dismissed. CONFIRM_MODAL.open is back to false.",
+            target = T_STATUS,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: settings modal with closable X-button ----
+        move_to(app, p_settings_btn, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_open", JV((target = "PM_WIN/SETTINGS_MODAL")))
+        sleep(MODAL_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "closable=true adds an X-button on the title bar. ImGui wires it to state.open — click X (or press ESC) to flip open=false and dismiss.",
+            target = T_WIN,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 5: dismiss via Apply button ----
+        var apply_snap = wait_for_render(app, "PM_WIN/SETTINGS_MODAL/S_APPLY", 5.0f)
+        if (apply_snap != null) {
+            let p_apply = widget_center(apply_snap, "PM_WIN/SETTINGS_MODAL/S_APPLY")
+            var apply_events : array<JsonValue?>
+            apply_events |> click_at(0, p_apply, 200)
+            post_command(app, "imgui_mouse_play", JV((events = apply_events)))
+        }
+        sleep(MODAL_DWELL_MS)
+    }
+}

--- a/tests/integration/record_popup_modal.das
+++ b/tests/integration/record_popup_modal.das
@@ -43,9 +43,11 @@ def main {
         let T_OPEN_SETTINGS = "PM_WIN/OPEN_SETTINGS"
         let T_STATUS = "PM_WIN/STATUS_LINE"
 
-        var snap = wait_for_render(app, T_OPEN_CONFIRM, 10.0f)
+        // wait_for_widget gates on existence; wait_for_render passes
+        // through for absent paths.
+        var snap = wait_for_widget(app, T_OPEN_CONFIRM, 10.0f)
         if (snap == null) {
-            panic("{T_OPEN_CONFIRM} never rendered — wrong app running?")
+            panic("{T_OPEN_CONFIRM} never registered — wrong app running?")
         }
         let p_confirm_btn = widget_center(snap, T_OPEN_CONFIRM)
         let p_settings_btn = widget_center(snap, T_OPEN_SETTINGS)
@@ -79,7 +81,7 @@ def main {
 
         // ---- Stage 3: close the confirm modal via Yes-button click ----
         // After the modal is open, CONFIRM_YES is registered.
-        var ack_snap = wait_for_render(app, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES", 5.0f)
+        var ack_snap = wait_for_widget(app, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES", 5.0f)
         if (ack_snap != null) {
             let p_yes = widget_center(ack_snap, "PM_WIN/CONFIRM_MODAL/CONFIRM_YES")
             var yes_events : array<JsonValue?>
@@ -109,7 +111,7 @@ def main {
         sleep(READ_MS)
 
         // ---- Stage 5: dismiss via Apply button ----
-        var apply_snap = wait_for_render(app, "PM_WIN/SETTINGS_MODAL/S_APPLY", 5.0f)
+        var apply_snap = wait_for_widget(app, "PM_WIN/SETTINGS_MODAL/S_APPLY", 5.0f)
         if (apply_snap != null) {
             let p_apply = widget_center(apply_snap, "PM_WIN/SETTINGS_MODAL/S_APPLY")
             var apply_events : array<JsonValue?>

--- a/tests/integration/record_tab_bar.das
+++ b/tests/integration/record_tab_bar.das
@@ -36,12 +36,14 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 def main {
     with_recording_app("examples/tutorial/tab_bar.das",
                        "tab_bar.apng", 60) $(app) {
+        // tab_item DOES capture a header bbox (current_item_bbox after
+        // BeginTabItem), so these paths resolve correctly. The bar itself
+        // (TB_WIN/MAIN_TABS) is stateless_finalize without bbox — anchor
+        // narration at a tab header instead. See PR #67 Copilot round 1.
         let T_GENERAL = "TB_WIN/MAIN_TABS/GENERAL_TAB"
         let T_AUDIO = "TB_WIN/MAIN_TABS/AUDIO_TAB"
         let T_INFO = "TB_WIN/MAIN_TABS/INFO_TAB"
         let T_DRAFT = "TB_WIN/MAIN_TABS/DRAFT_TAB"
-        let T_BAR = "TB_WIN/MAIN_TABS"
-        let T_WIN = "TB_WIN"
 
         var snap = wait_for_render(app, T_GENERAL, 10.0f)
         if (snap == null) {
@@ -51,10 +53,9 @@ def main {
         let p_audio = widget_center(snap, T_AUDIO)
         let p_info = widget_center(snap, T_INFO)
         let p_draft = widget_center(snap, T_DRAFT)
-        let p_win = widget_center(snap, T_WIN)
 
         //! Initial cursor placement.
-        move_to(app, p_win, 600)
+        move_to(app, p_general, 600)
         sleep(SETTLE_MS)
 
         // ---- Stage 1: hover the tab strip ----
@@ -62,7 +63,7 @@ def main {
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
             text = "tab_bar(IDENT, (flags)) hosts tab_item children. Only the active tab's body block runs; ImGui owns active-tab selection internally.",
-            target = T_BAR,
+            target = T_GENERAL,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
@@ -105,9 +106,11 @@ def main {
 
         post_command(app, "imgui_close", JV((target = T_DRAFT)))
         sleep(SWITCH_DWELL_MS)
+        // DRAFT_TAB is gone from the registry now; anchor narration at
+        // GENERAL_TAB (a still-visible tab header) instead.
         post_command(app, "imgui_narrate", JV((
             text = "imgui_close routes through pending_close — Draft disappears from the strip. imgui_open against the same path re-registers it.",
-            target = T_BAR,
+            target = T_GENERAL,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)

--- a/tests/integration/record_tab_bar.das
+++ b/tests/integration/record_tab_bar.das
@@ -45,9 +45,11 @@ def main {
         let T_INFO = "TB_WIN/MAIN_TABS/INFO_TAB"
         let T_DRAFT = "TB_WIN/MAIN_TABS/DRAFT_TAB"
 
-        var snap = wait_for_render(app, T_GENERAL, 10.0f)
+        // wait_for_widget gates on existence; wait_for_render passes
+        // through for absent paths.
+        var snap = wait_for_widget(app, T_GENERAL, 10.0f)
         if (snap == null) {
-            panic("{T_GENERAL} never rendered — wrong app running?")
+            panic("{T_GENERAL} never registered — wrong app running?")
         }
         let p_general = widget_center(snap, T_GENERAL)
         let p_audio = widget_center(snap, T_AUDIO)

--- a/tests/integration/record_tab_bar.das
+++ b/tests/integration/record_tab_bar.das
@@ -1,0 +1,118 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``tab_bar.apng`` against
+//! ``examples/tutorial/tab_bar.das``. Tours active-tab switching via
+//! imgui_click against tab headers and the closable-X behavior.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS    = 5000u          //! 5s read window
+let SETTLE_MS  = 1500u          //! 1.5s cursor settle
+let SWITCH_DWELL_MS = 1800u     //! 1.8s post-tab-switch dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/tab_bar.das",
+                       "tab_bar.apng", 60) $(app) {
+        let T_GENERAL = "TB_WIN/MAIN_TABS/GENERAL_TAB"
+        let T_AUDIO = "TB_WIN/MAIN_TABS/AUDIO_TAB"
+        let T_INFO = "TB_WIN/MAIN_TABS/INFO_TAB"
+        let T_DRAFT = "TB_WIN/MAIN_TABS/DRAFT_TAB"
+        let T_BAR = "TB_WIN/MAIN_TABS"
+        let T_WIN = "TB_WIN"
+
+        var snap = wait_for_render(app, T_GENERAL, 10.0f)
+        if (snap == null) {
+            panic("{T_GENERAL} never rendered — wrong app running?")
+        }
+        let p_general = widget_center(snap, T_GENERAL)
+        let p_audio = widget_center(snap, T_AUDIO)
+        let p_info = widget_center(snap, T_INFO)
+        let p_draft = widget_center(snap, T_DRAFT)
+        let p_win = widget_center(snap, T_WIN)
+
+        //! Initial cursor placement.
+        move_to(app, p_win, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: hover the tab strip ----
+        move_to(app, p_general, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "tab_bar(IDENT, (flags)) hosts tab_item children. Only the active tab's body block runs; ImGui owns active-tab selection internally.",
+            target = T_BAR,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: click Audio tab via imgui_click ----
+        post_command(app, "imgui_click", JV((target = T_AUDIO)))
+        sleep(SWITCH_DWELL_MS)
+        move_to(app, p_audio, 700)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_click against a tab header switches the active tab. The General body stopped registering its checkboxes — only Audio's widgets are in the snapshot now.",
+            target = T_AUDIO,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: switch to Info ----
+        post_command(app, "imgui_click", JV((target = T_INFO)))
+        sleep(SWITCH_DWELL_MS)
+        move_to(app, p_info, 700)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "Tab switching is path-routed — every tab_item is registered under MAIN_TABS/. Drivers don't need access to ImGui internals.",
+            target = T_INFO,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: switch to Draft, then close it ----
+        post_command(app, "imgui_click", JV((target = T_DRAFT)))
+        sleep(SWITCH_DWELL_MS)
+        move_to(app, p_draft, 700)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "Draft is closable — the X-button next to the label flips state.open=false. Next frame the tab is skipped entirely.",
+            target = T_DRAFT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        post_command(app, "imgui_close", JV((target = T_DRAFT)))
+        sleep(SWITCH_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_close routes through pending_close — Draft disappears from the strip. imgui_open against the same path re-registers it.",
+            target = T_BAR,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        post_command(app, "imgui_open", JV((target = T_DRAFT)))
+        sleep(1500u)
+    }
+}

--- a/tests/integration/record_tree_node.das
+++ b/tests/integration/record_tree_node.das
@@ -84,19 +84,21 @@ def main {
         // ---- Stage 3: open RENDER, then narrate nesting ----
         post_command(app, "imgui_open", JV((target = T_RENDER_PATH)))
         sleep(TOGGLE_DWELL_MS)
-        // Re-snap to pick up the now-rendered RENDER children.
+        // Re-snap to pick up the now-rendered RENDER children. Narration must
+        // stay inside this guard — narrating against an unregistered T_FOV_LEAF
+        // silently lands the overlay at (0,0).
         var snap2 = wait_for_widget(app, T_FOV_LEAF, 5.0f)
         if (snap2 != null) {
             let p_fov = widget_center(snap2, T_FOV_LEAF)
             move_to(app, p_fov, 700)
             sleep(SETTLE_MS)
+            post_command(app, "imgui_narrate", JV((
+                text = "Nested tree_nodes compose freely. Camera subtree's slider registers at TN_WIN/RENDER_TREE/CAMERA_SUBTREE/RENDER_FOV — three-deep path.",
+                target = T_FOV_LEAF,
+                frames = NARRATE_FRAMES
+            )))
+            sleep(READ_MS)
         }
-        post_command(app, "imgui_narrate", JV((
-            text = "Nested tree_nodes compose freely. Camera subtree's slider registers at TN_WIN/RENDER_TREE/CAMERA_SUBTREE/RENDER_FOV — three-deep path.",
-            target = T_FOV_LEAF,
-            frames = NARRATE_FRAMES
-        )))
-        sleep(READ_MS)
 
         // ---- Stage 4: ASSETS (OpenOnArrow) ----
         // Re-snap because the layout has shifted (RENDER_TREE is now open,

--- a/tests/integration/record_tree_node.das
+++ b/tests/integration/record_tree_node.das
@@ -45,9 +45,11 @@ def main {
         let T_FOV_LEAF = "TN_WIN/RENDER_TREE/CAMERA_SUBTREE/RENDER_FOV"
         let T_ASSETS_LEAF = "TN_WIN/ASSETS_TREE/ASSETS_HINT"
 
-        var snap = wait_for_render(app, T_PHYSICS_LEAF, 10.0f)
+        // wait_for_widget gates on existence; wait_for_render passes
+        // through for absent paths.
+        var snap = wait_for_widget(app, T_PHYSICS_LEAF, 10.0f)
         if (snap == null) {
-            panic("{T_PHYSICS_LEAF} never rendered — wrong app running?")
+            panic("{T_PHYSICS_LEAF} never registered — wrong app running?")
         }
         let p_physics = widget_center(snap, T_PHYSICS_LEAF)
 
@@ -83,7 +85,7 @@ def main {
         post_command(app, "imgui_open", JV((target = T_RENDER_PATH)))
         sleep(TOGGLE_DWELL_MS)
         // Re-snap to pick up the now-rendered RENDER children.
-        var snap2 = wait_for_render(app, T_FOV_LEAF, 5.0f)
+        var snap2 = wait_for_widget(app, T_FOV_LEAF, 5.0f)
         if (snap2 != null) {
             let p_fov = widget_center(snap2, T_FOV_LEAF)
             move_to(app, p_fov, 700)
@@ -101,7 +103,7 @@ def main {
         // pushing ASSETS_TREE down). ASSETS_HINT exists from frame 1 because
         // the tutorial source declares ASSETS_TREE with DefaultOpen.
         var p_assets = widget_center(snap, T_ASSETS_LEAF)
-        var snap_assets = wait_for_render(app, T_ASSETS_LEAF, 5.0f)
+        var snap_assets = wait_for_widget(app, T_ASSETS_LEAF, 5.0f)
         if (snap_assets != null) {
             p_assets = widget_center(snap_assets, T_ASSETS_LEAF)
         }

--- a/tests/integration/record_tree_node.das
+++ b/tests/integration/record_tree_node.das
@@ -97,7 +97,14 @@ def main {
         sleep(READ_MS)
 
         // ---- Stage 4: ASSETS (OpenOnArrow) ----
-        let p_assets = widget_center(snap, T_ASSETS_LEAF)
+        // Re-snap because the layout has shifted (RENDER_TREE is now open,
+        // pushing ASSETS_TREE down). ASSETS_HINT exists from frame 1 because
+        // the tutorial source declares ASSETS_TREE with DefaultOpen.
+        var p_assets = widget_center(snap, T_ASSETS_LEAF)
+        var snap_assets = wait_for_render(app, T_ASSETS_LEAF, 5.0f)
+        if (snap_assets != null) {
+            p_assets = widget_center(snap_assets, T_ASSETS_LEAF)
+        }
         move_to(app, p_assets, 900)
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((

--- a/tests/integration/record_tree_node.das
+++ b/tests/integration/record_tree_node.das
@@ -1,0 +1,101 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``tree_node.apng`` against
+//! ``examples/tutorial/tree_node.das``. Tours DefaultOpen, nested
+//! tree_nodes, and OpenOnArrow click semantics.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS    = 5000u          //! 5s read window
+let SETTLE_MS  = 1500u          //! 1.5s cursor settle
+let TOGGLE_DWELL_MS = 2200u     //! 2.2s post-toggle dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/tree_node.das",
+                       "tree_node.apng", 60) $(app) {
+        let T_PHYSICS = "TN_WIN/PHYSICS_TREE"
+        let T_RENDER = "TN_WIN/RENDER_TREE"
+        let T_ASSETS = "TN_WIN/ASSETS_TREE"
+        let T_WIN = "TN_WIN"
+
+        var snap = wait_for_render(app, T_PHYSICS, 10.0f)
+        if (snap == null) {
+            panic("{T_PHYSICS} never rendered — wrong app running?")
+        }
+        let p_physics = widget_center(snap, T_PHYSICS)
+        let p_render = widget_center(snap, T_RENDER)
+        let p_assets = widget_center(snap, T_ASSETS)
+        let p_win = widget_center(snap, T_WIN)
+
+        //! Initial cursor placement.
+        move_to(app, p_win, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: narrate PHYSICS (DefaultOpen) ----
+        move_to(app, p_physics, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "tree_node(IDENT, (text, flags)) — block-arg container. DefaultOpen flag expanded the chevron from frame 1; opened mirrors TreeNodeEx's return.",
+            target = T_PHYSICS,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: close PHYSICS via imgui_close ----
+        post_command(app, "imgui_close", JV((target = T_PHYSICS)))
+        sleep(TOGGLE_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_close routes through pending_close — next frame SetNextItemOpen(false) overrides ImGui's stored state. opened flips false; the body block stops running.",
+            target = T_PHYSICS,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+        post_command(app, "imgui_open", JV((target = T_PHYSICS)))
+        sleep(1500u)
+
+        // ---- Stage 3: open RENDER, then narrate nesting ----
+        post_command(app, "imgui_open", JV((target = T_RENDER)))
+        sleep(TOGGLE_DWELL_MS)
+        move_to(app, p_render, 700)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "Nested tree_nodes compose freely. Camera subtree's slider registers at TN_WIN/RENDER_TREE/CAMERA_SUBTREE/RENDER_FOV — three-deep path.",
+            target = T_RENDER,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: ASSETS (OpenOnArrow) ----
+        move_to(app, p_assets, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "OpenOnArrow flag — only the chevron click toggles; clicking the LABEL doesn't expand. Useful for selectable-row trees where the label is the selection.",
+            target = T_ASSETS,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}

--- a/tests/integration/record_tree_node.das
+++ b/tests/integration/record_tree_node.das
@@ -36,22 +36,23 @@ def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
 def main {
     with_recording_app("examples/tutorial/tree_node.das",
                        "tree_node.apng", 60) $(app) {
-        let T_PHYSICS = "TN_WIN/PHYSICS_TREE"
-        let T_RENDER = "TN_WIN/RENDER_TREE"
-        let T_ASSETS = "TN_WIN/ASSETS_TREE"
-        let T_WIN = "TN_WIN"
+        // tree_node and window containers finalize without a bbox, so
+        // anchor every move/narrate target at a real leaf widget. See
+        // PR #67 Copilot round 1.
+        let T_PHYSICS_PATH = "TN_WIN/PHYSICS_TREE"
+        let T_PHYSICS_LEAF = "TN_WIN/PHYSICS_TREE/PHYSICS_GRAVITY"
+        let T_RENDER_PATH = "TN_WIN/RENDER_TREE"
+        let T_FOV_LEAF = "TN_WIN/RENDER_TREE/CAMERA_SUBTREE/RENDER_FOV"
+        let T_ASSETS_LEAF = "TN_WIN/ASSETS_TREE/ASSETS_HINT"
 
-        var snap = wait_for_render(app, T_PHYSICS, 10.0f)
+        var snap = wait_for_render(app, T_PHYSICS_LEAF, 10.0f)
         if (snap == null) {
-            panic("{T_PHYSICS} never rendered — wrong app running?")
+            panic("{T_PHYSICS_LEAF} never rendered — wrong app running?")
         }
-        let p_physics = widget_center(snap, T_PHYSICS)
-        let p_render = widget_center(snap, T_RENDER)
-        let p_assets = widget_center(snap, T_ASSETS)
-        let p_win = widget_center(snap, T_WIN)
+        let p_physics = widget_center(snap, T_PHYSICS_LEAF)
 
         //! Initial cursor placement.
-        move_to(app, p_win, 600)
+        move_to(app, p_physics, 600)
         sleep(SETTLE_MS)
 
         // ---- Stage 1: narrate PHYSICS (DefaultOpen) ----
@@ -59,41 +60,49 @@ def main {
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
             text = "tree_node(IDENT, (text, flags)) — block-arg container. DefaultOpen flag expanded the chevron from frame 1; opened mirrors TreeNodeEx's return.",
-            target = T_PHYSICS,
+            target = T_PHYSICS_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
 
         // ---- Stage 2: close PHYSICS via imgui_close ----
-        post_command(app, "imgui_close", JV((target = T_PHYSICS)))
+        post_command(app, "imgui_close", JV((target = T_PHYSICS_PATH)))
         sleep(TOGGLE_DWELL_MS)
+        // PHYSICS_GRAVITY is gone now that PHYSICS_TREE is collapsed —
+        // narrate against ASSETS_HINT (always present) to mention the gating.
         post_command(app, "imgui_narrate", JV((
             text = "imgui_close routes through pending_close — next frame SetNextItemOpen(false) overrides ImGui's stored state. opened flips false; the body block stops running.",
-            target = T_PHYSICS,
+            target = T_ASSETS_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
-        post_command(app, "imgui_open", JV((target = T_PHYSICS)))
+        post_command(app, "imgui_open", JV((target = T_PHYSICS_PATH)))
         sleep(1500u)
 
         // ---- Stage 3: open RENDER, then narrate nesting ----
-        post_command(app, "imgui_open", JV((target = T_RENDER)))
+        post_command(app, "imgui_open", JV((target = T_RENDER_PATH)))
         sleep(TOGGLE_DWELL_MS)
-        move_to(app, p_render, 700)
-        sleep(SETTLE_MS)
+        // Re-snap to pick up the now-rendered RENDER children.
+        var snap2 = wait_for_render(app, T_FOV_LEAF, 5.0f)
+        if (snap2 != null) {
+            let p_fov = widget_center(snap2, T_FOV_LEAF)
+            move_to(app, p_fov, 700)
+            sleep(SETTLE_MS)
+        }
         post_command(app, "imgui_narrate", JV((
             text = "Nested tree_nodes compose freely. Camera subtree's slider registers at TN_WIN/RENDER_TREE/CAMERA_SUBTREE/RENDER_FOV — three-deep path.",
-            target = T_RENDER,
+            target = T_FOV_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)
 
         // ---- Stage 4: ASSETS (OpenOnArrow) ----
+        let p_assets = widget_center(snap, T_ASSETS_LEAF)
         move_to(app, p_assets, 900)
         sleep(SETTLE_MS)
         post_command(app, "imgui_narrate", JV((
             text = "OpenOnArrow flag — only the chevron click toggles; clicking the LABEL doesn't expand. Useful for selectable-row trees where the label is the selection.",
-            target = T_ASSETS,
+            target = T_ASSETS_LEAF,
             frames = NARRATE_FRAMES
         )))
         sleep(READ_MS)


### PR DESCRIPTION
## Summary

Closes the container-tutorial gap surfaced in the post-PR-#66 re-survey: 6 container rails brushed-through in `containers.rst` but lacking dedicated focused tutorials. Each gets a single-container demo, an APNG recording driver, and a Sphinx RST page wired into the toctree.

Containers covered:
- **child** — `BeginChild`/`EndChild` with size/flags/scroll, `ChildState` observability
- **collapsing_header** — section fold with the closable X-button channel (open vs opened gates)
- **group** — pure-layout `BeginGroup`/`EndGroup` with hit-test + same_line behavior
- **popup_modal** — blocking modal with closable / non-closable flavors
- **tab_bar** — active-tab body gating, closable tabs, `ImGuiTabBarFlags`
- **tree_node** — `[container]` block-arg form contrasted with `tree_node_ex` `[widget]` leaf form

## Diff shape

- 6 new `examples/tutorial/*.das` tutorial sources (one focused demo per rail)
- 6 new `tests/integration/record_*.das` APNG drivers — auto-picked by `rerecord_all.ps1`'s `record_*.das` glob; no script edit needed
- 6 new `doc/source/tutorials/*.rst` pages
- `doc/source/tutorials/index.rst` — toctree gets 6 new entries clustered next to the existing `containers.rst` umbrella page

`+2508 / -0`, 19 files.

## Verification

- All 12 new `.das` files compile + lint clean via MCP `compile_check` + `lint`.
- No new test smokes added — these containers are already exercised by `test_containers_*.das` from the features-demo suite (PR #66 left integration coverage in place).
- Toctree placement keeps each new page next to `containers.rst` so the umbrella tour and its focused siblings sit together.

## Sequencing note

The RST pages use `.. image:: ../_static/tutorials/<name>.apng` per existing convention. APNGs need to land on `origin/assets` (via `publish_apngs_to_assets.ps1`) before CI builds for Sphinx `-W` to pass. Same workflow as PR #65:

1. `pwsh tests/integration/rerecord_all.ps1 -DaslangExe ...` — record all (new + existing) APNGs locally
2. Eyeball-review under `doc/source/_static/tutorials/`
3. `pwsh tests/integration/publish_apngs_to_assets.ps1` — force-amend-push to `origin/assets`
4. CI builds the PR; `fetch_tutorial_apngs.ps1` / `.sh` pulls them at build time

## Test plan
- [ ] Local `daslang.exe` smoke-run each `examples/tutorial/*.das` (single-frame at minimum) — verify the demo windows show their content
- [ ] Local `pwsh rerecord_all.ps1` produces 6 new APNGs without crashes, plus refreshes the existing ones
- [ ] Eyeball each new APNG: chevron toggles, X-button dismissals, tab switches, scroll behavior all render correctly
- [ ] `publish_apngs_to_assets.ps1` to `origin/assets`, then CI's Sphinx build passes with `-W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)