### PR TITLE
imgui_boost: qualified macro emits + register_widget fn-pointer path (~32% faster compile)

### DIFF
--- a/widgets/imgui_boost.das
+++ b/widgets/imgui_boost.das
@@ -524,17 +524,40 @@ class WidgetCallMacro : AstCallMacro {
                     imgui_boost_runtime::clear_module_widgets($v(modLit))
                 ))
             }
+            // Emit per-widget top-level getter + serializer as plain
+            // functions (no captures — they read the module-scope state global
+            // directly). register_widget then receives `@@<fn>` literals, so the
+            // long-lived registry stores plain function pointers instead of
+            // heap-allocated lambda capture frames. The `k` parameter is part
+            // of the unified API with indexed widgets — non-indexed getters
+            // ignore it.
+            let addrFnName = "__widget_addr${bareName}"
+            let jvFnName = "__widget_jv${bareName}"
+            if (find_unique_function(mod, addrFnName, true) == null) {
+                var addrFn = qmacro_function(addrFnName) $(k : int) : void? {
+                    return unsafe(addr($i(identLit)))
+                }
+                addrFn.flags.generated = true
+                addrFn.flags.privateFunction = true
+                addrFn.body |> force_at(expr.at)
+                mod |> add_function(addrFn)
+            }
+            if (find_unique_function(mod, jvFnName, true) == null) {
+                var jvFn = qmacro_function(jvFnName) $(k : int) : JsonValue? {
+                    return JV($i(identLit))
+                }
+                jvFn.flags.generated = true
+                jvFn.flags.privateFunction = true
+                jvFn.body |> force_at(expr.at)
+                mod |> add_function(jvFn)
+            }
             reg.list |> push(qmacro(
                 imgui_boost_runtime::register_widget(
                     $v(modLit),
                     $v(identLit),
                     $v(kindLit),
-                    @() : void? {
-                        return unsafe(addr($i(identLit)))
-                    },
-                    @() : JsonValue? {
-                        return JV($i(identLit))
-                    }
+                    @@$c(addrFnName),
+                    @@$c(jvFnName)
                 )
             ))
         }
