### PR TITLE
imgui_boost: WidgetMeta pivot to (addr, TypeInfo) — drop per-widget JV/serializer emit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,16 +141,48 @@ for (col in type<ImGuiCol>) {
 
 ## Tests (`tests/integration/`)
 
-Tests run via `dastest`. From the daslang repo root with dasImgui installed `--global`:
+Tests run via `dastest`. Two equivalent local recipes — one mirrors CI exactly (`daspkg install --global`), one skips the install and uses this checkout directly via `-load_module`. **Both require `cwd = <dasImgui-root>`** because (a) the `modules/dasImgui` self-junction has to be visible to satisfy `--test modules/dasImgui/tests/integration` AND (b) `test_module_isolation.das` does `fopen("modules/dasImgui/widgets/imgui_visual_aids.das")` relative to cwd. **Both require `--headless`** — without it, the spawned daslang-live subprocesses pop real GLFW windows and flake on focus/port-reuse.
+
+**Recipe A — CI mirror (daspkg --global):**
 
 ```bash
+cd <daslang>
+<daslang>/bin/Release/daslang utils/daspkg/main.das -- install <path-to-this-dasImgui> --global
 <daslang>/bin/Release/daslang dastest/dastest.das -- \
     --test modules/dasImgui/tests/integration \
     --headless \
     --exclude glfw_synth --exclude key_hud
 ```
 
+**Recipe B — local-only (`-load_module`, no install):**
+
+```bash
+cd <dasImgui-root>                             # so modules/dasImgui self-junction resolves
+<daslang>/bin/Release/daslang \
+    -load_module <dasImgui-root> \             # daslang flag, BEFORE the script path
+    <daslang>/dastest/dastest.das -- \
+    --test modules/dasImgui/tests/integration \
+    --headless \
+    --exclude glfw_synth --exclude key_hud
+```
+
+`-load_module` is the daslang-side flag (see `daslang -h`) and **must come before the dastest script path**; placing it after `--` makes dastest swallow it and daslang's default project_root scan never picks up the module's `.das_module` (`register_native_path("imgui", "imgui_harness", ...)`) — so the very first test fails with `error[20605]: missing prerequisite 'imgui/imgui_harness'`. The self-junction alone (`modules/dasImgui -> .`) is NOT sufficient; daslang's project_root scan skips self-references.
+
+**Windows local runs also need the same `--exclude` set as Windows CI** (libhv's IOCP path stalls at 16 POSTs/subprocess):
+
+```bash
+    --exclude inputs_drag --exclude inputs_numeric --exclude inputs_slider \
+    --exclude indexed_dynamic --exclude inputs_color --exclude inputs_choice \
+    --exclude inputs_text
+```
+
 The `--headless` flag propagates to spawned daslang-live subprocesses via `widgets/imgui_playwright.das:515` (`playwright_wants_headless`).
+
+**Process cleanup between runs.** A killed/timed-out dastest leaves the live `daslang-live` child holding port 9090; the next run then fails immediately with `ERROR: another instance of daslang-live is already running on port 9090` on every test. Sweep before re-running:
+
+```powershell
+Get-Process -Name 'daslang','daslang-live','dastest','imguiApp','imguiAppHeadless' -ErrorAction SilentlyContinue | Stop-Process -Force
+```
 
 **Three test families:**
 

--- a/widgets/imgui_boost.das
+++ b/widgets/imgui_boost.das
@@ -524,40 +524,19 @@ class WidgetCallMacro : AstCallMacro {
                     imgui_boost_runtime::clear_module_widgets($v(modLit))
                 ))
             }
