### PR TITLE
imgui_boost: kill per-widget serializer/dispatcher lambdas (−20% imgui_demo compile)

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,57 @@
+# Repo-managed git hooks
+
+Tracked hooks that mirror CI checks. Cross-platform: Linux, macOS, Windows (Git Bash).
+
+## Enable (once per clone)
+
+```sh
+git config core.hooksPath .githooks
+```
+
+Reverts via `git config --unset core.hooksPath`. Skip once with `git push --no-verify`.
+
+### Windows notes
+
+- Git for Windows ships Git Bash — the `#!/usr/bin/env bash` shebang works out of the box. No extra install needed.
+- If you use PowerShell or `cmd` for `git push`, that's fine — git invokes the hook through its own shell, not yours.
+- File-mode permissions are ignored on Windows; just having the file in `.githooks/` is enough.
+
+### Linux / macOS
+
+Hooks must be executable. Cloning preserves the executable bit (it's set in the repo via `git update-index --chmod=+x`). If you ever lose it locally:
+
+```sh
+chmod +x .githooks/*
+```
+
+## Hooks
+
+- **pre-push** — formatter (`--verify` on the whole tree) + lint on pushed `.das` files. Mirrors `.github/workflows/docs.yml`.
+
+## Requirements
+
+dasImgui is a module — the `daslang` binary lives in your sibling daslang checkout. The script auto-detects:
+
+- `../daScript/bin/Release/daslang.exe` / `bin/Debug/daslang.exe` (Windows MSVC)
+- `../daScript/bin/daslang` / `bin/daslang.exe` (Linux/macOS/MSYS)
+- `../daScript/build/daslang`, `build/bin/daslang`
+- `../daslang/bin/...` (alt directory name)
+- `daslang` on `PATH`
+
+Build daslang before pushing:
+
+```sh
+cd ../daScript && cmake --build build --target daslang
+```
+
+Override the resolved path:
+
+```sh
+DASLANG=/custom/path/daslang.exe git push
+```
+
+Override the daslang source tree (needed for `utils/lint/main.das` and `utils/das-fmt/dasfmt.das`):
+
+```sh
+DASLANG_SRC=/custom/path/daScript git push
+```

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# pre-push: mirror CI's formatter + lint on changed .das files.
+# Cross-platform: runs under Git Bash on Windows, bash on Linux/macOS.
+#
+# Enable per-clone:
+#   git config core.hooksPath .githooks
+# Skip once:
+#   git push --no-verify
+# Override daslang binary path:
+#   DASLANG=/path/to/daslang git push
+#
+# dasImgui is a module, not a daslang checkout — the daslang binary lives
+# in the user's daslang clone. The hook probes sibling layouts; set $DASLANG
+# (or $DASLANG_SRC for the source tree) to override.
+
+set -eu
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+# Resolve daslang binary — sibling daScript checkout, then $PATH.
+resolve_daslang() {
+    if [ -n "${DASLANG:-}" ] && [ -x "$DASLANG" ]; then
+        echo "$DASLANG"; return
+    fi
+    for p in \
+        "$ROOT/../daScript/bin/Release/daslang.exe" \
+        "$ROOT/../daScript/bin/Debug/daslang.exe" \
+        "$ROOT/../daScript/bin/daslang" \
+        "$ROOT/../daScript/bin/daslang.exe" \
+        "$ROOT/../daScript/build/daslang" \
+        "$ROOT/../daScript/build/bin/daslang" \
+        "$ROOT/../daslang/bin/Release/daslang.exe" \
+        "$ROOT/../daslang/bin/daslang"
+    do
+        [ -x "$p" ] && { echo "$p"; return; }
+    done
+    local from_path
+    from_path="$(command -v daslang 2>/dev/null || true)"
+    [ -n "$from_path" ] && { echo "$from_path"; return; }
+    return 1
+}
+
+DASLANG="$(resolve_daslang || true)"
+if [ -z "$DASLANG" ]; then
+    echo "pre-push: daslang binary not found" >&2
+    echo "         set DASLANG=/path/to/daslang(.exe) or build a sibling daScript checkout" >&2
+    exit 1
+fi
+
+# Resolve daslang source root (need utils/lint/main.das + utils/das-fmt/dasfmt.das).
+DASLANG_SRC="${DASLANG_SRC:-}"
+if [ -z "$DASLANG_SRC" ]; then
+    bindir="$(cd "$(dirname "$DASLANG")" && pwd)"
+    while [ "$bindir" != "/" ] && [ ! -f "$bindir/utils/lint/main.das" ]; do
+        bindir="$(dirname "$bindir")"
+    done
+    [ -f "$bindir/utils/lint/main.das" ] && DASLANG_SRC="$bindir"
+fi
+if [ -z "$DASLANG_SRC" ] || [ ! -f "$DASLANG_SRC/utils/lint/main.das" ]; then
+    echo "pre-push: cannot locate daslang source tree (utils/lint/main.das)" >&2
+    echo "         set DASLANG_SRC=/path/to/daScript to override" >&2
+    exit 1
+fi
+
+echo "pre-push: using $DASLANG"
+echo "pre-push: daslang source: $DASLANG_SRC"
+
+# Formatter: whole tree, verify-only (CI parity).
+echo "pre-push: formatter --verify ..."
+"$DASLANG" "$DASLANG_SRC/utils/das-fmt/dasfmt.das" -- --path "$ROOT" --verify
+
+# Lint: only .das files changed in the pushed range vs remote tip
+# (mirrors CI's `git diff origin/<base>...HEAD`).
+ZERO40="0000000000000000000000000000000000000000"
+ZERO64="0000000000000000000000000000000000000000000000000000000000000000"
+RANGES=()
+while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+    case "$LOCAL_SHA" in "$ZERO40"|"$ZERO64") continue;; esac  # branch delete
+    case "$REMOTE_SHA" in
+        "$ZERO40"|"$ZERO64")
+            BASE="$(git merge-base "$LOCAL_SHA" origin/master 2>/dev/null || true)"
+            [ -n "$BASE" ] && RANGES+=("$BASE..$LOCAL_SHA")
+            ;;
+        *)
+            RANGES+=("$REMOTE_SHA..$LOCAL_SHA")
+            ;;
+    esac
+done
+
+if [ ${#RANGES[@]} -eq 0 ]; then
+    echo "pre-push: no ranges (deleting or empty); skipping lint"
+    exit 0
+fi
+
+# Portable read-into-array (mapfile is bash 4+; macOS default ships bash 3.2).
+CHANGED=()
+while IFS= read -r line; do
+    CHANGED+=("$line")
+done < <(git diff --name-only --diff-filter=AM "${RANGES[@]}" -- '*.das' | sort -u)
+
+if [ ${#CHANGED[@]} -eq 0 ]; then
+    echo "pre-push: no .das files changed; skipping lint"
+    exit 0
+fi
+
+echo "pre-push: linting ${#CHANGED[@]} .das file(s)"
+# `-load_module $ROOT` lets the lint resolve `require imgui/*` for dasImgui's
+# own modules. Parallel workers don't propagate `-load_module` (worker argv
+# starts at $0 = daslang), so we stay serial here. CI is also serial; this
+# is a few seconds per file in practice.
+"$DASLANG" -load_module "$ROOT" "$DASLANG_SRC/utils/lint/main.das" -- "${CHANGED[@]}" --quiet -j 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,8 @@ jobs:
           # Path basename becomes the daspkg install dir basename
           # (daspkg uses source basename, not .das_package's package_name).
           path: dasImgui
+          # Full history for the lint step's `git diff origin/<base>...HEAD`.
+          fetch-depth: 0
 
       - name: "Install system dependencies"
         run: |
@@ -78,6 +80,31 @@ jobs:
             -DDAS_GLFW_DISABLED=OFF \
             -G Ninja
           cmake --build ./build --parallel --target daslang
+
+      - name: "Lint changed .das files"
+        # Mirrors daslang's extended_checks.yml lint step. Runs against the
+        # dasImgui checkout via `-load_module` so requires inside `imgui/*`
+        # resolve without daspkg-installing the module first — fails fast
+        # before the slower APNG fetch + sphinx build.
+        working-directory: ${{ github.workspace }}/dasImgui
+        run: |
+          set -eux
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          BASE_REF="${BASE_REF:-master}"
+          # Ensure origin/$BASE_REF is fetched even if checkout pinned us
+          # to a non-default branch.
+          git fetch --depth=50 origin "$BASE_REF" 2>/dev/null || true
+          mapfile -t CHANGED < <(git diff --name-only --diff-filter=AM "origin/${BASE_REF}...HEAD" -- '*.das')
+          if [ ${#CHANGED[@]} -eq 0 ]; then
+            echo "no .das files changed; skipping lint"
+            exit 0
+          fi
+          echo "linting ${#CHANGED[@]} file(s): ${CHANGED[*]}"
+          # Serial (-j 1): parallel workers don't propagate -load_module.
+          ${{ github.workspace }}/daslang-src/bin/daslang \
+            -load_module ${{ github.workspace }}/dasImgui \
+            ${{ github.workspace }}/daslang-src/utils/lint/main.das -- \
+            "${CHANGED[@]}" --quiet -j 1
 
       - name: "Fetch tutorial APNGs from orphan assets branch"
         working-directory: ${{ github.workspace }}/dasImgui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### Changed
+
+- **`[widget_dispatch]` annotation re-keyed by state-struct type, not by
+  function name.** One `[widget_dispatch] def _(var state : T; action;
+  payload)` body fires for every widget kind whose state is `T` — the
+  fn name is irrelevant. Dispatch lookup at HTTP-receive time uses
+  `meta.ti.hash` (one global `g_dispatchers : table<uint64;
+  KindDispatcher>`); non-Structure `ti` (scalar pointee from
+  `[edit_widget]`) falls through to a generic `sscan_json_at(state_addr,
+  *ti)` in `dispatch_or_err`. Built-in widgets builtin file no longer
+  carries the `_register_*_dispatch_kinds()` `[init]` blocks (gone:
+  ~150 explicit `register_widget_kind` calls); ~50 per-kind
+  `dispatch_*` helpers collapse to ~35 per-state-struct
+  `[widget_dispatch]` bodies. Display-only state structs
+  (Narrative/Empty/Plot/Image/etc.) get no dispatcher and silently
+  no-op.
+- **Per-widget serializer/dispatcher lambdas killed.** Pre-PR4 every
+  `[widget]` body emitted 2 heap-allocated closures per render
+  (`ser <- @ capture(...)` + `disp <- @ capture(...)`); `widget_finalize`
+  routed them through path-keyed `g_serializers` / `g_dispatchers`
+  tables. Post-PR4: `widget_finalize` takes `(state_addr : void?, ti :
+  TypeInfo const?)` directly, no closures emitted. Snapshot rail
+  routes through `sprint_json_at(state_addr, *ti)` (which now matches
+  daslib `JV<vec>` wire shape after upstream daslang #2871). Compile
+  delta on `examples/imgui_demo/imgui_demo.das`: **−19.8% wall**
+  (7.01s → 5.62s mean, every patched run beats every baseline run).
+- **`[edit_widget]` family no longer needs per-pointee-type dispatcher
+  registrations.** Pre-PR4: 10 hardcoded `dispatch_edit_bool` /
+  `dispatch_edit_int` / `dispatch_edit_float3` / ... wrappers + one
+  `register_widget_kind` per edit_* kind. Post-PR4: 0. The scalar-
+  pointee `ti` is recorded in `g_widgets[path].ti`; `dispatch_or_err`
+  detects non-Structure ti and uses it to drive
+  `sscan_json_at(state_addr, *ti)` directly. Generic auto(T) edit_*
+  rails (`edit_drag_scalar` / `edit_input_scalar` / `edit_checkbox_flags`
+  / ...) work out of the box — meta.ti varies per instantiation, the
+  generic path covers everything.
+
 ### Added
 
 - `popup_window(IDENT, str_id, flags) $blk` — stateless `[container]`

--- a/daslib/imgui_boost.das
+++ b/daslib/imgui_boost.das
@@ -397,9 +397,7 @@ def EmbeddedListBox(name : string; var ent : auto(EnumT)&; max_height_in_items :
         for (ef in *ti.enumType) {
             let isSelected = ef.value == int64(int(ent))
             if (Selectable("{ef.name}##{name}", isSelected, ImGuiSelectableFlags.None, float2(max_tw, 0.))) {
-                unsafe {
-                    ent = reinterpret<EnumT>(ef.value)
-                }
+                ent = unsafe(reinterpret<EnumT>(ef.value))
                 return true
             }
         }

--- a/examples/features/indexed_dynamic.das
+++ b/examples/features/indexed_dynamic.das
@@ -82,10 +82,7 @@ def update() {
         // access would trip "can't insert to a locked table" if iterated
         // directly through `keys(...)`, since table[k] auto-inserts and the
         // iterator holds the table lock.
-        var live_keys : array<int>
-        for (k in keys(CHANNEL_VOL)) {
-            live_keys |> push(k)
-        }
+        let live_keys <- [for (k in keys(CHANNEL_VOL)); k]
         for (k in live_keys) {
             slider_float(CHANNEL_VOL[k], (text = "ch{k}"))
         }

--- a/examples/features/input_text_callback.das
+++ b/examples/features/input_text_callback.das
@@ -21,10 +21,7 @@ let private COMMANDS <- ["help", "history", "clear", "classify", "echo", "exit"]
 def private completion_cb(var data : ImGuiInputTextCallbackData) : int {
     if (data.EventFlag == ImGuiInputTextFlags.CallbackCompletion) {
         let prefix = clone_string(data.Buf)
-        var matches : array<string>
-        for (c in COMMANDS) {
-            if (c |> starts_with(prefix)) matches |> push(c)
-        }
+        var matches <- [for (c in COMMANDS); c; where c |> starts_with(prefix)]
         if (length(matches) == 1) {
             data |> DeleteChars(0, data.BufTextLen)
             data |> InsertChars(0, matches[0])

--- a/examples/features/widget_init_defaults.das
+++ b/examples/features/widget_init_defaults.das
@@ -39,18 +39,19 @@ def show_defaults(var state : DefaultsState; text : string) : int {
     Text("count={state.count} ratio={state.ratio} caption={state.caption}")
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV(state)
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            if (action == "set") {
-                state.pending_bump = true
-                state.has_pending = true
-            }
-        }
-        widget_finalize(widget_ident, "show_defaults", entry, ser, disp)
+        widget_finalize(widget_ident, "show_defaults", entry,
+                        addr(state),
+                        reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<DefaultsState>)))
     }
     return state.count
+}
+
+[widget_dispatch]
+def show_defaults(var state : DefaultsState; action : string; payload : string) {
+    if (action == "set") {
+        state.pending_bump = true
+        state.has_pending = true
+    }
 }
 
 [export]

--- a/examples/imgui_demo/app_console.das
+++ b/examples/imgui_demo/app_console.das
@@ -121,7 +121,7 @@ def private exec_command(cmd : string) {
 // =============================================================================
 
 def private is_word_sep(c : int) : bool {
-    return c == int(' ') || c == int('\t') || c == int(',') || c == int(';')
+    return c == ' ' || c == '\t' || c == ',' || c == ';'
 }
 
 def private text_edit_callback(var data : ImGuiInputTextCallbackData) : int {
@@ -141,12 +141,9 @@ def private text_edit_callback(var data : ImGuiInputTextCallbackData) : int {
         let upper_prefix = to_upper(prefix)
         let plen = word_end - word_start
 
-        var candidates : array<string>
-        for (c in CONSOLE_COMMANDS) {
-            if (length(c) >= plen && to_upper(slice(c, 0, plen)) == upper_prefix) {
-                candidates |> push_clone(c)
-            }
-        }
+        var candidates <- [for (c in CONSOLE_COMMANDS);
+                               c;
+                               where length(c) >= plen && to_upper(slice(c, 0, plen)) == upper_prefix]
 
         if (empty(candidates)) {
             add_log("No match for \"{prefix}\"!")

--- a/examples/imgui_demo/app_log.das
+++ b/examples/imgui_demo/app_log.das
@@ -81,7 +81,7 @@ def ShowExampleAppLog() {
             let words = fixed_array("Bumfuzzled", "Cattywampus", "Snickersnee",
                                     "Abibliophobia", "Absquatulate",
                                     "Nincompoop", "Pauciloquent")
-            for (n in range(5)) {
+            for (_n in range(5)) {
                 let category = categories[LOG_DEBUG_COUNTER % length(categories)]
                 let word = words[LOG_DEBUG_COUNTER % length(words)]
                 add_log("[{LOG_DEBUG_COUNTER}] [{category}] " +
@@ -134,7 +134,7 @@ def ShowExampleAppLog() {
                     // terms, so `PassFilter("")` returns true even though
                     // the filter is active — clipper path would then
                     // render lines the user explicitly excluded.)
-                    list_clipper(length(LOG_ITEMS)) <| $(start, end_) {
+                    list_clipper(length(LOG_ITEMS)) $(start, end_) {
                         for (i in range(start, end_)) {
                             text(LOG_ITEM_TEXT[i], (text = LOG_ITEMS[i]))
                         }

--- a/examples/imgui_demo/app_small.das
+++ b/examples/imgui_demo/app_small.das
@@ -72,7 +72,7 @@ def ShowExampleAppLayout() : bool {
             }
         }
         // Left pane — resizable child with 100 selectable rows.
-        let left_flags = int(ImGuiChildFlags.Border) | int(ImGuiChildFlags.ResizeX)
+        let left_flags = int(ImGuiChildFlags.Border | ImGuiChildFlags.ResizeX)
         child(SMALL_LAYOUT_LEFT_CHILD,
               (text = "left pane", size = float2(150.0f, 0.0f),
                child_flags = unsafe(reinterpret<ImGuiChildFlags>(left_flags)),
@@ -167,9 +167,9 @@ def private ShowPlaceholderObject(prefix : string; uid : int) {
                         table_next_row()
                         table_set_column_index(0)
                         align_text_to_frame_padding(SMALL_PROPED_ATFP_FIELD)
-                        let leaf_flags = (int(ImGuiTreeNodeFlags.Leaf) |
-                                          int(ImGuiTreeNodeFlags.NoTreePushOnOpen) |
-                                          int(ImGuiTreeNodeFlags.Bullet))
+                        let leaf_flags = int(ImGuiTreeNodeFlags.Leaf |
+                                              ImGuiTreeNodeFlags.NoTreePushOnOpen |
+                                              ImGuiTreeNodeFlags.Bullet)
                         tree_node_ex(SMALL_PROPED_FIELD[i],
                             (text = "Field_{i}",
                              flags = unsafe(reinterpret<ImGuiTreeNodeFlags>(leaf_flags))))
@@ -207,9 +207,9 @@ def ShowExampleAppPropertyEditor() : bool {
             }
         }
         with_style((ImGuiStyleVar.FramePadding, float2(2.0f, 2.0f))) {
-            let tflags = (int(ImGuiTableFlags.BordersOuter) |
-                          int(ImGuiTableFlags.Resizable) |
-                          int(ImGuiTableFlags.ScrollY))
+            let tflags = int(ImGuiTableFlags.BordersOuter |
+                              ImGuiTableFlags.Resizable |
+                              ImGuiTableFlags.ScrollY)
             data_table(SMALL_PROPED_TABLE,
                        (text = "##split", columns = 2,
                         flags = unsafe(reinterpret<ImGuiTableFlags>(tflags)),
@@ -297,7 +297,7 @@ def ShowExampleAppLongText() : bool {
             } elif (SMALL_LONG_TEST_TYPE == 1) {
                 // Clipper-cull. Per-line content is identical (matches cpp).
                 with_style((ImGuiStyleVar.ItemSpacing, float2(0.0f, 0.0f))) {
-                    list_clipper(lines_n) <| $(start, end_) {
+                    list_clipper(lines_n) $(start, end_) {
                         for (i in range(start, end_)) {
                             text(SMALL_LONG_LINES_TEXT[i],
                                 (text = SMALL_LONG_LINES_BUF[i]))
@@ -380,7 +380,7 @@ def small_constr_init() {
                                       float(int(data.DesiredSize.x / aspect_ratio)))
         })
     SMALL_CONSTR_SQUARE_CN <- ImGuiSizeConstraints(
-        @ (var data : ImGuiSizeCallbackData) : void {
+        @(var data : ImGuiSizeCallbackData) : void {
             let s = max(data.DesiredSize.x, data.DesiredSize.y)
             data.DesiredSize = float2(s, s)
         })
@@ -489,12 +489,12 @@ var private SMALL_OVERLAY_LOCATION = 0  // 0..3 = corner, -1 = custom, -2 = cent
 
 def ShowExampleAppSimpleOverlay() : bool {
     let PAD = 10.0f
-    var window_flags = (int(ImGuiWindowFlags.NoDecoration) |
-                        int(ImGuiWindowFlags.NoDocking) |
-                        int(ImGuiWindowFlags.AlwaysAutoResize) |
-                        int(ImGuiWindowFlags.NoSavedSettings) |
-                        int(ImGuiWindowFlags.NoFocusOnAppearing) |
-                        int(ImGuiWindowFlags.NoNav))
+    var window_flags = int(ImGuiWindowFlags.NoDecoration |
+                            ImGuiWindowFlags.NoDocking |
+                            ImGuiWindowFlags.AlwaysAutoResize |
+                            ImGuiWindowFlags.NoSavedSettings |
+                            ImGuiWindowFlags.NoFocusOnAppearing |
+                            ImGuiWindowFlags.NoNav)
     let viewport = GetMainViewport()
     if (SMALL_OVERLAY_LOCATION >= 0) {
         let work_pos = viewport.WorkPos
@@ -510,7 +510,7 @@ def ShowExampleAppSimpleOverlay() : bool {
         SetNextWindowViewport(viewport.ID)
         window_flags |= int(ImGuiWindowFlags.NoMove)
     } elif (SMALL_OVERLAY_LOCATION == -2) {
-        let center = viewport_center(unsafe(*viewport))
+        let center = viewport_center(unsafe(*viewport))   // nolint:STYLE024  ptr-deref needs unsafe (rule misses ExprPtr2Ref)
         SetNextWindowPos(center, ImGuiCond.Always, float2(0.5f, 0.5f))
         SetNextWindowViewport(viewport.ID)
         window_flags |= int(ImGuiWindowFlags.NoMove)
@@ -571,9 +571,9 @@ def ShowExampleAppSimpleOverlay() : bool {
 // =============================================================================
 
 var private SMALL_FULL_USE_WORK_AREA = true
-var private SMALL_FULL_FLAGS = (int(ImGuiWindowFlags.NoDecoration) |
-                                int(ImGuiWindowFlags.NoMove) |
-                                int(ImGuiWindowFlags.NoSavedSettings))
+var private SMALL_FULL_FLAGS = int(ImGuiWindowFlags.NoDecoration |
+                                    ImGuiWindowFlags.NoMove |
+                                    ImGuiWindowFlags.NoSavedSettings)
 
 def ShowExampleAppFullscreen() : bool {
     let viewport = GetMainViewport()
@@ -660,7 +660,7 @@ def ShowExampleAppWindowTitles() {
     let frame = GetFrameCount()
     let spinner = "|/-\\"
     let si = (frame / 15) % 4
-    let title = "Animated title {character_at(spinner, si)} {frame}###AnimatedTitle"
+    let title = "Animated title {character_at(spinner, si)} {frame}###AnimatedTitle"   // nolint:PERF003  4-char literal, once per frame
     SetNextWindowPos(float2(base_pos.x + 100.0f, base_pos.y + 300.0f),
                      ImGuiCond.FirstUseEver, float2(0.0f, 0.0f))
     window(SMALL_TITLES_W3, (text = title, closable = false,

--- a/examples/imgui_demo/columns.das
+++ b/examples/imgui_demo/columns.das
@@ -273,7 +273,7 @@ def private HorizontalScrollingSection() {
             columns_open(10)
             // Cull the 2000 virtual rows to the visible region via the
             // list_clipper boost helper (wraps ImGuiListClipper Begin/Step/End).
-            list_clipper(2000) <| $(start, end_) {
+            list_clipper(2000) $(start, end_) {
                 for (i in range(start, end_)) {
                     for (j in range(10)) {
                         text("Line {i} Column {j}...")

--- a/tests/integration/test_app_custom_rendering.das
+++ b/tests/integration/test_app_custom_rendering.das
@@ -25,13 +25,13 @@ def test_app_custom_rendering_smoke(t : T?) {
         t |> success(widget_exists(snap0, "CR_WIN/CR_TABS"),
                      "CR_WIN/CR_TABS tab_bar registers")
         let tab_prim = find_widget(snap0, "CR_WIN/CR_TABS/CR_TAB_PRIM")
-        t |> equal(string(tab_prim?["kind"] ?? ""), "tab_item",
+        t |> equal(tab_prim?["kind"] ?? "", "tab_item",
                    "CR_TAB_PRIM (default-active) renders as tab_item")
 
         // Context-menu popup is always installed (per the cpp port) but
         // open=false by default — confirms the popup container is wired.
         let ctx = find_widget(snap0, "CR_CV_CTX_MENU")
-        t |> equal(string(ctx?["kind"] ?? ""), "popup",
+        t |> equal(ctx?["kind"] ?? "", "popup",
                    "CR_CV_CTX_MENU registered as kind=popup")
         t |> equal(ctx?["payload"]?["open"] ?? true, false,
                    "context menu starts closed")

--- a/tests/integration/test_app_dockspace.das
+++ b/tests/integration/test_app_dockspace.das
@@ -23,9 +23,9 @@ def test_app_dockspace_smoke(t : T?) {
         if (snap == null) return
 
         let ds = find_widget(snap, "DS_WIN/DS")
-        t |> equal(string(ds?["kind"] ?? ""), "dockspace_in_window",
+        t |> equal(ds?["kind"] ?? "", "dockspace_in_window",
                    "DS_WIN/DS registers as kind=dockspace_in_window")
-        let dock_id = uint(ds?["payload"]?["dock_id"] ?? 0u)
+        let dock_id = ds?["payload"]?["dock_id"] ?? 0u
         t |> success(dock_id != 0u,
                      "dock_id captured (got 0x{dock_id})")
 

--- a/tests/integration/test_app_documents.das
+++ b/tests/integration/test_app_documents.das
@@ -39,7 +39,7 @@ def test_app_documents_smoke(t : T?) {
         // Close-confirmation modal is installed; opens only when a dirty
         // doc is being closed. Fresh fixture: starts closed.
         let modal = find_widget(snap, "DOCS_CLOSE_MODAL")
-        t |> equal(string(modal?["kind"] ?? ""), "popup_modal",
+        t |> equal(modal?["kind"] ?? "", "popup_modal",
                    "DOCS_CLOSE_MODAL registered as popup_modal")
         t |> equal(modal?["payload"]?["open"] ?? true, false,
                    "close-confirmation modal starts closed (no dirty docs)")

--- a/tests/integration/test_app_small_auto_resize.das
+++ b/tests/integration/test_app_small_auto_resize.das
@@ -24,7 +24,7 @@ def test_app_small_auto_resize_smoke(t : T?) {
         var slider = find_widget(snap0, "SMALL_AUTO_WIN/SMALL_AUTO_SLIDER")
         t |> equal(slider?["kind"] ?? "", "slider_int",
                    "slider registers as kind=slider_int")
-        t |> equal(int(slider?["payload"]?["value"] ?? 0), 10,
+        t |> equal(slider?["payload"]?["value"] ?? 0, 10,
                    "slider initial value matches the init=10 seed")
 
         // Drive value to 5 and verify the new line count via the per-line

--- a/tests/integration/test_app_small_constrained_resize.das
+++ b/tests/integration/test_app_small_constrained_resize.das
@@ -26,7 +26,7 @@ def test_app_small_constrained_resize_smoke(t : T?) {
         var combo_entry = find_widget(snap0, "SMALL_CONSTR_WIN/SMALL_CONSTR_COMBO")
         t |> equal(combo_entry?["kind"] ?? "", "combo",
                    "constraint combo registers as kind=combo")
-        t |> equal(int(combo_entry?["payload"]?["value"] ?? 0), 6,
+        t |> equal(combo_entry?["payload"]?["value"] ?? 0, 6,
                    "default constraint type is 6 (Aspect Ratio 16:9 — callback path)")
 
         var btn200 = find_widget(snap0, "SMALL_CONSTR_WIN/SMALL_CONSTR_BTN_200")

--- a/tests/integration/test_button_repeat.das
+++ b/tests/integration/test_button_repeat.das
@@ -24,7 +24,7 @@ def test_button_repeat_smoke(t : T?) {
         // The repeat-vs-fire-once behavioral difference requires hold-time
         // input; record_button_repeat.das exercises that. Smoke gate is
         // just existence + initial click_count == 0.
-        let outside_clicks = int(widget_payload_field(snap, "MAIN_WIN/BTN_OUTSIDE", "click_count") ?? 0)
+        let outside_clicks = widget_payload_field(snap, "MAIN_WIN/BTN_OUTSIDE", "click_count") ?? 0
         t |> equal(outside_clicks, 0, "outside button has not been clicked yet")
     }
 }

--- a/tests/integration/test_child_scroll_reenter.das
+++ b/tests/integration/test_child_scroll_reenter.das
@@ -27,8 +27,8 @@ def test_child_scroll_reenter_moves_scroll(t : T?) {
         t |> success(snap0 != null, "SCROLLY child renders")
         if (snap0 == null) return
         // SCROLLY.scroll.y starts at 0.0 — the child opens scrolled to top.
-        let y0 = (find_widget(snap0, "MAIN_WIN/SCROLLY")?["payload"]?["scroll"]?["y"] ?? 0.0lf)
-        t |> equal(double(y0), 0.0lf, "initial SCROLLY.scroll.y == 0")
+        let y0 : double = find_widget(snap0, "MAIN_WIN/SCROLLY")?["payload"]?["scroll"]?["y"] ?? 0.0lf
+        t |> equal(y0, 0.0lf, "initial SCROLLY.scroll.y == 0")
         // One click should fire child_scroll_reenter once and move scroll
         // by `delta = 8.0f` (per the feature file). Click several times to
         // get a clearly-non-zero observation that's robust to single-frame
@@ -40,7 +40,7 @@ def test_child_scroll_reenter_moves_scroll(t : T?) {
         var snap1 = snapshot(d)
         t |> success(snap1 != null, "post-click snapshot available")
         if (snap1 == null) return
-        let y1 : double = double(find_widget(snap1, "MAIN_WIN/SCROLLY")?["payload"]?["scroll"]?["y"] ?? 0.0lf)
+        let y1 : double = find_widget(snap1, "MAIN_WIN/SCROLLY")?["payload"]?["scroll"]?["y"] ?? 0.0lf
         t |> success(y1 > 0.0lf,
                      "SCROLLY.scroll.y moved (y={y1}); wrapper's PushID(IDENT) reentered the same window")
     }

--- a/tests/integration/test_dockspace_in_window.das
+++ b/tests/integration/test_dockspace_in_window.das
@@ -27,9 +27,9 @@ def test_dockspace_in_window_captures_dock_id(t : T?) {
         t |> success(ds_snap != null, "HOST/DS dockspace registers")
         if (ds_snap == null) return
         let ds_widget = find_widget(ds_snap, "HOST/DS")
-        t |> equal(string(ds_widget?["kind"] ?? ""), "dockspace_in_window",
+        t |> equal(ds_widget?["kind"] ?? "", "dockspace_in_window",
                    "HOST/DS registers as kind=dockspace_in_window (not bare dockspace)")
-        let dock_id_0 = uint(ds_widget?["payload"]?["dock_id"] ?? 0u)
+        let dock_id_0 = ds_widget?["payload"]?["dock_id"] ?? 0u
         t |> success(dock_id_0 != 0u,
                      "DS.dock_id captured on first render (got 0x{dock_id_0})")
         // Wait a few frames; dock_id must stay stable.
@@ -37,7 +37,7 @@ def test_dockspace_in_window_captures_dock_id(t : T?) {
         var snap1 = snapshot(d)
         t |> success(snap1 != null, "stable-snapshot snap1 available")
         if (snap1 == null) return
-        let dock_id_1 = uint(find_widget(snap1, "HOST/DS")?["payload"]?["dock_id"] ?? 0u)
+        let dock_id_1 = find_widget(snap1, "HOST/DS")?["payload"]?["dock_id"] ?? 0u
         t |> equal(dock_id_1, dock_id_0,
                    "DS.dock_id stable across frames")
     }

--- a/tests/integration/test_drawlist_path_key.das
+++ b/tests/integration/test_drawlist_path_key.das
@@ -48,7 +48,7 @@ def test_drawlist_path_key_shape(t : T?) {
         var bad_shape = ""
         var bad_bbox = ""
         for (k, v in keys(globals.value as _object), values(globals.value as _object)) {
-            let kind = string(v?["kind"] ?? "")
+            let kind = v?["kind"] ?? ""
             if (!is_drawlist_kind(kind)) continue
             seen_drawlist++
             // Strip container prefix (anything before the last '/')
@@ -80,7 +80,7 @@ def test_drawlist_path_key_shape(t : T?) {
         // without snagging neighbouring widget machinery.
         var state_global_leaks = ""
         for (k, v in keys(globals.value as _object), values(globals.value as _object)) {
-            let kind = string(v?["kind"] ?? "")
+            let kind = v?["kind"] ?? ""
             if (!is_drawlist_kind(kind)) continue
             var leaf = k
             let last_slash = rfind(k, "/")

--- a/tests/integration/test_edit_external_combo.das
+++ b/tests/integration/test_edit_external_combo.das
@@ -22,7 +22,7 @@ def test_edit_external_combo_smoke(t : T?) {
         t |> success(widget_exists(snap, "MAIN_WIN/COMBO_DIFFICULTY"),
                      "COMBO_DIFFICULTY registered")
 
-        let idx0 = int(widget_payload_field(snap, "MAIN_WIN/COMBO_THEME", "value") ?? 0)
+        let idx0 = widget_payload_field(snap, "MAIN_WIN/COMBO_THEME", "value") ?? 0
         t |> equal(idx0, 1, "initial selected idx = 1 ('Dark')")
 
         set_value(d, "MAIN_WIN/COMBO_THEME", JV(3))

--- a/tests/integration/test_with_window_drawlist.das
+++ b/tests/integration/test_with_window_drawlist.das
@@ -29,9 +29,9 @@ def count_primitives_under(var snap : JsonValue?; prefix : string) : int {
     var globals = snap?["globals"]
     return n if (globals == null || !(globals.value is _object))
     for (k, v in keys(globals.value as _object), values(globals.value as _object)) {
-        let kind = string(v?["kind"] ?? "")
+        let kind = v?["kind"] ?? ""
         if (length(kind) > 4 && slice(kind, 0, 4) == "add_") {
-            if (length(prefix) == 0) {
+            if (empty(prefix)) {
                 n++ if (find(k, "/") == -1)
             } else {
                 n++ if (length(k) > length(prefix) && slice(k, 0, length(prefix)) == prefix)

--- a/widgets/imgui_boost.das
+++ b/widgets/imgui_boost.das
@@ -949,3 +949,93 @@ class EditExternalCallMacro : AstCallMacro {
         return <- newCall
     }
 }
+
+// ===== [widget_dispatch] — per-state-struct dispatcher registration =====
+//
+// Applied to a top-level function with signature
+//   def <name>(var state : T; action : string; payload : string) { ... }
+// keyed by the FIRST PARAMETER'S STRUCT TYPE (T), not by the function name.
+// One ``[widget_dispatch]`` per state struct covers every widget kind whose
+// state is that struct — e.g. the single ClickState dispatcher fires for
+// ``button``/``small_button``/``arrow_button``/.... Macro emits:
+//   - a type-erased wrapper that casts ``state_addr : void?`` to ``T?`` and
+//     delegates to the user body, and
+//   - an init registration via
+//       imgui_boost_runtime::register_widget_dispatch_for_type(
+//           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<T>)),
+//           @@<wrapper>)
+//     pushed into the shared per-module ``register`imgui`widget_kinds`` init
+//     block (same setup_call_list pattern as [widget]'s register_widget at L518).
+//
+// External widget kinds defined in user modules use this same annotation. The
+// function NAME is irrelevant — what matters is the first parameter's struct
+// type. Built-in dispatchers live in ``imgui_widgets_builtin.das`` /
+// ``imgui_containers_builtin.das`` / ``imgui_docking_builtin.das`` /
+// ``imgui_layout_builtin.das`` alongside the existing ``_finalize`` helpers.
+
+[function_macro(name = "widget_dispatch")]
+class WidgetDispatchFunctionMacro : AstFunctionAnnotation {
+    //! ``[widget_dispatch]`` annotation — registers a per-state-struct dispatcher for HTTP set/click/open/close actions. Required signature: ``def <name>(var state : T; action : string; payload : string)``. Keyed by ``T`` (first parameter's struct type); the function name is irrelevant. One body per state struct covers every kind whose state is ``T``. Renames the user function to private ``__dispatch_body_<T>`` (avoids collision with same-named ``[widget]`` defs), emits a type-erased wrapper ``__dispatch_wrap_<T>``, and pushes an init call to ``register_widget_dispatch_for_type`` so ``dispatch_or_err`` resolves via ``meta.ti.hash`` at runtime.
+    def override apply(var func : FunctionPtr; var group : ModuleGroup;
+                       args : AnnotationArgumentList; var errors : das_string) : bool {
+        if (length(func.arguments) != 3) {
+            errors := "[widget_dispatch] requires exactly 3 parameters: (var state : T; action : string; payload : string)"
+            return false
+        }
+        let stateArg = func.arguments[0]
+        if (stateArg._type == null || stateArg._type.structType == null) {
+            errors := "[widget_dispatch] first parameter must be a struct (state)"
+            return false
+        }
+        let actionArg = func.arguments[1]
+        if (actionArg._type == null || actionArg._type.baseType != Type.tString) {
+            errors := "[widget_dispatch] second parameter must be `action : string`"
+            return false
+        }
+        let payloadArg = func.arguments[2]
+        if (payloadArg._type == null || payloadArg._type.baseType != Type.tString) {
+            errors := "[widget_dispatch] third parameter must be `payload : string`"
+            return false
+        }
+        // Key the dispatcher by the state struct's name (not the function
+        // name). This collapses N kinds sharing a state struct down to one
+        // body — and the macro can be re-applied to multiple bodies for the
+        // same struct (last wins, with a setup_call_list dedup keeping the
+        // init block idempotent).
+        let structName = string(stateArg._type.structType.name)
+        func.name := "__dispatch_body_{structName}"
+        func.flags.generated = true
+        func.flags.privateFunction = true
+        let mod = compiling_module()
+        let wrapperName = "__dispatch_wrap_{structName}"
+        let bodyName = "__dispatch_body_{structName}"
+        if (find_unique_function(mod, wrapperName, true) == null) {
+            // Type-erased wrapper. Casts addr to ``T -const?`` and delegates
+            // to the renamed user body. One wrapper per state struct;
+            // registered against the struct's ``TypeInfo`` hash via the
+            // init block below.
+            var wrapper = qmacro_function(wrapperName) $(state_addr : void?; action : string; payload : string) {
+                unsafe {
+                    var s & = *reinterpret<$t(stateArg._type) -const?>(state_addr)
+                    $c(bodyName)(s, action, payload)
+                }
+            }
+            wrapper.flags.generated = true
+            wrapper.flags.privateFunction = true
+            wrapper.body |> force_at(func.at)
+            mod |> add_function(wrapper)
+        }
+        // Push init registration into the shared module init block. Pass the
+        // state struct's TypeInfo* at registration time; the runtime reads
+        // ``ti.hash`` and stores under that key in ``g_dispatchers``.
+        var reg <- setup_call_list("register`imgui`widget_kinds", func.at, true, true)
+        let wrapperLit = wrapperName
+        var typeForTI = clone_type(stateArg._type)
+        reg.list |> push(qmacro(
+            imgui_boost_runtime::register_widget_dispatch_for_type(
+                unsafe(reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<$t(typeForTI)>))),
+                @@$c(wrapperLit))
+        ))
+        return true
+    }
+}

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -690,6 +690,16 @@ struct WidgetMeta {
 
 var g_widgets : table<string; WidgetMeta>
 
+// Sentinel module_name for entries created lazily by `widgets_mark_seen` (the
+// [edit_widget] external-pointer path). Pre-registered entries from
+// `register_widget`/`register_widget_indexed`/`register_widget_str` carry the
+// caller's `compiling_module().name` — which is "" for main files (top-level
+// scripts with no `module X` decl) and non-empty for required modules. Lazy
+// entries get this sentinel instead so the snapshot freshness gate at
+// `widget_meta_jv`'s iteration loop can drop them after one frame absent
+// without affecting main-file pre-registered entries.
+let private LAZY_EDIT_WIDGET_MODULE = "<edit_widget>"
+
 // ===== Phase 2 reverse maps + coroutine runner =====
 //
 // `g_id_to_path` is a long-lived hex_id → path_key map populated by every
@@ -1034,7 +1044,7 @@ def public widget_finalize(widget_ident : string;
                            state_addr : void?;
                            ti : TypeInfo const?) {
     //! Bottom-of-body helper for ``[widget]`` macros: capture bbox/hover/active/focus, write (state_addr, ti) into ``g_widgets[path_key]``, and ``PopID``.
-    //! Snapshot reads via ``sprint_json_at(state_addr, *ti, …)``; HTTP dispatch resolves the per-kind handler from ``g_kind_dispatchers`` keyed by ``kind``. No per-widget lambdas required.
+    //! Snapshot reads via ``sprint_json_at(state_addr, *ti, …)``; HTTP dispatch resolves the handler from ``g_dispatchers`` keyed by ``(*ti).hash`` (the state struct's runtime type). No per-widget lambdas required.
     let path_key = widget_path_key(widget_ident)
     check_unique_render(path_key, kind)
     entry.kind = kind
@@ -1066,10 +1076,9 @@ def private widgets_mark_seen(bare_ident : string; path_key : string;
     // this is an idempotent overwrite of identical values; for [edit_widget]
     // external-pointer widgets (which never went through register_widget at
     // [init]) this is the only source of the meta — create it lazily on
-    // first render. The owning module is the one running the render path
-    // (compiling_module()-equivalent at runtime isn't available, so we tag
-    // edit_widget metas with kind alone; clear_module_widgets keeps working
-    // because pre-registered metas always carry module_name from register_widget).
+    // first render. Lazy entries get a sentinel module_name so the snapshot
+    // freshness gate can drop them after one frame absent without affecting
+    // pre-registered entries from top-level scripts (which carry module_name="").
     if (state_addr != null && ti != null) {
         if (key_exists(g_widgets, path_key)) {
             unsafe {
@@ -1080,6 +1089,7 @@ def private widgets_mark_seen(bare_ident : string; path_key : string;
         } else {
             unsafe {
                 g_widgets[path_key] <- WidgetMeta(
+                    module_name = LAZY_EDIT_WIDGET_MODULE,
                     kind = kind,
                     state_addr = state_addr,
                     ti = ti,
@@ -1109,16 +1119,17 @@ def public container_finalize(widget_ident : string;
     PopID()
 }
 
-// ===== L2/L3 dispatcher table — per-kind, addr-routed =====
+// ===== L2/L3 dispatcher table — per-state-struct-type, addr-routed =====
 //
-// One top-level function per widget kind, registered into ``g_kind_dispatchers``
-// at module init via the ``[widget_dispatch]`` annotation (imgui_boost.das).
-// At HTTP dispatch time, ``dispatch_or_err`` resolves the target path's meta
-// to ``(state_addr, kind)``, looks up the kind's dispatcher, and invokes it
-// with ``(state_addr, action, payload_json_string)``. No per-widget capture
-// frame, no ``from_JV<T>`` generic instantiation — the dispatcher casts
-// ``state_addr`` to its state-struct type and runs ``sscan_json`` on the
-// typed pending field for ``set`` actions.
+// One top-level function per state struct, registered into ``g_dispatchers``
+// at module init via the ``[widget_dispatch]`` annotation (imgui_boost.das),
+// keyed by the state's runtime ``TypeInfo.hash``. At HTTP dispatch time,
+// ``dispatch_or_err`` resolves the target path's meta to ``(state_addr, ti)``,
+// looks up ``g_dispatchers[(*ti).hash]``, and invokes the dispatcher with
+// ``(state_addr, action, payload_json_string)``. No per-widget capture frame,
+// no ``from_JV<T>`` generic instantiation — the dispatcher casts ``state_addr``
+// to its state-struct type and runs ``sscan_json`` on the typed pending field
+// for ``set`` actions.
 
 typedef KindDispatcher = function<(state_addr : void?; action : string; payload : string) : void>
 
@@ -1236,7 +1247,17 @@ def imgui_snapshot(input : JsonValue?) : JsonValue? {
         if (key_exists(g_registry, k)) {
             globals |> insert(k, widget_entry_jv(k, g_registry[k]))
         } else {
-            continue if (find(k, "[") >= 0 && meta.last_seen_frame < g_frame - 1)
+            // Freshness gate for entries clear_module_widgets can't reach on
+            // @live reload: indexed slots (path contains '[' — user-table key
+            // may have been erased) and lazy-created [edit_widget] entries
+            // (module_name == LAZY_EDIT_WIDGET_MODULE sentinel — never went
+            // through register_widget). Both self-expire after one frame
+            // absent so snapshot doesn't deref a state_addr left dangling by
+            // a heap reset. Pre-registered entries with module_name == ""
+            // (main-file top-level scripts) are safe — clear_module_widgets("")
+            // covers them on reload.
+            let needs_freshness = find(k, "[") >= 0 || meta.module_name == LAZY_EDIT_WIDGET_MODULE
+            continue if (needs_freshness && meta.last_seen_frame < g_frame - 1)
             globals |> insert(k, widget_meta_jv(k, meta))
         }
     }

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -635,15 +635,20 @@ def private resolve_meta_addr(meta : WidgetMeta) : void? {
 }
 
 def private state_payload_jv(state_addr : void?; ti : TypeInfo const?) : JsonValue? {
-    //! Build the per-widget state JSON payload via ``sprint_json_at`` + ``read_json``. Returns ``null`` when either ``state_addr`` or ``ti`` is null (erased indexed slot / unregistered kind).
+    //! Build the per-widget state JSON payload. Always routes through ``sprint_json_at`` (the C++ debug walker). For non-Structure types (bool / scalar / vector pointee — e.g. ``edit_*`` rails), wraps the raw output in a ``{"value": ...}`` envelope to match the historic shape; for structures the walker output is used as-is. ``from_JV<vecN>`` accepts both the array form ``[x,y,z]`` (which the walker emits) and the object form ``{x,y,z}``, so callers don't need a per-kind serializer to massage the wire shape. Returns ``null`` when ``state_addr`` or ``ti`` is missing.
     return null if (state_addr == null || ti == null)
     var err : string
-    return read_json(sprint_json_at(state_addr, *ti, false), err)
+    let raw = sprint_json_at(state_addr, *ti, false)
+    return read_json("\{\"value\":{raw}\}", err) if ((*ti).basicType != Type.tStructure)
+    return read_json(raw, err)
 }
 
 def private widget_entry_jv(ident : string; var entry : WidgetEntry) : JsonValue? {
-    if (key_exists(g_serializers, ident)) {
-        entry.payload = invoke(g_serializers[ident])
+    // Snapshot blob for a widget rendered this frame. Reads state via
+    // (state_addr, ti) from g_widgets[ident] through state_payload_jv.
+    let meta = unsafe(g_widgets?[ident])
+    if (meta != null) {
+        entry.payload = state_payload_jv(resolve_meta_addr(*meta), meta.ti)
     }
     return JV(entry)
 }
@@ -870,47 +875,23 @@ def public register_focusable(widget_ident : string) {
 }
 
 def public pending_value_container_finalize(widget_ident : string; kind : string;
-                                            var state : auto) {
-    //! Container-side install of the ``pending_value`` dispatcher (``imgui_set``); used by layout containers like ``split_h`` / ``dock_left``.
-    let path = container_path_key()
+                                            var state : auto(ST)) {
+    //! Container-side finalize for state structs with ``pending_value``/``has_pending``. Writes (addr(state), TypeInfo of ST) into ``g_widgets``; per-kind dispatcher routes ``set`` actions via ``[widget_dispatch]`` or a manual ``register_widget_kind`` entry.
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.pending_value = from_JV(payload?["value"],
-                                              type<typedecl(s.pending_value)>,
-                                              default<typedecl(s.pending_value)>)
-                    s.has_pending = true
-                }
-            }
-        }
-        container_finalize(widget_ident, kind, entry, ser, disp)
+        container_finalize(widget_ident, kind, entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ST>)))
     }
 }
 
-def public pending_value_finalize(widget_ident : string; kind : string; var state : auto) {
-    //! Generic serializer + ``imgui_set`` dispatcher install for any state struct with ``has_pending``/``pending_value``/``changed``; covers Drag/Slider/Input-numeric/Color/Combo/ListBox.
-    let path = widget_path_key(widget_ident)
+def public pending_value_finalize(widget_ident : string; kind : string; var state : auto(ST)) {
+    //! Generic finalize for any state struct with ``pending_value``/``has_pending`` (Drag/Slider/Input-numeric/Color/Combo/ListBox). Writes (addr(state), TypeInfo of ST) into ``g_widgets``; per-kind dispatcher is registered via ``[widget_dispatch]`` and routes the ``set`` action through ``sscan_json`` on the typed ``state.pending_value``.
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.pending_value = from_JV(payload?["value"],
-                                              type<typedecl(s.pending_value)>,
-                                              default<typedecl(s.pending_value)>)
-                    s.has_pending = true
-                }
-            }
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
+        widget_finalize(widget_ident, kind, entry,
+                        addr(state),
+                        reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ST>)))
     }
     register_focusable(widget_ident)
 }
@@ -1027,9 +1008,6 @@ def public with_state(path : string; t : type<auto(T)>;
     }
 }
 
-var private g_serializers : table<string; lambda<() : JsonValue?>>
-var private g_dispatcher_seen : table<string; bool>
-
 // Per-frame "this path rendered already" set. Each path_key may be
 // finalized exactly once between begin_frame()/end_of_frame() — collision
 // means a single-global widget got rendered twice in the same frame
@@ -1053,9 +1031,10 @@ def private check_unique_render(path_key : string; kind : string) {
 def public widget_finalize(widget_ident : string;
                            kind : string;
                            var entry : WidgetEntry;
-                           var serializer : lambda<() : JsonValue?>;
-                           var dispatcher : lambda<(action : string; payload : JsonValue?) : void>) {
-    //! Bottom-of-body helper for ``[widget]`` macros: capture bbox/hover/active/focus, install the per-widget serializer + dispatcher, and ``PopID``.
+                           state_addr : void?;
+                           ti : TypeInfo const?) {
+    //! Bottom-of-body helper for ``[widget]`` macros: capture bbox/hover/active/focus, write (state_addr, ti) into ``g_widgets[path_key]``, and ``PopID``.
+    //! Snapshot reads via ``sprint_json_at(state_addr, *ti, …)``; HTTP dispatch resolves the per-kind handler from ``g_kind_dispatchers`` keyed by ``kind``. No per-widget lambdas required.
     let path_key = widget_path_key(widget_ident)
     check_unique_render(path_key, kind)
     entry.kind = kind
@@ -1068,27 +1047,45 @@ def public widget_finalize(widget_ident : string;
     entry.focus = IsItemFocused()
     g_id_to_path[entry.hex_id] = path_key
     g_id_to_bbox[entry.hex_id] = entry.bbox
-    unsafe {
-        g_serializers[path_key] <- serializer
-    }
-    if (!key_exists(g_dispatcher_seen, path_key)) {
-        unsafe {
-            g_dispatchers[path_key] <- dispatcher
-        }
-        g_dispatcher_seen[path_key] = true
-    }
     g_registry[path_key] <- entry
-    widgets_mark_seen(widget_ident, path_key)
+    widgets_mark_seen(widget_ident, path_key, kind, state_addr, ti)
     PopID()
 }
 
-def private widgets_mark_seen(bare_ident : string; path_key : string) {
+def private widgets_mark_seen(bare_ident : string; path_key : string;
+                              kind : string; state_addr : void?; ti : TypeInfo const?) {
     // First render: migrate the bare-ident entry to its container-aware path_key. Subsequent renders just bump last_seen_frame.
     if (bare_ident != path_key && key_exists(g_widgets, bare_ident)) {
         var moved <- g_widgets[bare_ident]
         g_widgets |> erase(bare_ident)
         unsafe {
             g_widgets[path_key] <- moved
+        }
+    }
+    // Refresh (state_addr, ti) every frame. For pre-registered [widget] paths
+    // this is an idempotent overwrite of identical values; for [edit_widget]
+    // external-pointer widgets (which never went through register_widget at
+    // [init]) this is the only source of the meta — create it lazily on
+    // first render. The owning module is the one running the render path
+    // (compiling_module()-equivalent at runtime isn't available, so we tag
+    // edit_widget metas with kind alone; clear_module_widgets keeps working
+    // because pre-registered metas always carry module_name from register_widget).
+    if (state_addr != null && ti != null) {
+        if (key_exists(g_widgets, path_key)) {
+            unsafe {
+                var meta & = g_widgets[path_key]
+                meta.state_addr = state_addr
+                meta.ti = ti
+            }
+        } else {
+            unsafe {
+                g_widgets[path_key] <- WidgetMeta(
+                    kind = kind,
+                    state_addr = state_addr,
+                    ti = ti,
+                    last_seen_frame = -1
+                )
+            }
         }
     }
     if (key_exists(g_widgets, path_key)) {
@@ -1099,36 +1096,45 @@ def private widgets_mark_seen(bare_ident : string; path_key : string) {
 def public container_finalize(widget_ident : string;
                               kind : string;
                               var entry : WidgetEntry;
-                              var serializer : lambda<() : JsonValue?>;
-                              var dispatcher : lambda<(action : string; payload : JsonValue?) : void>) {
-    //! Container counterpart of ``widget_finalize`` (sibling above); install the per-container serializer + dispatcher at the cached container path key.
+                              state_addr : void?;
+                              ti : TypeInfo const?) {
+    //! Container counterpart of ``widget_finalize`` (sibling above); writes ``(state_addr, ti)`` into ``g_widgets`` at the cached container path key.
     let path_key = container_path_key()
     check_unique_render(path_key, kind)
     entry.kind = kind
     entry.hex_id = GetID(widget_ident)
     g_id_to_path[entry.hex_id] = path_key
-    unsafe {
-        g_serializers[path_key] <- serializer
-    }
-    if (!key_exists(g_dispatcher_seen, path_key)) {
-        unsafe {
-            g_dispatchers[path_key] <- dispatcher
-        }
-        g_dispatcher_seen[path_key] = true
-    }
     g_registry[path_key] <- entry
-    widgets_mark_seen(widget_ident, path_key)
+    widgets_mark_seen(widget_ident, path_key, kind, state_addr, ti)
     PopID()
 }
 
-// ===== L2/L3 dispatcher table =====
+// ===== L2/L3 dispatcher table — per-kind, addr-routed =====
 //
-// One closure per registered widget. The closure switches on `action`
-// ("click", "set", "open", "close") and applies the payload to the
-// captured state global. Lazy first-frame registration via widget_finalize
-// above keeps the boost's macro layer free of per-kind init emission.
+// One top-level function per widget kind, registered into ``g_kind_dispatchers``
+// at module init via the ``[widget_dispatch]`` annotation (imgui_boost.das).
+// At HTTP dispatch time, ``dispatch_or_err`` resolves the target path's meta
+// to ``(state_addr, kind)``, looks up the kind's dispatcher, and invokes it
+// with ``(state_addr, action, payload_json_string)``. No per-widget capture
+// frame, no ``from_JV<T>`` generic instantiation — the dispatcher casts
+// ``state_addr`` to its state-struct type and runs ``sscan_json`` on the
+// typed pending field for ``set`` actions.
 
-var private g_dispatchers : table<string; lambda<(action : string; payload : JsonValue?) : void>>
+typedef KindDispatcher = function<(state_addr : void?; action : string; payload : string) : void>
+
+//! Dispatch is keyed by the state's runtime ``TypeInfo.hash`` — one dispatcher
+//! per state-struct type covers every widget kind that uses that struct (e.g.
+//! the single ClickState dispatcher fires for ``button``/``small_button``/
+//! ``arrow_button``/...). Non-Structure ti (scalar pointee from ``[edit_widget]``)
+//! that don't have a registered dispatcher fall back to the generic
+//! ``sscan_json_at(state_addr, *ti)`` write-through in ``dispatch_or_err``.
+var private g_dispatchers : table<uint64; KindDispatcher>
+
+def public register_widget_dispatch_for_type(ti : TypeInfo const?; dispatcher : KindDispatcher) {
+    //! Register a dispatcher for every widget whose state has this ``TypeInfo``. Emitted by the ``[widget_dispatch]`` annotation. The user-facing function name is irrelevant — what matters is the first parameter's struct type.
+    return if (ti == null)
+    g_dispatchers[(*ti).hash] = dispatcher
+}
 
 // ===== Phase 2 — Result wire format + per-command await =====
 //
@@ -1256,7 +1262,7 @@ def private classify_target(target : string) : tuple<int; string> {
         if (key_exists(g_id_to_path, hid)) return (2, g_id_to_path[hid])
         return (1, target)
     }
-    if (key_exists(g_dispatchers, target)) return (2, target)
+    if (key_exists(g_widgets, target)) return (2, target)
     return (0, target)
 }
 
@@ -1279,7 +1285,35 @@ def private dispatch_or_err(action : string; input : JsonValue?) : Result<string
             g_pending_focus |> insert(resolved)
             return ok(resolved, type<string>)
         }
-        invoke(g_dispatchers[resolved], action, input)
+        let meta = unsafe(g_widgets?[resolved])
+        if (meta == null) return err("no widget meta for {resolved}", type<string>)
+        let state_addr = resolve_meta_addr(*meta)
+        if (state_addr == null) return err("state slot gone for {resolved}", type<string>)
+        return err("widget meta missing TypeInfo for {resolved} (kind {meta.kind})", type<string>) if (meta.ti == null)
+        // payload is the JSON string of the action's value field — most kinds
+        // sscan into a typed pending field; multi-field actions (set_window_pos)
+        // sscan the whole value object. Falls back to the whole input when
+        // there's no "value" field (e.g. open/close on a container — no payload).
+        let value = input?["value"]
+        var payload : string
+        if (value != null) {
+            payload = write_json(value)
+        }
+        let ti_hash = (*meta.ti).hash
+        let dispatcher = unsafe(g_dispatchers?[ti_hash])
+        if (dispatcher != null) {
+            invoke(*dispatcher, state_addr, action, payload)
+            return ok(resolved, type<string>)
+        }
+        // No registered dispatcher for this state struct. For non-Structure ti
+        // (scalar pointee from [edit_widget]), fall back to a generic scalar
+        // write-through using the runtime ti. Structures with no dispatcher
+        // are display-only — silently succeed.
+        if ((*meta.ti).basicType != Type.tStructure && action == "set") {
+            unsafe {
+                sscan_json_at(payload, state_addr, *meta.ti)
+            }
+        }
         return ok(resolved, type<string>)
     }
     if (action != "click") return err("L1 hex_id fallback only supports 'click', got '{action}'", type<string>)

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1313,8 +1313,9 @@ def private dispatch_or_err(action : string; input : JsonValue?) : Result<string
         return err("widget meta missing TypeInfo for {resolved} (kind {meta.kind})", type<string>) if (meta.ti == null)
         // payload is the JSON string of the action's value field — most kinds
         // sscan into a typed pending field; multi-field actions (set_window_pos)
-        // sscan the whole value object. Falls back to the whole input when
-        // there's no "value" field (e.g. open/close on a container — no payload).
+        // sscan the whole value object. When there's no "value" field (e.g.
+        // open/close on a container) payload stays "" — those dispatchers don't
+        // read it.
         let value = input?["value"]
         var payload : string
         if (value != null) {

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -41,41 +41,27 @@ require math
 // `pending_value : int` shape) and inline their own dispatcher because the
 // shared `pending_value_finalize` helper is private to imgui_widgets_builtin.
 
-def private open_close_finalize(widget_ident : string; kind : string; var state : auto;
+def private open_close_finalize(widget_ident : string; kind : string; var state : auto(ST);
                                 bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
-    let path = container_path_key()
+    //! Container finalize for state with ``pending_open`` / ``pending_close``. Routes the open/close [widget_dispatch] handlers (registered per kind below) through ``g_kind_dispatchers``.
     var entry : WidgetEntry
     entry.bbox = bbox
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "open") {
-                    s.pending_open = true
-                } elif (action == "close") {
-                    s.pending_close = true
-                }
-            }
-        }
-        container_finalize(widget_ident, kind, entry, ser, disp)
+        container_finalize(widget_ident, kind, entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ST>)))
     }
 }
 
-def public stateless_finalize(widget_ident : string; kind : string; var state : auto;
+def public stateless_finalize(widget_ident : string; kind : string; var state : auto(ST);
                               bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
-    let path = container_path_key()
+    //! Container finalize for stateless containers (no dispatcher actions). Snapshot rail still reflects state for telemetry; dispatch is a registered no-op per kind below.
     var entry : WidgetEntry
     entry.bbox = bbox
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            // No actions; serializer is the only telemetry surface for stateless containers.
-        }
-        container_finalize(widget_ident, kind, entry, ser, disp)
+        container_finalize(widget_ident, kind, entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ST>)))
     }
 }
 
@@ -674,21 +660,11 @@ def combo_select(var state : ComboState; text : string; preview_value : string;
         invoke(blk)
         EndCombo()
     }
-    let path = container_path_key()
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.pending_value = payload?["value"] ?? 0
-                    s.has_pending = true
-                }
-            }
-        }
-        container_finalize(widget_ident, "combo_select", entry, ser, disp)
+        container_finalize(widget_ident, "combo_select", entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ComboState>)))
     }
 }
 
@@ -706,21 +682,11 @@ def list_box(var state : ListBoxState; text : string; size : float2; blk : block
         invoke(blk)
         EndListBox()
     }
-    let path = container_path_key()
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.pending_value = payload?["value"] ?? 0
-                    s.has_pending = true
-                }
-            }
-        }
-        container_finalize(widget_ident, "list_box", entry, ser, disp)
+        container_finalize(widget_ident, "list_box", entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ListBoxState>)))
     }
 }
 
@@ -758,4 +724,50 @@ def drag_drop_target(var state : DragDropTargetState; blk : block) {
         EndDragDropTarget()
     }
     stateless_finalize(widget_ident, "drag_drop_target", state)
+}
+
+// ===== Per-state-struct dispatchers (containers) =====
+//
+// One [widget_dispatch] body per state struct. Dispatch keyed by ti.hash
+// fires for every container kind whose state is that struct (popup +
+// popup_modal share PopupState etc.). TreeNodeState/ComboState/ListBoxState
+// dispatchers live in imgui_widgets_builtin.das; their dispatchers also
+// cover the container forms (tree_node, combo_select, list_box) without
+// extra registration. Stateless containers (group/menu/popup_context*/
+// tab_bar/tooltip/drag_drop_*) get no dispatcher and silently no-op.
+
+[widget_dispatch]
+def _window_dispatch(var state : WindowState; action : string; payload : string) {
+    if (action == "open") {
+        state.pending_open = true
+    } elif (action == "close") {
+        state.pending_close = true
+    }
+}
+
+[widget_dispatch]
+def _popup_dispatch(var state : PopupState; action : string; payload : string) {
+    if (action == "open") {
+        state.pending_open = true
+    } elif (action == "close") {
+        state.pending_close = true
+    }
+}
+
+[widget_dispatch]
+def _tab_item_dispatch(var state : TabItemState; action : string; payload : string) {
+    if (action == "open") {
+        state.pending_open = true
+    } elif (action == "close") {
+        state.pending_close = true
+    }
+}
+
+[widget_dispatch]
+def _collapsing_header_dispatch(var state : CollapsingHeaderState; action : string; payload : string) {
+    if (action == "open") {
+        state.pending_open = true
+    } elif (action == "close") {
+        state.pending_close = true
+    }
 }

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -34,9 +34,10 @@ require math
 //
 // `stateless_finalize` — for containers whose dispatch surface is empty
 // (group, menu_bar, menu, child, tab_bar, tooltip, item_tooltip). No
-// ``[widget_dispatch]`` is registered for those state structs; ``dispatch_or_err``
-// reports "no dispatcher for ti.hash …" if a stray action ever targets them.
-// The serializer still reflects state for snapshot.
+// ``[widget_dispatch]`` is registered for those state structs; on a stray
+// action targeting one, ``dispatch_or_err`` silently returns ok (the
+// Structure-with-no-dispatcher path is treated as display-only). The
+// serializer still reflects state for snapshot.
 //
 // `combo_select` / `list_box` reuse ComboState / ListBoxState (a
 // `pending_value : int` shape) and share the per-state-struct dispatcher
@@ -57,7 +58,7 @@ def private open_close_finalize(widget_ident : string; kind : string; var state 
 
 def public stateless_finalize(widget_ident : string; kind : string; var state : auto(ST);
                               bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
-    //! Container finalize for stateless containers (no dispatcher actions). Snapshot rail still reflects state for telemetry; no ``[widget_dispatch]`` is registered for ``ST``, so ``g_dispatchers[(*ti).hash]`` is absent and dispatch_or_err reports "no dispatcher for ti.hash …" if a stray action ever targets one.
+    //! Container finalize for stateless containers (no dispatcher actions). Snapshot rail still reflects state for telemetry; no ``[widget_dispatch]`` is registered for ``ST``, so ``g_dispatchers[(*ti).hash]`` is absent and ``dispatch_or_err`` silently returns ok if a stray action ever targets one (Structure-with-no-dispatcher = display-only).
     var entry : WidgetEntry
     entry.bbox = bbox
     unsafe {

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -33,17 +33,19 @@ require math
 // renderer consumes them at the top of the next frame.
 //
 // `stateless_finalize` — for containers whose dispatch surface is empty
-// (group, menu_bar, menu, child, tab_bar, tooltip, item_tooltip). The
-// dispatcher lambda is a no-op; the serializer still reflects state for
-// snapshot.
+// (group, menu_bar, menu, child, tab_bar, tooltip, item_tooltip). No
+// ``[widget_dispatch]`` is registered for those state structs; ``dispatch_or_err``
+// reports "no dispatcher for ti.hash …" if a stray action ever targets them.
+// The serializer still reflects state for snapshot.
 //
 // `combo_select` / `list_box` reuse ComboState / ListBoxState (a
-// `pending_value : int` shape) and inline their own dispatcher because the
-// shared `pending_value_finalize` helper is private to imgui_widgets_builtin.
+// `pending_value : int` shape) and share the per-state-struct dispatcher
+// from imgui_widgets_builtin (one ``[widget_dispatch]`` per state type
+// covers every kind that uses that state).
 
 def private open_close_finalize(widget_ident : string; kind : string; var state : auto(ST);
                                 bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
-    //! Container finalize for state with ``pending_open`` / ``pending_close``. Routes the open/close [widget_dispatch] handlers (registered per kind below) through ``g_kind_dispatchers``.
+    //! Container finalize for state with ``pending_open`` / ``pending_close``. Dispatch routes through ``g_dispatchers`` keyed by ``ST``'s ``TypeInfo.hash`` to the ``[widget_dispatch] def _(var state : ST; …)`` body below.
     var entry : WidgetEntry
     entry.bbox = bbox
     unsafe {
@@ -55,7 +57,7 @@ def private open_close_finalize(widget_ident : string; kind : string; var state 
 
 def public stateless_finalize(widget_ident : string; kind : string; var state : auto(ST);
                               bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
-    //! Container finalize for stateless containers (no dispatcher actions). Snapshot rail still reflects state for telemetry; dispatch is a registered no-op per kind below.
+    //! Container finalize for stateless containers (no dispatcher actions). Snapshot rail still reflects state for telemetry; no ``[widget_dispatch]`` is registered for ``ST``, so ``g_dispatchers[(*ti).hash]`` is absent and dispatch_or_err reports "no dispatcher for ti.hash …" if a stray action ever targets one.
     var entry : WidgetEntry
     entry.bbox = bbox
     unsafe {

--- a/widgets/imgui_docking_builtin.das
+++ b/widgets/imgui_docking_builtin.das
@@ -68,56 +68,64 @@ struct DockWindowState {
 
 def private dockspace_finalize(widget_ident : string; kind : string;
                                var state : DockSpaceState) {
-    let path = container_path_key()
+    //! Dockspace finalize. State path; the per-kind [widget_dispatch] handles "reset".
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "reset") {
-                    s.pending_reset = true
-                }
-            }
-        }
-        container_finalize(widget_ident, kind, entry, ser, disp)
+        container_finalize(widget_ident, kind, entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<DockSpaceState>)))
     }
 }
 
 def private dock_window_finalize(widget_ident : string; var state : DockWindowState) {
-    let path = container_path_key()
+    //! dock_window finalize. State path; the per-kind [widget_dispatch] handles open/close/dock/undock/set_window_pos.
     var entry : WidgetEntry
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
+        container_finalize(widget_ident, "dock_window", entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<DockWindowState>)))
+    }
+}
+
+// Per-state-struct dispatchers for the docking family.
+
+[widget_dispatch]
+def _dockspace_dispatch(var state : DockSpaceState; action : string; payload : string) {
+    if (action == "reset") {
+        state.pending_reset = true
+    }
+}
+
+[widget_dispatch]
+def _dock_window_dispatch(var state : DockWindowState; action : string; payload : string) {
+    if (action == "open") {
+        state.pending_open = true
+    } elif (action == "close") {
+        state.pending_close = true
+    } elif (action == "dock") {
+        unsafe {
+            sscan_json_at(payload, addr(state.pending_dock_to),
+                          *reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<uint>)))
         }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "open") {
-                    s.pending_open = true
-                } elif (action == "close") {
-                    s.pending_close = true
-                } elif (action == "dock") {
-                    s.pending_dock_to = from_JV(payload?["value"], type<uint>, 0u)
-                } elif (action == "undock") {
-                    s.pending_undock = true
-                } elif (action == "set_window_pos") {
-                    //! Payload shape: `{x, y[, w, h]}` — pos always set, size optional.
-                    let v = payload?["value"]
-                    s.pending_pos = float2(v?["x"] ?? 0.0f, v?["y"] ?? 0.0f)
-                    s.pending_pos_set = true
-                    let has_w = v?["w"] != null
-                    let has_h = v?["h"] != null
-                    if (has_w || has_h) {
-                        s.pending_size = float2(v?["w"] ?? s.size.x,
-                                                v?["h"] ?? s.size.y)
-                        s.pending_size_set = true
-                    }
-                }
+    } elif (action == "undock") {
+        state.pending_undock = true
+    } elif (action == "set_window_pos") {
+        // Payload: ``{x, y[, w, h]}`` — pos always set, size optional. The one
+        // place we still touch JsonValue at dispatch time; alternative would
+        // be a dedicated payload struct just for this action.
+        var err : string
+        let v = read_json(payload, err)
+        if (v != null) {
+            state.pending_pos = float2(v?["x"] ?? 0.0f, v?["y"] ?? 0.0f)
+            state.pending_pos_set = true
+            let has_w = v?["w"] != null
+            let has_h = v?["h"] != null
+            if (has_w || has_h) {
+                state.pending_size = float2(v?["w"] ?? state.size.x,
+                                            v?["h"] ?? state.size.y)
+                state.pending_size_set = true
             }
         }
-        container_finalize(widget_ident, "dock_window", entry, ser, disp)
     }
 }
 

--- a/widgets/imgui_layout_builtin.das
+++ b/widgets/imgui_layout_builtin.das
@@ -200,6 +200,10 @@ def dock_left(var state : SliderStateFloat; blk : block) {
     pending_value_container_finalize(widget_ident, "dock_left", state)
 }
 
+// (split_h / split_v / dock_left all use SliderStateFloat — the dispatcher
+//  for that state struct lives in imgui_widgets_builtin and covers them
+//  automatically since dispatch is keyed by state ti.hash.)
+
 // ===== columns =====
 
 def public columns_open(n : int; id : string = ""; border : bool = true) {

--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -413,13 +413,13 @@ def private mod_name_to_key(name : string) : int {
 }
 
 def private needs_shift_ascii(c : int) : bool {
-    if (c >= int('A') && c <= int('Z')) return true   // nolint:PERF014
-    return (c == int('~') || c == int('!') || c == int('@') || c == int('#')
-         || c == int('$') || c == int('%') || c == int('^') || c == int('&')
-         || c == int('*') || c == int('(') || c == int(')') || c == int('_')
-         || c == int('+') || c == int('{') || c == int('}') || c == int('|')
-         || c == int(':') || c == int('"') || c == int('<') || c == int('>')
-         || c == int('?'))
+    if (c >= 'A' && c <= 'Z') return true   // nolint:PERF014
+    return (c == '~' || c == '!' || c == '@' || c == '#'
+         || c == '$' || c == '%' || c == '^' || c == '&'
+         || c == '*' || c == '(' || c == ')' || c == '_'
+         || c == '+' || c == '{' || c == '}' || c == '|'
+         || c == ':' || c == '"' || c == '<' || c == '>'
+         || c == '?')
 }
 
 def private base_key_ascii(c : int) : int {
@@ -430,35 +430,35 @@ def private base_key_ascii(c : int) : int {
     // float literal), so we anchor the digit base on `ImGuiKey.A - 10`.
     let key_a = int(ImGuiKey.A)
     let key_0 = key_a - 10
-    if (c >= int('A') && c <= int('Z')) return key_a + (c - int('A'))   // nolint:PERF014
-    if (c >= int('a') && c <= int('z')) return key_a + (c - int('a'))   // nolint:PERF014
-    if (c >= int('0') && c <= int('9')) return key_0 + (c - int('0'))   // nolint:PERF014
+    if (c >= 'A' && c <= 'Z') return key_a + (c - 'A')   // nolint:PERF014
+    if (c >= 'a' && c <= 'z') return key_a + (c - 'a')   // nolint:PERF014
+    if (c >= '0' && c <= '9') return key_0 + (c - '0')   // nolint:PERF014
     // shifted digit row: ! @ # $ % ^ & * ( ) → keys 1 2 3 4 5 6 7 8 9 0
-    if (c == int('!')) return key_0 + 1
-    if (c == int('@')) return key_0 + 2
-    if (c == int('#')) return key_0 + 3
-    if (c == int('$')) return key_0 + 4
-    if (c == int('%')) return key_0 + 5
-    if (c == int('^')) return key_0 + 6
-    if (c == int('&')) return key_0 + 7
-    if (c == int('*')) return key_0 + 8
-    if (c == int('(')) return key_0 + 9
-    if (c == int(')')) return key_0
+    if (c == '!') return key_0 + 1
+    if (c == '@') return key_0 + 2
+    if (c == '#') return key_0 + 3
+    if (c == '$') return key_0 + 4
+    if (c == '%') return key_0 + 5
+    if (c == '^') return key_0 + 6
+    if (c == '&') return key_0 + 7
+    if (c == '*') return key_0 + 8
+    if (c == '(') return key_0 + 9
+    if (c == ')') return key_0
     // punctuation
-    if (c == int(' ')) return int(ImGuiKey.Space)
-    if (c == int('\n')) return int(ImGuiKey.Enter)
-    if (c == int('\t')) return int(ImGuiKey.Tab)
-    if (c == int(',') || c == int('<')) return int(ImGuiKey.Comma)
-    if (c == int('.') || c == int('>')) return int(ImGuiKey.Period)
-    if (c == int('/') || c == int('?')) return int(ImGuiKey.Slash)
-    if (c == int(';') || c == int(':')) return int(ImGuiKey.Semicolon)
-    if (c == int('\'') || c == int('"')) return int(ImGuiKey.Apostrophe)
-    if (c == int('-') || c == int('_')) return int(ImGuiKey.Minus)
-    if (c == int('=') || c == int('+')) return int(ImGuiKey.Equal)
-    if (c == int('[') || c == int('{')) return int(ImGuiKey.LeftBracket)
-    if (c == int(']') || c == int('}')) return int(ImGuiKey.RightBracket)
-    if (c == int('\\') || c == int('|')) return int(ImGuiKey.Backslash)
-    if (c == int('`') || c == int('~')) return int(ImGuiKey.GraveAccent)
+    if (c == ' ') return int(ImGuiKey.Space)
+    if (c == '\n') return int(ImGuiKey.Enter)
+    if (c == '\t') return int(ImGuiKey.Tab)
+    if (c == ',' || c == '<') return int(ImGuiKey.Comma)
+    if (c == '.' || c == '>') return int(ImGuiKey.Period)
+    if (c == '/' || c == '?') return int(ImGuiKey.Slash)
+    if (c == ';' || c == ':') return int(ImGuiKey.Semicolon)
+    if (c == '\'' || c == '"') return int(ImGuiKey.Apostrophe)
+    if (c == '-' || c == '_') return int(ImGuiKey.Minus)
+    if (c == '=' || c == '+') return int(ImGuiKey.Equal)
+    if (c == '[' || c == '{') return int(ImGuiKey.LeftBracket)
+    if (c == ']' || c == '}') return int(ImGuiKey.RightBracket)
+    if (c == '\\' || c == '|') return int(ImGuiKey.Backslash)
+    if (c == '`' || c == '~') return int(ImGuiKey.GraveAccent)
     return 0
 }
 
@@ -554,7 +554,7 @@ def imgui_key_chord(input : JsonValue?) : JsonValue? {
     return JV((error = "missing key")) if (empty(args.key))
     var target_key = 0
     if (length(args.key) == 1) {
-        target_key = base_key_ascii(int(first_character(args.key)))
+        target_key = base_key_ascii(first_character(args.key))
     }
     return JV((error = "unsupported chord key", key = args.key)) if (target_key == 0)
     // Validate mod names up front.

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -355,10 +355,7 @@ def public expect_render(app : ImguiApp;
     let g = snap?["globals"]
     if (g != null && g is _object) {
         let obj & = unsafe(g as _object)
-        var key_list : array<string>
-        for (k in keys(obj)) {
-            key_list |> push(k)
-        }
+        let key_list <- [for (k in keys(obj)); k]
         keys_buf = "[" + join(key_list, ", ") + "]"
     }
     panic("expect_render({widget_ident}) timeout after {timeout_sec}s — widget never reported rendered:true.\nRegistered widgets: {keys_buf}")

--- a/widgets/imgui_style_builtin.das
+++ b/widgets/imgui_style_builtin.das
@@ -107,10 +107,8 @@ class private WithStyleCallMacro : AstCallMacro {
             macro_verify(length(mt.values) == 2, prog, a.at,
                          "with_style: each tuple must have exactly two elements (enum key, value)")
             return null if (length(mt.values) != 2)
-            let key = clone_expression(mt.values[0])
-            let val = clone_expression(mt.values[1])
             bodyStmts |> push <| qmacro_expr(${
-                push_style_one($e(key), $e(val))
+                push_style_one($e(mt.values[0]), $e(mt.values[1]))
             })
         }
         bodyStmts |> push <| qmacro_expr(${

--- a/widgets/imgui_table_builtin.das
+++ b/widgets/imgui_table_builtin.das
@@ -187,7 +187,7 @@ def public sort_specs(blk : block<(specs : array<TableSortSpec>) : void>) : bool
             let s = GetSortSpec(p, i)
             arr |> push(TableSortSpec(
                 column_index = int(s.ColumnIndex),
-                column_user_id = uint(s.ColumnUserID),
+                column_user_id = s.ColumnUserID,
                 sort_order = int(s.SortOrder),
                 sort_direction = GetColumnSortDirection(s)))
         }

--- a/widgets/imgui_theme_daslang.das
+++ b/widgets/imgui_theme_daslang.das
@@ -145,7 +145,7 @@ def public apply_daslang_theme(var style : ImGuiStyle) {
 def public apply_daslang_theme() {
     //! Convenience overload — applies the theme to ``ImGui::GetStyle()``.
     //! Call once from your script's ``init()`` after ``live_imgui_init``.
-    apply_daslang_theme(unsafe(GetStyle()))
+    apply_daslang_theme(GetStyle())
 }
 
 // ===== Font =====

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -31,118 +31,66 @@ require math
 
 // ===== Common finalize helpers =====
 
-def private click_finalize(widget_ident : string; kind : string; var state : ClickState) {
-    //! Lambda + dispatcher install for click-style widgets (Button family).
-    //! Dispatcher action: "click" → state.pending_click = true (consumed next frame).
-    let path = widget_path_key(widget_ident)
-    var entry : WidgetEntry
+// Generic state-addr+ti plumbing for [widget]/[container] state structs.
+// Pull (state_addr, ti) out of a state-by-ref param exactly once, then route
+// to widget_finalize / container_finalize. The kind-specific action handlers
+// live in [widget_dispatch] defs near each state struct's call sites.
+
+def private finalize_state(widget_ident : string; kind : string;
+                           var state : auto(ST); var entry : WidgetEntry) {
     unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "click") {
-                    s.pending_click = true
-                }
-            }
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
+        widget_finalize(widget_ident, kind, entry,
+                        addr(state),
+                        reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ST>)))
     }
+}
+
+def private finalize_container_state(widget_ident : string; kind : string;
+                                     var state : auto(ST); var entry : WidgetEntry) {
+    unsafe {
+        container_finalize(widget_ident, kind, entry,
+                           addr(state),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<ST>)))
+    }
+}
+
+def private click_finalize(widget_ident : string; kind : string; var state : ClickState) {
+    //! Click-style finalize (Button family). State path; dispatch handled per-kind via [widget_dispatch].
+    var entry : WidgetEntry
+    finalize_state(widget_ident, kind, state, entry)
     register_focusable(widget_ident)
 }
 
 def private toggle_finalize(widget_ident : string; kind : string; var state : ToggleState) {
-    //! Lambda + dispatcher install for bool-toggle widgets (Checkbox, RadioButton-bool,
-    //! Selectable, MenuItem). Dispatcher action: "set" with bool payload.
-    let path = widget_path_key(widget_ident)
+    //! Bool-toggle finalize (Checkbox, RadioButton-bool, Selectable, MenuItem). State path; dispatch handled per-kind via [widget_dispatch].
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.pending_value = payload?["value"] ?? false
-                    s.pending_toggle = true
-                }
-            }
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
     register_focusable(widget_ident)
 }
 
 def private radio_int_finalize(widget_ident : string; kind : string; var state : RadioIntState) {
-    //! Lambda + dispatcher install for the int-form RadioButton.
-    //! Dispatcher action: "set" with int payload; renderer applies before the imgui call.
-    let path = widget_path_key(widget_ident)
+    //! Int-form RadioButton finalize. State path; dispatch handled per-kind via [widget_dispatch].
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.pending_value = payload?["value"] ?? 0
-                    s.pending_set = true
-                }
-            }
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
     register_focusable(widget_ident)
 }
 
 def private text_value_finalize(widget_ident : string; kind : string; var state : InputTextState) {
-    // String-typed cousin of pending_value_finalize. The JsonValue payload's
-    // underlying bytes drop when the dispatcher returns; we `:=` clone into
-    // the widget context heap so `state.pending_value` is still valid when
-    // the next widget body frame consumes it.
-    let path = widget_path_key(widget_ident)
+    //! String-pending finalize. State path; dispatch handled via [widget_dispatch] (clones `value` string into the context heap).
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.pending_value := payload?["value"] ?? ""
-                    s.has_pending = true
-                }
-            }
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
     register_focusable(widget_ident)
 }
 
 def edit_finalize(widget_ident : string; kind : string; var ptr : auto(TT)? implicit) {
-    // External-pointer finalize: serializer captures the raw pointer and
-    // dereferences at snapshot time (snapshot reads `*ptr` live), dispatcher
-    // writes through `*ptr` on `set`. Caller owns the pointee — pass
-    // `safe_addr(local)` or `unsafe(addr(struct.field))` and accept lifetime
-    // responsibility. Generic on `TT` so the same body covers every scalar
-    // and vector type (`bool`/`int`/`float`/`float2`/etc.) via from_JV.
-    //
-    // Module-public (was `def private`) so `[edit_container]` rails living
-    // in imgui_containers_builtin.das (`edit_tab_item`, future `edit_window`
-    // etc.) can call edit_finalize without re-implementing the body.
+    //! External-pointer finalize: writes (ptr, ti=TypeInfo of TT) into g_widgets so
+    //! snapshot + dispatch route through `*ptr` via sprint_json_at / sscan_json_at.
+    //! Caller owns the pointee lifetime; pass `safe_addr(local)` or `unsafe(addr(struct.field))`.
     var entry : WidgetEntry
     unsafe {
-        var p = ptr
-        let ser <- @ capture(= p) () : JsonValue ? {
-            return JV((value = *p))
-        }
-        let disp <- @ capture(= p) (action : string; payload : JsonValue ?) {
-            if (action == "set") {
-                *p = from_JV(payload?["value"], type<TT>, default<TT>)
-            }
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
+        widget_finalize(widget_ident, kind, entry,
+                        reinterpret<void?>(ptr),
+                        reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<TT>)))
     }
     register_focusable(widget_ident)
 }
@@ -150,40 +98,296 @@ def edit_finalize(widget_ident : string; kind : string; var ptr : auto(TT)? impl
 def edit_container_open_close_finalize(widget_ident : string; kind : string;
                                        var ptr : bool? implicit;
                                        bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
-    // [edit_container] finalize for bool-typed open/close pointers. The
-    // container macro pushed `widget_ident` onto the container path BEFORE
-    // the body, so use container_path_key() (NOT widget_path_key, which
-    // would re-append and double the segment).
-    //
-    // Dispatcher handles three actions:
-    //   "set"   — generic JV write-through (mirrors edit_finalize)
-    //   "open"  — *ptr = true   (imgui_open semantic for X-button-style flags)
-    //   "close" — *ptr = false  (imgui_close)
-    // The bool specialization keeps the rail honest: a non-bool external
-    // pointer (e.g. edit_progress_bar with float?) has no meaning for
-    // open/close, so it shouldn't get the same helper.
-    //
-    // Optional `bbox` is captured by the caller (current_item_bbox after
-    // BeginTabItem / similar) and registered as the header click target.
+    //! [edit_container] finalize for bool-typed open/close pointers. Pointer + ti go into g_widgets so the per-kind [widget_dispatch] handles "set"/"open"/"close" by writing through *ptr.
     var entry : WidgetEntry
     entry.bbox = bbox
     unsafe {
-        var p = ptr
-        let ser <- @ capture(= p) () : JsonValue ? {
-            return JV((value = *p))
-        }
-        let disp <- @ capture(= p) (action : string; payload : JsonValue ?) {
-            if (action == "set") {
-                *p = from_JV(payload?["value"], type<bool>, false)
-            } elif (action == "open") {
-                *p = true
-            } elif (action == "close") {
-                *p = false
-            }
-        }
-        container_finalize(widget_ident, kind, entry, ser, disp)
+        container_finalize(widget_ident, kind, entry,
+                           reinterpret<void?>(ptr),
+                           reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<bool>)))
     }
 }
+
+// ===== Per-state-struct dispatchers =====
+//
+// One ``[widget_dispatch]`` body per state struct — the macro keys by the
+// first parameter's struct type, so each body fires for every widget kind
+// whose state is that struct (e.g. ClickState handles ``button``/
+// ``small_button``/``arrow_button``/...). No per-kind registration table:
+// ``dispatch_or_err`` looks up by ``meta.ti.hash``.
+//
+// Non-Structure ``ti`` (scalar pointee from ``[edit_widget]``) falls through
+// to the generic ``sscan_json_at(state_addr, *ti)`` in ``dispatch_or_err`` —
+// no per-edit-pointee dispatcher needed.
+//
+// Display-only state structs (NarrativeState, EmptyMarkerState,
+// ProgressBarState, ImageState, PlotState, LabelTextState, TextFilterState,
+// ChildState, GroupState, MenuBarState, MainMenuBarState, MenuState,
+// TooltipState, TabBarState, DragDropSourceState, DragDropTargetState,
+// PopupContextItemState, PopupContextWindowState, PopupWindowState) get no
+// dispatcher — ``dispatch_or_err`` silently succeeds when no entry exists
+// for a Structure ti.
+
+[widget_dispatch]
+def _click_dispatch(var state : ClickState; action : string; payload : string) {
+    if (action == "click") {
+        state.pending_click = true
+    }
+}
+
+[widget_dispatch]
+def _toggle_dispatch(var state : ToggleState; action : string; payload : string) {
+    if (action == "set") {
+        unsafe {
+            sscan_json_at(payload, addr(state.pending_value),
+                          *reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<bool>)))
+        }
+        state.pending_toggle = true
+    }
+}
+
+[widget_dispatch]
+def _radio_int_dispatch(var state : RadioIntState; action : string; payload : string) {
+    if (action == "set") {
+        unsafe {
+            sscan_json_at(payload, addr(state.pending_value),
+                          *reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<int>)))
+        }
+        state.pending_set = true
+    }
+}
+
+[widget_dispatch]
+def _input_text_dispatch(var state : InputTextState; action : string; payload : string) {
+    if (action == "set") {
+        var v : string
+        unsafe {
+            sscan_json_at(payload, addr(v),
+                          *reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<string>)))
+        }
+        state.pending_value := v
+        state.has_pending = true
+    }
+}
+
+[widget_dispatch]
+def _text_show_dispatch(var state : TextShowState; action : string; payload : string) {
+    if (action == "set") {
+        var v : string
+        unsafe {
+            sscan_json_at(payload, addr(v),
+                          *reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<string>)))
+        }
+        state.value := v
+    }
+}
+
+[widget_dispatch]
+def _tree_node_dispatch(var state : TreeNodeState; action : string; payload : string) {
+    if (action == "open") {
+        state.pending_open = true
+    } elif (action == "close") {
+        state.pending_close = true
+    }
+}
+
+// pending_value family — shared body, one thin dispatch per state struct.
+
+def private pending_value_apply(var s : auto(S); payload : string) {
+    unsafe {
+        sscan_json_at(payload, addr(s.pending_value),
+                      *reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<typedecl(s.pending_value)>)))
+    }
+    s.has_pending = true
+}
+
+[widget_dispatch]
+def _pv_drag_float(var state : DragStateFloat; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_float2(var state : DragStateFloat2; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_float3(var state : DragStateFloat3; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_float4(var state : DragStateFloat4; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_int(var state : DragStateInt; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_int2(var state : DragStateInt2; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_int3(var state : DragStateInt3; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_int4(var state : DragStateInt4; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_range_float(var state : DragStateRangeFloat; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_drag_range_int(var state : DragStateRangeInt; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_float(var state : SliderStateFloat; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_float2(var state : SliderStateFloat2; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_float3(var state : SliderStateFloat3; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_float4(var state : SliderStateFloat4; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_int(var state : SliderStateInt; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_int2(var state : SliderStateInt2; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_int3(var state : SliderStateInt3; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_slider_int4(var state : SliderStateInt4; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_float(var state : InputStateFloat; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_float2(var state : InputStateFloat2; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_float3(var state : InputStateFloat3; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_float4(var state : InputStateFloat4; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_int(var state : InputStateInt; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_int2(var state : InputStateInt2; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_int3(var state : InputStateInt3; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_int4(var state : InputStateInt4; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_input_double(var state : InputStateDouble; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_color3(var state : ColorState3; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_color4(var state : ColorState4; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_combo(var state : ComboState; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+[widget_dispatch]
+def _pv_listbox(var state : ListBoxState; action : string; payload : string) {
+    if (action == "set") {
+        pending_value_apply(state, payload)
+    }
+}
+
 
 // ===== Triggers (click family) =====
 
@@ -457,19 +661,7 @@ def tree_node_ex(var state : TreeNodeState; text : string;
     let im_open = TreeNodeEx(text, flags)
     state.opened = im_open
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV(state)
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            if (action == "open") {
-                state.pending_open = true
-            } elif (action == "close") {
-                state.pending_close = true
-            }
-        }
-        widget_finalize(widget_ident, "tree_node_ex", entry, ser, disp)
-    }
+    finalize_state(widget_ident, "tree_node_ex", state, entry)
     return im_open
 }
 
@@ -1277,18 +1469,9 @@ def input_text_callback(var state : InputTextState; text : string;
 // ===== Filter family =====
 
 def private text_filter_finalize(widget_ident : string; kind : string; var state : TextFilterState) {
+    //! Filter editor finalize. Read-only via the registry's sprint_json_at rail; dispatch is a registered no-op (a future "set" path would mirror the value back into filter.InputBuf and call filter.Build()).
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV((value = state.value))
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            // Read-only for now. A future "set" path would mirror the
-            // value back into filter.InputBuf and call filter.Build();
-            // playwright doesn't drive the filter editor yet.
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
     register_focusable(widget_ident)
 }
 
@@ -1379,21 +1562,9 @@ def combo_getter(var state : ComboState; text : string;
 // fixtures programmatically.
 
 def private text_show_finalize(widget_ident : string; kind : string; var state : TextShowState) {
-    let path = widget_path_key(widget_ident)
+    //! Display-only widget finalize with a "set" action handled by the per-kind [widget_dispatch] (writes state.value).
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            with_state(path, type<typedecl(state)>) $(var s) {
-                if (action == "set") {
-                    s.value := payload?["value"] ?? ""
-                }
-            }
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
 }
 
 [widget]
@@ -1423,42 +1594,21 @@ def text_show(var state : TextShowState; value : string = "") {
 // `register_focusable` is NOT called (display widgets are not focusable).
 
 def private narrative_finalize(widget_ident : string; kind : string; var state : NarrativeState) {
+    //! Read-only narrative finalize. State payload via sprint_json_at; dispatch is a registered no-op.
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV(state)
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            // Read-only display; no L2/L3 actions.
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
 }
 
 def private label_text_finalize(widget_ident : string; kind : string; var state : LabelTextState) {
+    //! Read-only label-text finalize. Same shape as narrative.
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV(state)
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            // Read-only display; no L2/L3 actions.
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
 }
 
 def private marker_finalize(widget_ident : string; kind : string; var state : EmptyMarkerState) {
+    //! Stateless decoration finalize. Same shape as narrative.
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV(state)
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            // Stateless decoration; no L2/L3 actions.
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
 }
 
 [widget]
@@ -1628,29 +1778,15 @@ def unindent(var state : EmptyMarkerState; indent_w : float = 0.0f) {
 // Per-call args echo into state for telemetry; no dispatcher (read-only).
 
 def private progress_bar_finalize(widget_ident : string; kind : string; var state : ProgressBarState) {
+    //! Read-only progress finalize. Same shape as narrative.
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV(state)
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            // Read-only display; no L2/L3 actions.
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
 }
 
 def private image_finalize(widget_ident : string; kind : string; var state : ImageState) {
+    //! Read-only image finalize. Same shape as narrative.
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(& state) () : JsonValue ? {
-            return JV(state)
-        }
-        let disp <- @ capture(& state) (action : string; payload : JsonValue ?) {
-            // Read-only display; no L2/L3 actions.
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
 }
 
 [widget]
@@ -1742,17 +1878,9 @@ def set_item_tooltip(var state : NarrativeState; text : string;
 // _builtin_PlotLines_cb / _builtin_PlotHistogram_cb forwarders.
 
 def private plot_finalize(widget_ident : string; kind : string; var state : PlotState) {
-    let path = widget_path_key(widget_ident)
+    //! Read-only plot finalize. Same shape as narrative.
     var entry : WidgetEntry
-    unsafe {
-        let ser <- @ capture(= path) () : JsonValue ? {
-            return state_jv(path, type<typedecl(state)>)
-        }
-        let disp <- @ capture(= path) (action : string; payload : JsonValue ?) {
-            // Plot is read-only; no L2/L3 actions. Dispatcher is a no-op.
-        }
-        widget_finalize(widget_ident, kind, entry, ser, disp)
-    }
+    finalize_state(widget_ident, kind, state, entry)
 }
 
 [widget]
@@ -2519,3 +2647,4 @@ def public log_text(s : string) {
     //! and `log_finish()` (or other `LogTo*` brackets).
     LogText(s)
 }
+

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -100,7 +100,7 @@ def edit_finalize(widget_ident : string; kind : string; var ptr : auto(TT)? impl
 def edit_container_open_close_finalize(widget_ident : string; kind : string;
                                        var ptr : bool? implicit;
                                        bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
-    //! [edit_container] finalize for bool-typed open/close pointers. Pointer + ti go into g_widgets so the per-kind [widget_dispatch] handles "set"/"open"/"close" by writing through *ptr.
+    //! [edit_container] finalize for bool-typed open/close pointers. Pointer + ti go into g_widgets so the per-kind [widget_dispatch] handles "set"/"open"/"close" by writing through ``*ptr``.
     var entry : WidgetEntry
     entry.bbox = bbox
     unsafe {

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -15,26 +15,28 @@ require strings
 require math
 
 //! Built-in widgets defined via `[widget]` — the same mechanism users get.
-//! Each def constructs two short closures (serializer + dispatcher) and
-//! hands them to widget_finalize. Common per-frame fields (hex_id/bbox/
-//! hover/active/focus) are captured inside widget_finalize; per-kind state
-//! lives in the state struct alone.
+//! Each def hands ``(state_addr, ti)`` (the state's address + its runtime
+//! ``TypeInfo``) to ``widget_finalize``; common per-frame fields (hex_id/
+//! bbox/hover/active/focus) are captured inside widget_finalize; per-kind
+//! state lives in the state struct alone.
 //!
-//! Four private *_finalize helpers below collapse the repetitive
-//! lambda-construction + widget_finalize call shared across click /
-//! toggle / radio_int / pending-value widget families. Each widget def
-//! stays focused on the imgui call + per-frame state mutation. The
-//! `pending_value_finalize` helper is generic on the state struct and
-//! drives `from_JV` off `typedecl(state.pending_value)` — one body
-//! covers every Drag* / Slider* / Input* family without per-type
-//! duplication.
+//! HTTP dispatch goes through ``g_dispatchers`` keyed by ``(*ti).hash`` (the
+//! state struct's runtime type), populated by the ``[widget_dispatch]``
+//! defs paired with each state struct further down. One ``[widget_dispatch]``
+//! body covers every widget kind that shares that state — e.g. one
+//! ClickState dispatcher handles ``button`` / ``small_button`` /
+//! ``arrow_button`` / ``invisible_button`` / ``image_button``. No
+//! per-widget serializer or dispatcher lambda is emitted; snapshot reads
+//! route through ``sprint_json_at(state_addr, *ti)`` and set-actions
+//! through ``sscan_json_at(state_addr, *ti)``.
 
 // ===== Common finalize helpers =====
-
+//
 // Generic state-addr+ti plumbing for [widget]/[container] state structs.
 // Pull (state_addr, ti) out of a state-by-ref param exactly once, then route
 // to widget_finalize / container_finalize. The kind-specific action handlers
-// live in [widget_dispatch] defs near each state struct's call sites.
+// live in [widget_dispatch] defs near each state struct's call sites; HTTP
+// dispatch matches them by ti.hash via g_dispatchers in imgui_boost_runtime.
 
 def private finalize_state(widget_ident : string; kind : string;
                            var state : auto(ST); var entry : WidgetEntry) {


### PR DESCRIPTION
## Summary

Pre-PR4 every `[widget]` body emitted two heap-allocated closures per render frame (`ser <- @ capture(= path) () : JsonValue?` and `disp <- @ capture(= path) (action, payload)`), stored into path-keyed `g_serializers` / `g_dispatchers` tables and looked up by widget ident at snapshot / HTTP-dispatch time. Pivot the rail to type-erased addr + TypeInfo dispatch keyed by state-struct identity.

- `widget_finalize` / `container_finalize` now take `(state_addr : void?, ti : TypeInfo const?)` directly. **No per-call-site closures emitted.**
- Dispatch lookup uses `meta.ti.hash` against one global `g_dispatchers` table. Non-Structure `ti` (scalar pointee from `[edit_widget]`) falls through to generic `sscan_json_at(state_addr, *ti)` in `dispatch_or_err`. Display-only state structs (`Narrative`/`Empty`/`Plot`/`Image`/etc.) get no dispatcher and silently no-op.
- `[widget_dispatch]` annotation **re-keyed by first-param struct type, not by fn name**. One body per state struct fires for every kind whose state is that struct (e.g. `ClickState` handles every `button`/`small_button`/`arrow_button`/... at once). The fn name is irrelevant.
- Snapshot rail routes through `sprint_json_at(state_addr, *ti)`; the vec wire shape now matches daslib `JV` after upstream daslang #2871.

## Architectural collapse

| | Before | After |
|---|---|---|
| Per-call-site lambda emit sites | 38 | **0** |
| Per-kind `dispatch_*` helpers | ~50 | ~35 per-state-struct `[widget_dispatch]` bodies |
| Per-pointee-type `edit_*` wrappers | 10 | **0** (generic ti path covers all) |
| `_register_*_dispatch_kinds()` `[init]` blocks | 3 | **0** |
| Explicit `register_widget_kind()` calls | ~150 | **0** (macro emits) |
| Dispatch tables | `g_serializers` + `g_dispatchers` | one `g_dispatchers` |

## Profile

`examples/imgui_demo/imgui_demo.das`, 5×back-to-back runs each:

| | Mean | Min | Max | Functions |
|---|---|---|---|---|
| Baseline (master) | 7.01s | 6.84s | 7.15s | 1159 |
| Patched (PR4) | **5.62s** | 5.45s | 5.90s | 1280 |
| Delta | **−19.8%** | | | +10.4% |

Every patched run beats every baseline run (max(PR4) 5.90s < min(baseline) 6.84s). Function count up because of the `[widget_dispatch]` thunks — offset by killing every per-instance lambda capture frame.

Cumulative dasImgui compile-time wins from PR #68 (−42%) + PR #69 (no compile delta; runtime addr+ti pivot) + this PR (−20%) compound to roughly **−53% wall** vs pre-PR-#68 baseline on `imgui_demo.das`.

## Review-comment follow-ups

Round 1 Copilot review delivered 7 comments:

- **Lazy `WidgetMeta` UAF on `@live` reload** (real bug). `widgets_mark_seen` lazy-creates a meta on first render of an `[edit_widget]` that never went through `register_widget`, so `clear_module_widgets` skips it on reload — a closed-window snapshot could then dereference a `state_addr` left dangling by the heap reset. Fixed via a freshness gate on the snapshot iteration loop: lazy entries are tagged with a `LAZY_EDIT_WIDGET_MODULE = "<edit_widget>"` sentinel `module_name` and self-expire after one frame absent, same gate the indexed-path uses. The sentinel disambiguates from main-file pre-registered entries (which legitimately carry `module_name = ""`).
- **Comment drift `g_kind_dispatchers` → `g_dispatchers`** (5 sites). Renamed during the ti.hash-keying refactor; comments lagged. Rewritten across `imgui_boost_runtime.das` / `imgui_widgets_builtin.das` / `imgui_containers_builtin.das`.
- **Pre-validation of `dispatch_or_err` payload when `value` missing**. Skipped. Boundary behavior: missing `value` → empty string payload → `sscan_json_at` no-ops or panics; the per-command Result wire surfaces the failure to the caller. Adding pre-validation duplicates the state-struct schema already declared via `ti`.

## Lint hardening (bundled per request)

- **`.githooks/pre-push`** — mirror of daslang's hook. Formatter `--verify` whole tree + lint on changed `.das` files vs `origin/master`. Probes sibling daslang checkout for the binary; `DASLANG` / `DASLANG_SRC` env-var overrides. Enable with `git config core.hooksPath .githooks`.
- **`docs.yml` lint step** after Build daslang — same `git diff origin/$BASE_REF...HEAD -- '*.das'` pattern as daslang's `extended_checks.yml`, runs via `-load_module $WORKSPACE/dasImgui`, fails fast before APNG fetch + sphinx (~10 min). Checkout step bumped to `fetch-depth: 0` for the diff to resolve.
- **Lint sweep across the whole repo** — 23 files, ~110 issues, dominated by `int('A')`/`int(char_literal)` patterns the new PERF020 rule catches. Mostly mechanical strips; one PERF003 on a 4-char animated-title spinner suppressed with explicit reasoning; one STYLE024 suppressed where `ExprPtr2Ref` is genuinely unsafe but the rule doesn't recognize ptr-deref yet.

## Test plan

- [x] dasImgui integration suite headless: 137 passed, 0 regressions vs master. 13 documented failures match the headless-only exclude list (glfw_synth_keys ×5, glfw_synth_mouse ×7, visual_aids_key_hud ×1 — all post HTTP `key_press`/`mouse_*` commands targeting `glfw_live`'s synth driver, which has no event queue without a GLFW context).
- [x] Lint clean on every modified `.das` file.
- [x] Format clean on every modified `.das` file.
- [ ] CI green on PR (docs.yml lint step is the new gate).

## Dependency

Depends on **daslang #2871** (json vec-shape pivot) — merged. Without that, the snapshot rail would emit `float3` as `[x,y,z]` while tests read via `?["y"]` expecting object form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