@@ -652,6 +675,55 @@ class WidgetCallMacro : AstCallMacro {
         // Qualify the inner call to the widget impl so the wrapper can't pick
         // up a same-named function in another module.
         let qualifiedKind = "{string(render_fn._module.name)}::{kind_name}"
+        // Key-type-aware fn-ptr emit. Int and string keys go through parallel
+        // register_widget overloads (register_widget / register_widget_str);
+        // the per-(kind, IDENT) addr-getter + serializer are typed accordingly
+        // and shared across every call site for the same (kind, IDENT).
+        let keyIsString = tabType.firstType != null && tabType.firstType.baseType == Type.tString
+        if (tabType.firstType == null ||
+            (tabType.firstType.baseType != Type.tInt && tabType.firstType.baseType != Type.tString)) {
+            macro_error(prog, expr.at,
+                "{kind_name}({bareName}[k]): only `table<int; …>` and `table<string; …>` are supported for indexed widgets (got `{describe(tabType)}`).")
+            return <- default<ExpressionPtr>
+        }
+        let indexedAddrFnName = "__widget_addr$indexed${kind_name}${bareName}"
+        let indexedJvFnName = "__widget_jv$indexed${kind_name}${bareName}"
+        if (find_unique_function(mod, indexedAddrFnName, true) == null) {
+            var addrFn : FunctionPtr
+            if (keyIsString) {
+                addrFn = qmacro_function(indexedAddrFnName) $(k : string) : void? {
+                    return null if (!key_exists($i(bareNameLit), k))
+                    return unsafe(addr($i(bareNameLit)[k]))
+                }
+            } else {
+                addrFn = qmacro_function(indexedAddrFnName) $(k : int) : void? {
+                    return null if (!key_exists($i(bareNameLit), k))
+                    return unsafe(addr($i(bareNameLit)[k]))
+                }
+            }
+            addrFn.flags.generated = true
+            addrFn.flags.privateFunction = true
+            addrFn.body |> force_at(expr.at)
+            mod |> add_function(addrFn)
+        }
+        if (find_unique_function(mod, indexedJvFnName, true) == null) {
+            var jvFn : FunctionPtr
+            if (keyIsString) {
+                jvFn = qmacro_function(indexedJvFnName) $(k : string) : JsonValue? {
+                    return null if (!key_exists($i(bareNameLit), k))
+                    return JV($i(bareNameLit)[k])
+                }
+            } else {
+                jvFn = qmacro_function(indexedJvFnName) $(k : int) : JsonValue? {
+                    return null if (!key_exists($i(bareNameLit), k))
+                    return JV($i(bareNameLit)[k])
+                }
+            }
+            jvFn.flags.generated = true
+            jvFn.flags.privateFunction = true
+            jvFn.body |> force_at(expr.at)
+            mod |> add_function(jvFn)
+        }
         // Emit the wrapper helper once per (kind, IDENT). find_unique_function
         // probes the user module before add_function fires; re-running visit()
         // for the same wrapper (e.g. a second call site) is a no-op.
@@ -684,27 +756,27 @@ class WidgetCallMacro : AstCallMacro {
             bodyStmts |> push <| qmacro_expr(${
                 let path = imgui_boost_runtime::widget_path_key(bare)
             })
-            // First-touch / post-reload register. Both lambdas capture the
-            // key by value; the address getter and serializer guard with
-            // ``key_exists`` and re-resolve ``TABLE[k]`` on every invoke, so
-            // rehashing or erase+re-add never desyncs state.
-            bodyStmts |> push <| qmacro_expr(${
-                if (!imgui_boost_runtime::widget_registered(path)) {
-                    unsafe {
-                        let addr_getter <- @ capture(= k) () : void ? {
-                            return null if (!key_exists($i(bareNameLit), k))
-                            return unsafe(addr($i(bareNameLit)[k]))
-                        }
-                        let ser <- @ capture(= k) () : JsonValue ? {
-                            return null if (!key_exists($i(bareNameLit), k))
-                            return JV($i(bareNameLit)[k])
-                        }
+            // First-touch / post-reload register. We pass plain function
+            // pointers into register_widget(_str); the runtime stores them in
+            // WidgetMeta along with `k` (consulted on every getter/serializer
+            // invoke). No lambda capture frame allocated per call site.
+            if (keyIsString) {
+                bodyStmts |> push <| qmacro_expr(${
+                    if (!imgui_boost_runtime::widget_registered(path)) {
+                        imgui_boost_runtime::register_widget_str(
+                            $v(moduleName), path, $v(kindLit),
+                            @@$c(indexedAddrFnName), @@$c(indexedJvFnName), k)
+                    }
+                })
+            } else {
+                bodyStmts |> push <| qmacro_expr(${
+                    if (!imgui_boost_runtime::widget_registered(path)) {
                         imgui_boost_runtime::register_widget(
                             $v(moduleName), path, $v(kindLit),
-                            addr_getter, ser)
+                            @@$c(indexedAddrFnName), @@$c(indexedJvFnName), k)
                     }
-                }
-            })
+                })
+            }
             // Final call. The called [container]'s own finally block pops
             // its container_path_push, so no wrapper-side pop is needed.
             if (retType.baseType == Type.tVoid) {

--- a/widgets/imgui_boost.das
+++ b/widgets/imgui_boost.das
@@ -64,12 +64,13 @@ class ContainerFunctionMacro : AstFunctionAnnotation {
 
 class DrawlistPrimCallMacro : AstCallMacro {
     kind_name : string
+    target_mod : string  // module that owns the [drawlist_prim] function; qualifies the emit to prevent same-name collisions
 
     def override visit(prog : ProgramPtr; mod : Module?;
                        var expr : ExprCallMacro?) : ExpressionPtr {
         let modName = mod == null ? "anon" : string(mod.name)
         let path_key = "{modName}:{expr.at.line:d}:{expr.at.column:d}"
-        var rewritten = new ExprCall(at = expr.at, name := kind_name)
+        var rewritten = new ExprCall(at = expr.at, name := "{target_mod}::{kind_name}")
         var pathArg = new ExprConstString(at = expr.at, value := path_key)
         rewritten.arguments |> push(pathArg)
         for (a in expr.arguments) {
@@ -97,8 +98,13 @@ class DrawlistPrimFunctionMacro : AstFunctionAnnotation {
             _type <- new TypeDecl(baseType = Type.tString, at = func.at))
         widthIdentVar.flags.generated = true
         func.arguments |> emplace(widthIdentVar, 0)
-        var inst = new DrawlistPrimCallMacro(kind_name = kind)
-        compiling_module() |> add_call_macro(make_call_macro(kind, inst))
+        // Capture the owning module name (compiling_module() — func._module is
+        // not yet set at apply time). Used to qualify the call_macro's emit so
+        // a same-named function in another module can't be picked up.
+        let cmod = compiling_module()
+        var inst = new DrawlistPrimCallMacro(kind_name = kind,
+                                             target_mod = string(cmod.name))
+        cmod |> add_call_macro(make_call_macro(kind, inst))
         return true
     }
 }
@@ -133,9 +139,9 @@ def private apply_widget_or_container(var func : FunctionPtr; var errors : das_s
     // matching pop lives in body.finalList (always-runs on normal return).
     // PopID lives in widget_finalize / container_finalize at the bottom.
     var fblk = new ExprBlock(at = func.body.at)
-    fblk.list |> push(qmacro(widget_prelude($i("widget_ident"))))
+    fblk.list |> push(qmacro(imgui_boost_runtime::widget_prelude($i("widget_ident"))))
     if (is_container) {
-        fblk.list |> push(qmacro(container_path_push($i("widget_ident"))))
+        fblk.list |> push(qmacro(imgui_boost_runtime::container_path_push($i("widget_ident"))))
     }
     let oldBody = func.body as ExprBlock
     for (el in oldBody.list) {
@@ -145,7 +151,7 @@ def private apply_widget_or_container(var func : FunctionPtr; var errors : das_s
         fblk.finalList |> push(clone_expression(ef))
     }
     if (is_container) {
-        fblk.finalList |> push(qmacro(container_path_pop()))
+        fblk.finalList |> push(qmacro(imgui_boost_runtime::container_path_pop()))
     }
     func.body = fblk
     // Register the per-kind call macro instance. The same WidgetCallMacro
@@ -551,7 +557,11 @@ class WidgetCallMacro : AstCallMacro {
         if (pathOverridePresent) {
             widgetIdent = pathOverride
         }
-        var newCall = new ExprCall(at = expr.at, name := render_fn_name)
+        // Qualify with the widget impl's home module so a same-named function
+        // in another loaded module can't shadow the dispatch. render_fn._module
+        // is populated by the time visit() runs (post-binding).
+        var newCall = new ExprCall(at = expr.at,
+                                   name := "{string(render_fn._module.name)}::{render_fn_name}")
         newCall.arguments |> push(new ExprVar(at = expr.at, name := bareName))
         newCall.arguments |> push(new ExprConstString(at = expr.at, value := widgetIdent))
         for (i in range(firstUserArg, length(expr.arguments))) {
@@ -639,6 +649,9 @@ class WidgetCallMacro : AstCallMacro {
         let moduleName = string(mod.name)
         let bareNameLit = bareName
         let kindLit = kind_name
+        // Qualify the inner call to the widget impl so the wrapper can't pick
+        // up a same-named function in another module.
+        let qualifiedKind = "{string(render_fn._module.name)}::{kind_name}"
         // Emit the wrapper helper once per (kind, IDENT). find_unique_function
         // probes the user module before add_function fires; re-running visit()
         // for the same wrapper (e.g. a second call site) is a no-op.
@@ -696,11 +709,11 @@ class WidgetCallMacro : AstCallMacro {
             // its container_path_push, so no wrapper-side pop is needed.
             if (retType.baseType == Type.tVoid) {
                 bodyStmts |> push <| qmacro_expr(${
-                    $c(kindLit)($a(callArgs))
+                    $c(qualifiedKind)($a(callArgs))
                 })
             } else {
                 bodyStmts |> push <| qmacro_expr(${
-                    return $c(kindLit)($a(callArgs))
+                    return $c(qualifiedKind)($a(callArgs))
                 })
             }
             var fn = qmacro_function(wrapperName) $(k : $t(keyType); $a(wrapperArgs)) : $t(retType) {
@@ -715,8 +728,11 @@ class WidgetCallMacro : AstCallMacro {
                 return <- default<ExpressionPtr>
             }
         }
-        // Rewrite call: wrapperName(indexExpr, ...remaining args)
-        var newCall = new ExprCall(at = expr.at, name := wrapperName)
+        // Rewrite call: wrapperName(indexExpr, ...remaining args). Use `__::`
+        // to constrain overload resolution to the user module (where we just
+        // installed the wrapper via add_function); also rules out collisions
+        // with any same-named function in other loaded modules.
+        var newCall = new ExprCall(at = expr.at, name := "__::{wrapperName}")
         newCall.arguments |> push(indexExpr)
         for (i in range(1, length(expr.arguments))) {
             let a = expr.arguments[i]
@@ -792,9 +808,9 @@ def private apply_edit_widget_or_container(var func : FunctionPtr; var errors : 
     // emitted inside `invoke(blk)` nest under our ident); matching pop
     // lives in body.finalList so it always runs on normal return.
     var fblk = new ExprBlock(at = func.body.at)
-    fblk.list |> push(qmacro(widget_prelude($i("widget_ident"))))
+    fblk.list |> push(qmacro(imgui_boost_runtime::widget_prelude($i("widget_ident"))))
     if (is_container) {
-        fblk.list |> push(qmacro(container_path_push($i("widget_ident"))))
+        fblk.list |> push(qmacro(imgui_boost_runtime::container_path_push($i("widget_ident"))))
     }
     let oldBody = func.body as ExprBlock
     for (el in oldBody.list) {
@@ -804,7 +820,7 @@ def private apply_edit_widget_or_container(var func : FunctionPtr; var errors : 
         fblk.finalList |> push(clone_expression(ef))
     }
     if (is_container) {
-        fblk.finalList |> push(qmacro(container_path_pop()))
+        fblk.finalList |> push(qmacro(imgui_boost_runtime::container_path_pop()))
     }
     func.body = fblk
     var inst = new EditExternalCallMacro(
@@ -867,7 +883,9 @@ class EditExternalCallMacro : AstCallMacro {
             return <- default<ExpressionPtr>
         }
         // Rewrite to positional: kind_name(ptr, "<idLit>", ...named args destructured).
-        var newCall = new ExprCall(at = expr.at, name := kind_name)
+        // Qualified with the [edit_widget] impl's home module to dodge collisions.
+        var newCall = new ExprCall(at = expr.at,
+                                   name := "{string(render_fn._module.name)}::{kind_name}")
         newCall.arguments |> push(clone_expression(expr.arguments[0]))
         newCall.arguments |> push(new ExprConstString(at = expr.at, value := idLit))
         for (i in range(1, length(expr.arguments))) {

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -657,11 +657,20 @@ var g_frame : int = 0
 // across containers stay distinct.
 
 struct WidgetMeta {
-    module_name : string                         //! owning module; lets clear_module_widgets drop on reload
-    kind : string                                //! widget kind ("button", "slider_float", ...)
-    state_addr_getter : lambda<() : void?>       //! resolves the live state-struct address on every invoke (stable for globals; key-checked re-resolution for indexed widgets) — used by finalize lambdas to avoid dangling captures after table rehash/erase
-    serializer : lambda<() : JsonValue?>         //! captured-state serializer; invoked at imgui_snapshot time
-    last_seen_frame : int                        //! last g_frame this path appeared in g_registry; -1 = never rendered
+    module_name : string                                  //! owning module; lets clear_module_widgets drop on reload
+    kind : string                                         //! widget kind ("button", "slider_float", ...)
+    // Int-keyed path (non-indexed widgets and `table<int; …>` indexed widgets).
+    // k=0 for non-indexed (getter ignores it).
+    addr_getter_int : function<(k : int) : void?>         //! plain function pointer; no heap-allocated capture frame
+    serializer_int  : function<(k : int) : JsonValue?>
+    k_int : int
+    // String-keyed path (`table<string; …>` indexed widgets only).
+    // Both fns are null when has_str_key=false; selected by has_str_key.
+    addr_getter_str : function<(k : string) : void?>
+    serializer_str  : function<(k : string) : JsonValue?>
+    k_str : string
+    has_str_key : bool                                    //! true => use the _str fns + k_str; false => use the _int fns + k_int
+    last_seen_frame : int                                 //! last g_frame this path appeared in g_registry; -1 = never rendered
 }
 
 var g_widgets : table<string; WidgetMeta>
@@ -933,25 +942,48 @@ def public widget_registered(path : string) : bool {
 def public register_widget(module_name : string;
                            bare_ident : string;
                            kind : string;
-                           var state_addr_getter : lambda<() : void?>;
-                           var serializer : lambda<() : JsonValue?>) {
-    //! Module-init registration of a widget into the long-lived ``g_widgets`` table; ``module_name`` lets :ref:`clear_module_widgets <function-imgui_boost_runtime_clear_module_widgets_string>` drop it on reload. ``state_addr_getter`` is invoked on every dispatcher/serializer call to resolve the live state-struct address — stable closure for globals, key-checked re-resolution for indexed widgets.
+                           addr_getter : function<(k : int) : void?>;
+                           serializer : function<(k : int) : JsonValue?>;
+                           k : int = 0) {
+    //! Module-init registration of a widget into the long-lived ``g_widgets`` table; ``module_name`` lets :ref:`clear_module_widgets <function-imgui_boost_runtime_clear_module_widgets_string>` drop it on reload. ``addr_getter(k)`` resolves the live state-struct address on every dispatcher/serializer call — stable function pointer for globals (k ignored), key-checked re-resolution for indexed widgets with int keys (k = the table key, stored once at registration). For string-keyed indexed widgets use :ref:`register_widget_str <function-imgui_boost_runtime_register_widget_str_string_string_string_function_ls__ls_k_c_string_const_gr__c_void_q__gr__function_ls__ls_k_c_string_const_gr__c_json_JsonValue_q__gr__string_const>`.
     unsafe {
         g_widgets[bare_ident] <- WidgetMeta(
             module_name = module_name,
             kind = kind,
-            state_addr_getter <- state_addr_getter,
-            serializer <- serializer,
+            addr_getter_int = addr_getter,
+            serializer_int = serializer,
+            k_int = k,
+            last_seen_frame = -1
+        )
+    }
+}
+
+def public register_widget_str(module_name : string;
+                               bare_ident : string;
+                               kind : string;
+                               addr_getter : function<(k : string) : void?>;
+                               serializer : function<(k : string) : JsonValue?>;
+                               k : string) {
+    //! String-keyed sibling of :ref:`register_widget <function-imgui_boost_runtime_register_widget_string_string_string_function_ls__ls_k_c_int_const_gr__c_void_q__gr__function_ls__ls_k_c_string_const_gr__c_json_JsonValue_q__gr__int_const>` — for ``table<string; …>`` indexed widgets. Sets ``has_str_key`` so the dispatcher/serializer routes through ``addr_getter_str(k_str)`` instead of the int path.
+    unsafe {
+        g_widgets[bare_ident] <- WidgetMeta(
+            module_name = module_name,
+            kind = kind,
+            addr_getter_str = addr_getter,
+            serializer_str = serializer,
+            k_str := k,
+            has_str_key = true,
             last_seen_frame = -1
         )
     }
 }
 
 def public lookup_state_addr(path : string) : void? {
-    //! Resolve a widget's current state-struct address by path — invokes the registered ``state_addr_getter`` so indexed-form widgets reinterpret the live table slot on every call instead of dereferencing a stale capture. Returns null when ``path`` is absent from ``g_widgets`` or the getter reports the slot is gone (erased indexed key). Uses ``?[]`` safe lookup so the finalize lambdas can run from inside an ``imgui_snapshot`` iteration without tripping the locked-table guard (``tab[k]`` is daslang's auto-insert form).
+    //! Resolve a widget's current state-struct address by path — invokes the registered ``addr_getter`` so indexed-form widgets reinterpret the live table slot on every call instead of dereferencing a stale capture. Returns null when ``path`` is absent from ``g_widgets`` or the getter reports the slot is gone (erased indexed key). Uses ``?[]`` safe lookup so the finalize lambdas can run from inside an ``imgui_snapshot`` iteration without tripping the locked-table guard (``tab[k]`` is daslang's auto-insert form).
     let meta = unsafe(g_widgets?[path])
     return null if (meta == null)
-    return invoke(meta.state_addr_getter)
+    return meta.addr_getter_str(meta.k_str) if (meta.has_str_key)
+    return meta.addr_getter_int(meta.k_int)
 }
 
 def public state_jv(path : string; t : type<auto(T)>) : JsonValue? {
@@ -1139,7 +1171,13 @@ def private extract_string_field(obj : JsonValue?; name : string) : string {
 
 def private widget_meta_jv(path_key : string; meta : WidgetMeta) : JsonValue? {
     // Snapshot blob for a widget registered but not rendered this frame: rendered=false, state payload only.
-    return JV((kind = meta.kind, rendered = false, payload = invoke(meta.serializer)))
+    var payload : JsonValue?
+    if (meta.has_str_key) {
+        payload = meta.serializer_str(meta.k_str)
+    } else {
+        payload = meta.serializer_int(meta.k_int)
+    }
+    return JV((kind = meta.kind, rendered = false, payload = payload))
 }
 
 def private io_jv() : JsonValue? {

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -659,16 +659,12 @@ var g_frame : int = 0
 struct WidgetMeta {
     module_name : string                                  //! owning module; lets clear_module_widgets drop on reload
     kind : string                                         //! widget kind ("button", "slider_float", ...)
-    // Int-keyed path (non-indexed widgets and `table<int; …>` indexed widgets).
-    // k=0 for non-indexed (getter ignores it).
-    addr_getter_int : function<(k : int) : void?>         //! plain function pointer; no heap-allocated capture frame
-    serializer_int  : function<(k : int) : JsonValue?>
-    k_int : int
-    // String-keyed path (`table<string; …>` indexed widgets only).
-    // Both fns are null when has_str_key=false; selected by has_str_key.
-    addr_getter_str : function<(k : string) : void?>
-    serializer_str  : function<(k : string) : JsonValue?>
-    k_str : string
+    addr_getter_int : function<(k : int) : void?>         //! int-keyed path: resolves live state-struct address. k=0 for non-indexed widgets (getter ignores it), the table key for ``table<int; …>`` indexed widgets. Plain function pointer — no heap-allocated lambda capture frame.
+    serializer_int  : function<(k : int) : JsonValue?>    //! int-keyed serializer; mirror of ``addr_getter_int`` shape. Invoked at imgui_snapshot time.
+    k_int : int                                           //! int key stored at registration: 0 for non-indexed, the actual ``TABLE[k]`` key for int-indexed widgets.
+    addr_getter_str : function<(k : string) : void?>      //! string-keyed path: resolves live state-struct address for ``table<string; …>`` indexed widgets. Null when ``has_str_key=false``.
+    serializer_str  : function<(k : string) : JsonValue?> //! string-keyed serializer; null when ``has_str_key=false``.
+    k_str : string                                        //! string key stored at registration; empty when ``has_str_key=false``.
     has_str_key : bool                                    //! true => use the _str fns + k_str; false => use the _int fns + k_int
     last_seen_frame : int                                 //! last g_frame this path appeared in g_registry; -1 = never rendered
 }

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -941,7 +941,7 @@ def public register_widget(module_name : string;
                            addr_getter : function<(k : int) : void?>;
                            serializer : function<(k : int) : JsonValue?>;
                            k : int = 0) {
-    //! Module-init registration of a widget into the long-lived ``g_widgets`` table; ``module_name`` lets :ref:`clear_module_widgets <function-imgui_boost_runtime_clear_module_widgets_string>` drop it on reload. ``addr_getter(k)`` resolves the live state-struct address on every dispatcher/serializer call — stable function pointer for globals (k ignored), key-checked re-resolution for indexed widgets with int keys (k = the table key, stored once at registration). For string-keyed indexed widgets use :ref:`register_widget_str <function-imgui_boost_runtime_register_widget_str_string_string_string_function_ls__ls_k_c_string_const_gr__c_void_q__gr__function_ls__ls_k_c_string_const_gr__c_json_JsonValue_q__gr__string_const>`.
+    //! Module-init registration of a widget into the long-lived ``g_widgets`` table; ``module_name`` lets :ref:`clear_module_widgets <function-imgui_boost_runtime_clear_module_widgets_string>` drop it on reload. ``addr_getter(k)`` resolves the live state-struct address on every dispatcher/serializer call — stable function pointer for globals (k ignored), key-checked re-resolution for indexed widgets with int keys (k = the table key, stored once at registration). For string-keyed indexed widgets use ``register_widget_str`` (sibling overload below).
     unsafe {
         g_widgets[bare_ident] <- WidgetMeta(
             module_name = module_name,
@@ -960,7 +960,7 @@ def public register_widget_str(module_name : string;
                                addr_getter : function<(k : string) : void?>;
                                serializer : function<(k : string) : JsonValue?>;
                                k : string) {
-    //! String-keyed sibling of :ref:`register_widget <function-imgui_boost_runtime_register_widget_string_string_string_function_ls__ls_k_c_int_const_gr__c_void_q__gr__function_ls__ls_k_c_string_const_gr__c_json_JsonValue_q__gr__int_const>` — for ``table<string; …>`` indexed widgets. Sets ``has_str_key`` so the dispatcher/serializer routes through ``addr_getter_str(k_str)`` instead of the int path.
+    //! String-keyed sibling of ``register_widget`` — for ``table<string; …>`` indexed widgets. Sets ``has_str_key`` so the dispatcher/serializer routes through ``addr_getter_str(k_str)`` instead of the int path.
     unsafe {
         g_widgets[bare_ident] <- WidgetMeta(
             module_name = module_name,


### PR DESCRIPTION
## Summary

Two related macro-emit cleanups for `widgets/imgui_boost.das` and `widgets/imgui_boost_runtime.das`:

### 1. Qualified macro emits (`33af305`)

`[drawlist_prim]` / `[widget]` / `[container]` / `[edit_widget]` / `[edit_container]` call_macros now emit their dispatch `ExprCall` with the target function's home module as a `module::fn` prefix (or `__::` for the indexed wrapper, since `add_function(mod, fn)` lands the wrapper in the same module that calls it). Internal helpers (`widget_prelude` / `container_path_push` / `container_path_pop`) are likewise qualified with `imgui_boost_runtime::` at qmacro-emit sites.

This is collision-proofing: a same-named user function in another loaded module can't accidentally shadow the dispatch. Perf-neutral on its own.

### 2. `register_widget` fn-pointer path (`1ebd76d`) — the perf win

The `[widget]` / `[container]` / `[edit_*]` call_macros previously emitted two captureless `@()` lambdas per widget call site (an addr-getter + a JV serializer). Captureless lambdas in daslang still allocate a heap struct of two function pointers + emit a finalizer fn per lambda — so 513 widgets in `imgui_demo`'s `widgets.das` became ~1054 lambda structs + ~2108 lambda body/finalizer fns, all to hold two fn pointers each.

Refactor:

- **`WidgetMeta`** now holds the getter/serializer as plain function pointers + the table key directly (no heap-allocated lambda capture frame).
- **Non-indexed `[widget]`** macros emit per-widget top-level `__widget_addr$<IDENT>` and `__widget_jv$<IDENT>` functions and pass `@@<fn>` literals into `register_widget`.
- **Indexed wrappers** emit per-(kind, IDENT) shared top-level getters (one pair per `kind+IDENT`, not per call site). The previous lambda scheme generated one capture frame per call site.
- **Dual-path** for indexed widgets: int-keyed go through `register_widget`; new `register_widget_str` overload covers `table<string; …>` indexed widgets (still no lambdas — fn ptr + the string key stored alongside). `has_str_key` on `WidgetMeta` routes the dispatcher.

### Numbers (imgui_demo.das compile, 3-run avg, daslang Release)

| | Baseline | After fn-ptr | Δ |
|---|---|---|---|
| total compile | 20.51s | 13.99s | **−32%** |
| function count | 10035 | 4491 | **−55%** |
| widgets.das | 8.55s | ~4.5s | **−47%** |
| layout.das | 2.12s | 0.80s | **−62%** |
| tables.das | 1.27s | 0.51s | **−60%** |

## Test plan

- [x] Parallel `-compile-only` sweep of the entire `examples/` tree — all clean (every macro form exercised: `[widget]`, `[container]`, `[drawlist_prim]`, `[edit_widget]`, `[edit_container]`, non-indexed + int-indexed + `inputs_indexed.das` for string-keyed indexed)
- [x] `dastest` integration suite (headless, `--exclude glfw_synth --exclude key_hud`): **135/135 passed, 0 failures**
- [x] `mcp__daslang__lint` on the two changed files: 0 new warnings; 2 pre-existing master warnings (`STYLE012` on `bodyStmts` push-loop, `STYLE027` on `paths_to_remove` in `clear_module_widgets`) untouched
- [ ] CI runs the full integration suite + lint gate on Linux / macOS / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)