-            // Emit per-widget top-level getter + serializer as plain
-            // functions (no captures — they read the module-scope state global
-            // directly). register_widget then receives `@@<fn>` literals, so the
-            // long-lived registry stores plain function pointers instead of
-            // heap-allocated lambda capture frames. The `k` parameter is part
-            // of the unified API with indexed widgets — non-indexed getters
-            // ignore it.
-            let addrFnName = "__widget_addr${bareName}"
-            let jvFnName = "__widget_jv${bareName}"
-            if (find_unique_function(mod, addrFnName, true) == null) {
-                var addrFn = qmacro_function(addrFnName) $(k : int) : void? {
-                    return unsafe(addr($i(identLit)))
-                }
-                addrFn.flags.generated = true
-                addrFn.flags.privateFunction = true
-                addrFn.body |> force_at(expr.at)
-                mod |> add_function(addrFn)
-            }
-            if (find_unique_function(mod, jvFnName, true) == null) {
-                var jvFn = qmacro_function(jvFnName) $(k : int) : JsonValue? {
-                    return JV($i(identLit))
-                }
-                jvFn.flags.generated = true
-                jvFn.flags.privateFunction = true
-                jvFn.body |> force_at(expr.at)
-                mod |> add_function(jvFn)
-            }
+            // Pass the state global's address + TypeInfo directly to
+            // register_widget — no per-widget getter/serializer thunks. The
+            // address is a stable inline expression; the TypeInfo resolves
+            // through ``rtti_typeinfo`` to a static-table pointer. Snapshot
+            // and dispatcher paths use these via ``sprint_json_at`` /
+            // ``sscan_json_at`` (zero per-call-site daslang code).
             reg.list |> push(qmacro(
                 imgui_boost_runtime::register_widget(
                     $v(modLit),
                     $v(identLit),
                     $v(kindLit),
-                    @@$c(addrFnName),
-                    @@$c(jvFnName)
+                    unsafe(addr($i(identLit))),
+                    unsafe(reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo($i(identLit))))
                 )
             ))
         }
@@ -687,8 +666,11 @@ class WidgetCallMacro : AstCallMacro {
             return <- default<ExpressionPtr>
         }
         let indexedAddrFnName = "__widget_addr$indexed${kind_name}${bareName}"
-        let indexedJvFnName = "__widget_jv$indexed${kind_name}${bareName}"
         if (find_unique_function(mod, indexedAddrFnName, true) == null) {
+            // Shared per-(kind, IDENT) addr-getter. Still needed for indexed
+            // widgets because table slots may be erased between frames — we
+            // re-resolve per-call. JV-getter is gone; ``sprint_json_at`` reads
+            // the resolved addr + ``ti`` directly.
             var addrFn : FunctionPtr
             if (keyIsString) {
                 addrFn = qmacro_function(indexedAddrFnName) $(k : string) : void? {
@@ -705,24 +687,6 @@ class WidgetCallMacro : AstCallMacro {
             addrFn.flags.privateFunction = true
             addrFn.body |> force_at(expr.at)
             mod |> add_function(addrFn)
-        }
-        if (find_unique_function(mod, indexedJvFnName, true) == null) {
-            var jvFn : FunctionPtr
-            if (keyIsString) {
-                jvFn = qmacro_function(indexedJvFnName) $(k : string) : JsonValue? {
-                    return null if (!key_exists($i(bareNameLit), k))
-                    return JV($i(bareNameLit)[k])
-                }
-            } else {
-                jvFn = qmacro_function(indexedJvFnName) $(k : int) : JsonValue? {
-                    return null if (!key_exists($i(bareNameLit), k))
-                    return JV($i(bareNameLit)[k])
-                }
-            }
-            jvFn.flags.generated = true
-            jvFn.flags.privateFunction = true
-            jvFn.body |> force_at(expr.at)
-            mod |> add_function(jvFn)
         }
         // Emit the wrapper helper once per (kind, IDENT). find_unique_function
         // probes the user module before add_function fires; re-running visit()
@@ -743,37 +707,45 @@ class WidgetCallMacro : AstCallMacro {
             }
             let keyType = clone_type(tabType.firstType)
             let retType = clone_type(render_fn.result)
-            var bodyStmts : array<ExpressionPtr>
-            // bare = "<bareName>[<k>]" — runtime interp builds the path component
-            bodyStmts |> push <| qmacro_expr(${
-                let bare = "{$v(bareNameLit)}[{k}]"
-            })
+            // bare = "<bareName>[<k>]" — runtime interp builds the path component.
             // Do NOT push to container_path here even for containers — the
             // called [container]'s own macro-injected `container_path_push
             // (widget_ident)` does that with the same `bare` value. A wrapper
             // push would double-nest the path (`.../DYN_TAB[0]/DYN_TAB[0]`).
-            // path = container-aware key (matches what widget_finalize computes)
-            bodyStmts |> push <| qmacro_expr(${
-                let path = imgui_boost_runtime::widget_path_key(bare)
-            })
-            // First-touch / post-reload register. We pass plain function
-            // pointers into register_widget(_str); the runtime stores them in
-            // WidgetMeta along with `k` (consulted on every getter/serializer
-            // invoke). No lambda capture frame allocated per call site.
+            // path = container-aware key (matches what widget_finalize computes).
+            var bodyStmts <- [
+                qmacro_expr(${
+                    let bare = "{$v(bareNameLit)}[{k}]"
+                }),
+                qmacro_expr(${
+                    let path = imgui_boost_runtime::widget_path_key(bare)
+                })]
+            // First-touch / post-reload register. ``addr_getter`` is the
+            // per-(kind, IDENT) shared fn-ptr (re-resolves the live table
+            // slot per-call so erased keys surface as null). ``ti`` is the
+            // element ``TypeInfo`` resolved from a typed ``IDENT[k]`` lookup
+            // — the typer walks back through ``IDENT``'s table type to the
+            // element type, then ``rtti_typeinfo`` resolves to a static-table
+            // pointer at compile time (the runtime expression is never
+            // evaluated). No per-call-site daslang code path.
             if (keyIsString) {
                 bodyStmts |> push <| qmacro_expr(${
                     if (!imgui_boost_runtime::widget_registered(path)) {
                         imgui_boost_runtime::register_widget_str(
                             $v(moduleName), path, $v(kindLit),
-                            @@$c(indexedAddrFnName), @@$c(indexedJvFnName), k)
+                            @@$c(indexedAddrFnName),
+                            unsafe(reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo($i(bareNameLit)[k]))),
+                            k)
                     }
                 })
             } else {
                 bodyStmts |> push <| qmacro_expr(${
                     if (!imgui_boost_runtime::widget_registered(path)) {
-                        imgui_boost_runtime::register_widget(
+                        imgui_boost_runtime::register_widget_indexed(
                             $v(moduleName), path, $v(kindLit),
-                            @@$c(indexedAddrFnName), @@$c(indexedJvFnName), k)
+                            @@$c(indexedAddrFnName),
+                            unsafe(reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo($i(bareNameLit)[k]))),
+                            k)
                     }
                 })
             }

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -15,6 +15,7 @@ require daslib/coroutines public
 require daslib/async_boost
 require daslib/archive
 require daslib/result public
+require daslib/rtti
 require math
 require strings
 
@@ -612,19 +613,32 @@ struct MainMenuBarState {
 
 struct WidgetEntry {
     //! Per-frame snapshot of one rendered widget. Common fields populated
-    //! every frame; per-kind detail is materialized on demand by the
-    //! serializer lambda stored in `g_serializers[ident]` (parallel table)
-    //! and pasted into `payload` at imgui_snapshot time. The lambda lives
-    //! outside the entry because `g_registry` is cleared every frame and
-    //! we need the serializer (which captures `& state` of the per-widget
-    //! global) to survive that clear.
+    //! every frame; per-kind detail is materialized on demand from the
+    //! ``(addr, ti)`` pair stored in ``g_widgets[ident]`` and pasted into
+    //! ``payload`` at imgui_snapshot time via ``sprint_json_at`` +
+    //! ``read_json``. No per-widget serializer lambda — the addr+ti pair
+    //! survives ``g_registry``'s per-frame clear because it's pinned in
+    //! the long-lived ``g_widgets`` table.
     kind : string                                //! widget kind ("button", "slider_float", ...)
     hex_id : uint                                //! ImGui's GetID() for this widget on this frame
     bbox : float4                                //! packed [x0, y0, x1, y1]
     @optional hover : bool                       //! IsItemHovered() this frame
     @optional active : bool                      //! IsItemActive() this frame
     @optional focus : bool                       //! IsItemFocused() this frame
-    @optional payload : JsonValue?               //! populated by widget_entry_jv from g_serializers
+    @optional payload : JsonValue?               //! populated by widget_entry_jv from (addr, ti) via sprint_json_at + read_json
+}
+
+def private resolve_meta_addr(meta : WidgetMeta) : void? {
+    return meta.addr_getter_str(meta.k_str) if (meta.has_str_key)
+    return meta.addr_getter_int(meta.k_int) if (meta.addr_getter_int != null)
+    return meta.state_addr
+}
+
+def private state_payload_jv(state_addr : void?; ti : TypeInfo const?) : JsonValue? {
+    //! Build the per-widget state JSON payload via ``sprint_json_at`` + ``read_json``. Returns ``null`` when either ``state_addr`` or ``ti`` is null (erased indexed slot / unregistered kind).
+    return null if (state_addr == null || ti == null)
+    var err : string
+    return read_json(sprint_json_at(state_addr, *ti, false), err)
 }
 
 def private widget_entry_jv(ident : string; var entry : WidgetEntry) : JsonValue? {
@@ -659,13 +673,13 @@ var g_frame : int = 0
 struct WidgetMeta {
     module_name : string                                  //! owning module; lets clear_module_widgets drop on reload
     kind : string                                         //! widget kind ("button", "slider_float", ...)
-    addr_getter_int : function<(k : int) : void?>         //! int-keyed path: resolves live state-struct address. k=0 for non-indexed widgets (getter ignores it), the table key for ``table<int; …>`` indexed widgets. Plain function pointer — no heap-allocated lambda capture frame.
-    serializer_int  : function<(k : int) : JsonValue?>    //! int-keyed serializer; mirror of ``addr_getter_int`` shape. Invoked at imgui_snapshot time.
-    k_int : int                                           //! int key stored at registration: 0 for non-indexed, the actual ``TABLE[k]`` key for int-indexed widgets.
-    addr_getter_str : function<(k : string) : void?>      //! string-keyed path: resolves live state-struct address for ``table<string; …>`` indexed widgets. Null when ``has_str_key=false``.
-    serializer_str  : function<(k : string) : JsonValue?> //! string-keyed serializer; null when ``has_str_key=false``.
+    state_addr : void?                                    //! non-indexed: stable address of the module-scope state global (set by ``register_widget``). Indexed widgets pass ``null`` here and re-resolve per-k through ``addr_getter_int`` / ``addr_getter_str``. Named ``state_addr`` (not ``addr``) because daslang reserves ``addr`` as the builtin address-of operator.
+    ti : TypeInfo const?                            //! ``TypeInfo`` of the state value at ``addr`` (or the indexed slot's element). Drives ``sprint_json_at`` at snapshot time and ``sscan_json_at`` on dispatcher set-actions without per-call-site daslang thunks.
+    addr_getter_int : function<(k : int) : void?>         //! int-indexed path only: resolves live state-struct address per-call against the user's ``table<int; …>``. Null for non-indexed widgets — use ``addr`` instead.
+    k_int : int                                           //! int key stored at registration for indexed-int widgets; 0 when not indexed.
+    addr_getter_str : function<(k : string) : void?>      //! string-indexed path only: resolves live state-struct address for ``table<string; …>``. Null when ``has_str_key=false``.
     k_str : string                                        //! string key stored at registration; empty when ``has_str_key=false``.
-    has_str_key : bool                                    //! true => use the _str fns + k_str; false => use the _int fns + k_int
+    has_str_key : bool                                    //! true => use ``addr_getter_str`` + ``k_str``; false => use ``state_addr`` (non-indexed) or ``addr_getter_int`` + ``k_int``.
     last_seen_frame : int                                 //! last g_frame this path appeared in g_registry; -1 = never rendered
 }
 
@@ -903,12 +917,7 @@ def public pending_value_finalize(widget_ident : string; kind : string; var stat
 
 def public clear_module_widgets(module_name : string) {
     //! Drop every widget tagged with this module from the long-lived registries (g_widgets / id_to_path / focusable / pending_focus); called from each module's ``[init]`` so hot-reload re-binds cleanly.
-    var paths_to_remove : array<string>
-    for (k, m in keys(g_widgets), values(g_widgets)) {
-        if (m.module_name == module_name) {
-            paths_to_remove |> push(k)
-        }
-    }
+    var paths_to_remove <- [for (k, m in keys(g_widgets), values(g_widgets)); k; where m.module_name == module_name]
     for (k in paths_to_remove) {
         g_widgets |> erase(k)
     }
@@ -938,16 +947,33 @@ def public widget_registered(path : string) : bool {
 def public register_widget(module_name : string;
                            bare_ident : string;
                            kind : string;
-                           addr_getter : function<(k : int) : void?>;
-                           serializer : function<(k : int) : JsonValue?>;
-                           k : int = 0) {
-    //! Module-init registration of a widget into the long-lived ``g_widgets`` table; ``module_name`` lets :ref:`clear_module_widgets <function-imgui_boost_runtime_clear_module_widgets_string>` drop it on reload. ``addr_getter(k)`` resolves the live state-struct address on every dispatcher/serializer call — stable function pointer for globals (k ignored), key-checked re-resolution for indexed widgets with int keys (k = the table key, stored once at registration). For string-keyed indexed widgets use ``register_widget_str`` (sibling overload below).
+                           state_addr : void?;
+                           ti : TypeInfo const?) {
+    //! Module-init registration of a non-indexed widget into the long-lived ``g_widgets`` table. ``state_addr`` is the stable address of the module-scope state global (passed by the ``[widget]`` macro as ``unsafe(addr(IDENT))``); ``ti`` is its ``TypeInfo`` (``typeinfo rtti_typeinfo(IDENT)``). Both feed ``sprint_json_at`` at snapshot time — no per-widget getter/serializer functions emitted. For indexed widgets use ``register_widget_indexed`` / ``register_widget_str``.
     unsafe {
         g_widgets[bare_ident] <- WidgetMeta(
             module_name = module_name,
             kind = kind,
+            state_addr = state_addr,
+            ti = ti,
+            last_seen_frame = -1
+        )
+    }
+}
+
+def public register_widget_indexed(module_name : string;
+                                   bare_ident : string;
+                                   kind : string;
+                                   addr_getter : function<(k : int) : void?>;
+                                   ti : TypeInfo const?;
+                                   k : int) {
+    //! Int-indexed sibling of ``register_widget``. ``addr_getter(k)`` re-resolves per-call against the user's ``table<int; …>`` (slots may be erased between frames); ``ti`` is the element's ``TypeInfo``. ``k`` is the table key, stored once at registration.
+    unsafe {
+        g_widgets[bare_ident] <- WidgetMeta(
+            module_name = module_name,
+            kind = kind,
+            ti = ti,
             addr_getter_int = addr_getter,
-            serializer_int = serializer,
             k_int = k,
             last_seen_frame = -1
         )
@@ -958,15 +984,15 @@ def public register_widget_str(module_name : string;
                                bare_ident : string;
                                kind : string;
                                addr_getter : function<(k : string) : void?>;
-                               serializer : function<(k : string) : JsonValue?>;
+                               ti : TypeInfo const?;
                                k : string) {
-    //! String-keyed sibling of ``register_widget`` — for ``table<string; …>`` indexed widgets. Sets ``has_str_key`` so the dispatcher/serializer routes through ``addr_getter_str(k_str)`` instead of the int path.
+    //! String-keyed sibling of ``register_widget_indexed`` for ``table<string; …>``. Sets ``has_str_key`` so the lookup routes through ``addr_getter_str(k_str)``.
     unsafe {
         g_widgets[bare_ident] <- WidgetMeta(
             module_name = module_name,
             kind = kind,
+            ti = ti,
             addr_getter_str = addr_getter,
-            serializer_str = serializer,
             k_str := k,
             has_str_key = true,
             last_seen_frame = -1
@@ -975,11 +1001,10 @@ def public register_widget_str(module_name : string;
 }
 
 def public lookup_state_addr(path : string) : void? {
-    //! Resolve a widget's current state-struct address by path — invokes the registered ``addr_getter`` so indexed-form widgets reinterpret the live table slot on every call instead of dereferencing a stale capture. Returns null when ``path`` is absent from ``g_widgets`` or the getter reports the slot is gone (erased indexed key). Uses ``?[]`` safe lookup so the finalize lambdas can run from inside an ``imgui_snapshot`` iteration without tripping the locked-table guard (``tab[k]`` is daslang's auto-insert form).
+    //! Resolve a widget's current state-struct address by path. For non-indexed widgets returns ``meta.state_addr`` directly; for indexed widgets invokes the registered ``addr_getter`` so the live table slot is re-resolved on every call (slots may be erased between frames). Returns null when ``path`` is absent from ``g_widgets`` or the getter reports the slot is gone.
     let meta = unsafe(g_widgets?[path])
     return null if (meta == null)
-    return meta.addr_getter_str(meta.k_str) if (meta.has_str_key)
-    return meta.addr_getter_int(meta.k_int)
+    return resolve_meta_addr(*meta)
 }
 
 def public state_jv(path : string; t : type<auto(T)>) : JsonValue? {
@@ -1076,7 +1101,7 @@ def public container_finalize(widget_ident : string;
                               var entry : WidgetEntry;
                               var serializer : lambda<() : JsonValue?>;
                               var dispatcher : lambda<(action : string; payload : JsonValue?) : void>) {
-    //! Container counterpart of :ref:`widget_finalize <function-imgui_boost_runtime_widget_finalize_string_string_WidgetEntry_lambda_ls__c_void_gr__lambda_ls_action_c_string;payload_c_JsonValue_q__c_void_gr_>`; install the per-container serializer + dispatcher at the cached container path key.
+    //! Container counterpart of :ref:`widget_finalize <function-imgui_boost_runtime_widget_finalize>`; install the per-container serializer + dispatcher at the cached container path key.
     let path_key = container_path_key()
     check_unique_render(path_key, kind)
     entry.kind = kind
@@ -1166,14 +1191,8 @@ def private extract_string_field(obj : JsonValue?; name : string) : string {
 }
 
 def private widget_meta_jv(path_key : string; meta : WidgetMeta) : JsonValue? {
-    // Snapshot blob for a widget registered but not rendered this frame: rendered=false, state payload only.
-    var payload : JsonValue?
-    if (meta.has_str_key) {
-        payload = meta.serializer_str(meta.k_str)
-    } else {
-        payload = meta.serializer_int(meta.k_int)
-    }
-    return JV((kind = meta.kind, rendered = false, payload = payload))
+    // Snapshot blob for a widget registered but not rendered this frame: rendered=false, state payload only. State payload is built from (addr, ti) via sprint_json_at + read_json — no per-widget serializer function.
+    return JV((kind = meta.kind, rendered = false, payload = state_payload_jv(resolve_meta_addr(meta), meta.ti)))
 }
 
 def private io_jv() : JsonValue? {
@@ -1227,7 +1246,7 @@ def imgui_snapshot(input : JsonValue?) : JsonValue? {
 }
 
 def private classify_target(target : string) : tuple<int; string> {
-    // Map target → (level, resolved). 2 = L2 path, 1 = L1 hex_id (click-only via bbox synthesis), 0 = unresolvable.
+    // Map target → (level, resolved). 2 = L2 path (dispatcher rendered at least once), 1 = L1 hex_id (click-only via bbox synthesis), 0 = unresolvable.
     if (empty(target)) return (0, "")
     let n = length(target)
     let is_hex = n > 2 && slice(target, 0, 2) == "0x" || n > 2 && slice(target, 0, 2) == "0X"

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1101,7 +1101,7 @@ def public container_finalize(widget_ident : string;
                               var entry : WidgetEntry;
                               var serializer : lambda<() : JsonValue?>;
                               var dispatcher : lambda<(action : string; payload : JsonValue?) : void>) {
-    //! Container counterpart of :ref:`widget_finalize <function-imgui_boost_runtime_widget_finalize>`; install the per-container serializer + dispatcher at the cached container path key.
+    //! Container counterpart of ``widget_finalize`` (sibling above); install the per-container serializer + dispatcher at the cached container path key.
     let path_key = container_path_key()
     check_unique_render(path_key, kind)
     entry.kind = kind


### PR DESCRIPTION
## Summary

Pivots dasImgui's widget snapshot/serializer rail onto the `sprint_json_at(addr, ti, human)` builtin landed in [daslang #2854](https://github.com/GaijinEntertainment/daScript/pull/2854). Drops the per-`[widget]` `__widget_jv$X` getter family (one generic-`JV<T>` site per widget) and the per-binding non-indexed `__widget_addr$X` family in favor of inline `unsafe(addr(IDENT))` + `typeinfo rtti_typeinfo(IDENT)` at the `register_widget` call site.

**Compile-time delta on `examples/imgui_demo/imgui_demo.das`:**
- Wall: **12.99 s → 7.30 s** (**−44%**)
- Function count: **4491 → ~1159** (**−74%**)

Builds directly on [#68 (fn-pointer register_widget path)](https://github.com/borisbat/dasImgui/pull/68) — same call-site shape, but the JV/serializer half is removed entirely and the address is now inline rather than `@@fn`.

## How

### `WidgetMeta` shape change

```diff
 struct WidgetMeta {
     module_name : string
     kind : string
-    addr_getter_int : function<(k : int) : void?>
-    serializer_int  : function<(k : int) : JsonValue?>
-    k_int : int
-    addr_getter_str : function<(k : string) : void?>
-    serializer_str  : function<(k : string) : JsonValue?>
+    state_addr : void?                                // non-indexed: stable global address
+    ti : TypeInfo const?                              // TypeInfo of the value at state_addr (or indexed element)
+    addr_getter_int : function<(k : int) : void?>    // indexed-int only (re-resolves table slot)
+    k_int : int
+    addr_getter_str : function<(k : string) : void?> // indexed-str only
     k_str : string
     has_str_key : bool
     last_seen_frame : int
 }
```

The `serializer_*` function pointers are gone. The `addr_getter_*` pointers stay only on the indexed path — table slots may be erased between frames, so the resolver still needs per-call re-resolution. Non-indexed widgets pass the address inline.

### Three `register_widget*` overloads

| Overload | Args | Used by |
|---|---|---|
| `register_widget(module, ident, kind, addr, ti)` | inline addr + ti | non-indexed `[widget]` |
| `register_widget_indexed(module, ident, kind, addr_getter, ti, k)` | per-call addr getter + ti + int key | int-indexed `[widget]` |
| `register_widget_str(module, ident, kind, addr_getter, ti, k)` | per-call addr getter + ti + str key | string-indexed `[widget]` |

### Macro emit (`imgui_boost.das`)

**Non-indexed `[widget]` emit** ([imgui_boost.das L527-L562](widgets/imgui_boost.das#L527)):
- Drops `__widget_addr$IDENT` + `__widget_jv$IDENT` function emit (was 2 functions per `[widget]` call site).
- Emits inline at call site:
  ```
  imgui_boost_runtime::register_widget(
      modLit, identLit, kindLit,
      unsafe(addr(IDENT)),
      unsafe(reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(IDENT)))
  )
  ```

**Indexed `[widget]` emit** ([imgui_boost.das L666-L750](widgets/imgui_boost.das#L666)):
- Keeps `__widget_addr$indexed$KIND$IDENT` (still needs per-call slot re-resolution).
- Drops `__widget_jv$indexed$KIND$IDENT` entirely.
- Emits `typeinfo rtti_typeinfo(IDENT[k])` per binding (resolved to a static-table pointer at compile time — the runtime expression is never evaluated).
- Indexed call site uses `register_widget_indexed` or `register_widget_str` depending on key type.

### Snapshot path

`widget_meta_jv` (snapshot blob for registered-but-not-rendered widgets, [imgui_boost_runtime.das L1193](widgets/imgui_boost_runtime.das#L1193)) now calls the new helper:

```daslang
def private state_payload_jv(state_addr : void?; ti : TypeInfo const?) : JsonValue? {
    return null if (state_addr == null || ti == null)
    var err : string
    return read_json(sprint_json_at(state_addr, *ti, false), err)
}
```

Plus `resolve_meta_addr(meta)` which dispatches addr_getter_str → addr_getter_int → state_addr based on the meta's `has_str_key` / `addr_getter_int != null` flags.

The full snapshot path (`widget_entry_jv` for **rendered** widgets) is still on the per-call serializer rail installed by `widget_finalize` in user code. This PR pivots only the registry's fast path for registered widgets that weren't rendered this frame.

## Out of scope (follow-ups)

- **Dispatcher set-action path.** `imgui_widgets_builtin.das` still emits per-binding `disp <- @ capture(=path) (action, payload) { from_JV(...) }` lambdas. `sscan_json_at` is plumbed but unused here — landing it requires a separate macro rewrite in the dispatcher emit. Independent PR.
- **LiveVarsPassMacro pivot to `sprint_json` / `sscan_json`.** Lands on daslang, not dasImgui.

## Test plan

- [x] `mcp__daslang__format_file` clean on both modified files.
- [x] `mcp__daslang__lint --project_root D:/DASPKG/dasImgui` PASS on both.
- [x] daslang full test suite: **9438/9438 pass** (verified pre-PR via PR daslang#2863).
- [x] dasImgui integration suite (`tests/integration/`): **119/121 pass locally** in the last run. The 2 failures are flakes I could not reproduce in isolation (each failing test re-passes when run alone; failing tests differ between runs). Letting CI confirm.
- [x] Manual: `daslang-live` + `imgui_snapshot` on `harness_widgets.das` (ImVector-backed widgets) → exit 0, JSON output byte-equivalent to pre-PR modulo whitespace.
- [ ] CI green.

## Notes

- **TypeInfo identity across @live reload.** `WidgetMeta.ti` points into the program's static typeinfo table; on reload, captured pointers would dangle. Mitigated by `clear_module_widgets(module_name)` (prepended to every module's `[init]` by the macro), which drops every meta from the dead program before `[init]` re-fires with fresh typeinfo pointers.
- **`addr` is a reserved daslang builtin.** The `WidgetMeta` field is named `state_addr` (not `addr`) for that reason.
- **JSON byte-equivalence.** `sprint_json_at` and `json_boost`'s `JV<T>` produce JSON-equivalent but not necessarily byte-identical output (whitespace, numeric formatting). Integration tests parser-compare snapshots rather than byte-compare; pre/post snapshots round-trip identically through the parser.
- **Dependency:** requires [daslang #2854](https://github.com/GaijinEntertainment/daScript/pull/2854) (`sprint_json_at` builtin) and [daslang #2863](https://github.com/GaijinEntertainment/daScript/pull/2863) (ManagedVectorAnnotation TypeDecl leak fix — triggered by `sprint_json_at` walking ImVector fields). Both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)