### PR TITLE
tutorial: drag + slider widget tutorials (10 + 10 widgets, 1 page each)

### DIFF
--- a/doc/source/tutorials/drag.rst
+++ b/doc/source/tutorials/drag.rst
@@ -1,0 +1,162 @@
+.. _tutorial_drag:
+
+#######################
+Drag widgets
+#######################
+
+The drag family is **click-and-scrub numeric editing**: press inside the
+widget, drag horizontally, release. The value tracks pixel movement
+scaled by ``speed``. Same call shape spans scalar / vector / range and
+float / int — one mental model, ten widgets.
+
+.. code-block:: das
+
+   drag_float(IDENT, (text = "..", speed = 0.01f, format = "%.3f",
+                      flags = ImGuiSliderFlags....))
+   drag_int(IDENT, (text = "..", speed = 1.0f, format = "%d"))
+   drag_float2 / drag_float3 / drag_float4        // vector forms
+   drag_int2   / drag_int3   / drag_int4
+   drag_float_range2(IDENT, (text, speed, format)) // paired lo / hi handles
+   drag_int_range2(IDENT, (text, speed, format))
+
+Bounds live on the state struct (``IDENT.bounds = (lo, hi)``), set once
+per frame from app code. Zero-init = unclamped — scrub goes anywhere.
+
+Source: ``examples/tutorial/drag.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/drag.apng
+   :alt: drag tutorial recording
+
+.. literalinclude:: ../../../examples/tutorial/drag.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_widgets_builtin`` — every ``drag_*`` rail.
+* ``imgui/imgui_boost_runtime`` — ``DragStateFloat`` / ``DragStateInt`` /
+  ``DragStateFloat3`` / ``DragStateRangeFloat`` state structs.
+
+Speed and format
+================
+
+``speed`` is units-per-pixel of horizontal cursor movement:
+
+.. code-block:: das
+
+   drag_float(OPACITY, (text = "opacity", speed = 0.005f))  // 0.005 / px → 200 px = 1.0
+   drag_int(SCORE,     (text = "score", speed = 1.0f))      // 1 / px → ImGui clamps to int
+
+``format`` is the printf-style label format. The default ``"%.3f"`` /
+``"%d"`` covers most cases; bump to ``"%.6f"`` for fine-grained float
+values or ``"%+04d"`` for signed-padded ints.
+
+Bounds
+======
+
+Bounds are a property of the **state**, not the call:
+
+.. code-block:: das
+
+   D_FLOAT.bounds = (0.0f, 1.0f)
+   drag_float(D_FLOAT, (text = "opacity", speed = 0.005f))
+
+Set them every frame (idempotent assignment, no branching needed). The
+wrapper passes ``(min, max)`` to ImGui's ``DragFloat`` which clamps the
+scrub. Zero-initialized bounds = ``(0, 0)`` = special-cased to mean
+**unclamped**.
+
+Vector forms
+============
+
+The ``2`` / ``3`` / ``4`` suffix puts that many components on one row,
+each its own drag handle. ``state.value`` becomes ``float2`` / ``float3``
+/ ``float4`` (or ``int2`` / ``int3`` / ``int4``):
+
+.. code-block:: das
+
+   D_VEC3.bounds = (-10.0f, 10.0f)   // applies to every component
+   drag_float3(D_VEC3, (text = "position", speed = 0.05f))
+   // D_VEC3.value.x, D_VEC3.value.y, D_VEC3.value.z
+
+Range forms
+===========
+
+``drag_float_range2`` / ``drag_int_range2`` render **two handles sharing
+one bar** — useful for "filter between lo and hi" widgets:
+
+.. code-block:: das
+
+   D_RANGE.bounds = (0.0f, 100.0f)
+   drag_float_range2(D_RANGE, (text = "band", speed = 0.5f))
+   // D_RANGE.value.x = lo, D_RANGE.value.y = hi (ImGui enforces lo <= hi)
+
+Driving from outside
+====================
+
+Every drag widget exposes the same telemetry channel — ``imgui_set``
+writes ``state.pending_value`` which the next frame consumes:
+
+.. code-block:: bash
+
+   # Scalar:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"DRAG_WIN/D_FLOAT","value":0.75}}' \
+        localhost:9090/command
+   # Vector — one number per component:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"DRAG_WIN/D_VEC3","value":[1.0,2.0,3.0]}}' \
+        localhost:9090/command
+   # Range — (lo, hi) tuple:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"DRAG_WIN/D_RANGE","value":[10.0,40.0]}}' \
+        localhost:9090/command
+
+The dispatcher (``[widget_dispatch]`` on the state struct) accepts the
+right JSON shape per state type — scalar number, array of numbers, or
+two-element array for ranges.
+
+Drag vs slider vs input
+=======================
+
+The three numeric-edit families differ in interaction shape:
+
+* **drag** — click and scrub, no fixed track. Best for "tweak this value"
+  where the absolute range is large or open-ended.
+* **slider** — click and drag along a fixed-width track between
+  ``v_min`` / ``v_max``. Best for bounded percentages, settings sliders.
+* **input** — type the number, optionally with ``+`` / ``-`` step buttons.
+  Best for precise values where the user knows the number.
+
+All three families share the same vector / scalar / format conventions.
+See :ref:`tutorial_slider`.
+
+Caller-owned variant
+====================
+
+For sites where the value lives on an external scalar (not a widget
+state struct), use the ``edit_drag_*`` rail instead — it takes a
+``T?`` pointer via ``safe_addr`` and skips the state-struct allocation:
+
+.. code-block:: das
+
+   var g_opacity : float = 0.5f
+   edit_drag_float(safe_addr(g_opacity), (id = "OPACITY",
+                                          text = "opacity", speed = 0.005f))
+
+See :ref:`tutorial_edit_external_tour`.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/drag.das <../../../examples/tutorial/drag.das>`
+
+   Features-side demo: ``examples/features/inputs_drag.das`` — every drag
+   widget in one window, useful for ``imgui_set`` smoke testing.
+
+   Sibling tutorial: :ref:`tutorial_slider`.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -47,3 +47,5 @@ construction.
    color_button_hover.rst
    selectable_hover.rst
    drawlist.rst
+   drag.rst
+   slider.rst

--- a/doc/source/tutorials/slider.rst
+++ b/doc/source/tutorials/slider.rst
@@ -1,0 +1,165 @@
+.. _tutorial_slider:
+
+#######################
+Slider widgets
+#######################
+
+The slider family is **bounded numeric editing along a fixed track**:
+click the track to jump, drag the handle to scrub. Same call shape spans
+scalar / vector / vertical and float / int — ten widgets, one mental
+model.
+
+.. code-block:: das
+
+   slider_float(IDENT, (text = "..", format = "%.3f",
+                        flags = ImGuiSliderFlags....))
+   slider_int(IDENT, (text = "..", format = "%d"))
+   slider_float2 / slider_float3 / slider_float4   // vector forms
+   slider_int2   / slider_int3   / slider_int4
+   vslider_float(IDENT, (text, size = float2(w, h), format = "%.3f"))
+   vslider_int(IDENT, (text, size, format))
+
+Bounds are **required** — slider has a fixed-width track between
+``(state.bounds.min, state.bounds.max)``. Unlike drag, zero-init bounds
+``(0, 0)`` collapses the track to a single point.
+
+Source: ``examples/tutorial/slider.das``.
+
+************
+Walkthrough
+************
+
+.. image:: ../_static/tutorials/slider.apng
+   :alt: slider tutorial recording
+
+.. literalinclude:: ../../../examples/tutorial/slider.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_widgets_builtin`` — every ``slider_*`` / ``vslider_*`` rail.
+* ``imgui/imgui_boost_runtime`` — ``SliderStateFloat`` / ``SliderStateInt`` /
+  vector state structs.
+
+Bounds
+======
+
+Bounds are a property of the **state**, not the call. Set them every
+frame (idempotent assignment, no branching):
+
+.. code-block:: das
+
+   S_FLOAT.bounds = (0.0f, 1.0f)
+   slider_float(S_FLOAT, (text = "volume", format = "%.2f"))
+
+The wrapper passes ``(min, max)`` to ImGui's ``SliderFloat`` which
+constrains the handle. Unlike :ref:`tutorial_drag`, zero bounds are
+**not** unclamped — the track has nowhere to render.
+
+Format
+======
+
+``format`` is the printf-style label format. Default ``"%.3f"`` /
+``"%d"``; customize for units:
+
+.. code-block:: das
+
+   slider_int(S_INT, (text = "percent", format = "%d%%"))    // 42%
+   slider_float(S_TEMP, (text = "temp", format = "%.1f °C")) // 23.5 °C
+
+Vector forms
+============
+
+The ``2`` / ``3`` / ``4`` suffix puts that many handles on one row.
+``state.value`` becomes ``float2`` / ``float3`` / ``float4`` (or
+``int2`` / ``int3`` / ``int4``):
+
+.. code-block:: das
+
+   S_VEC3.bounds = (-1.0f, 1.0f)        // applies to every component
+   slider_float3(S_VEC3, (text = "rotation", format = "%.2f"))
+   // S_VEC3.value.x, S_VEC3.value.y, S_VEC3.value.z
+
+Vertical orientation
+====================
+
+``vslider_float`` / ``vslider_int`` share the same state struct as the
+horizontal form, but render the track **top-to-bottom**. The
+distinguishing arg is ``size : float2`` (width, height):
+
+.. code-block:: das
+
+   V_MID.bounds = (0.0f, 1.0f)
+   vslider_float(V_MID, (text = "##mid",
+                         size = float2(36.0f, 140.0f), format = "%.2f"))
+
+Common pattern: three vslider_floats with ``same_line`` between them
+form a mixer-channel strip. The ``"##mid"`` text prefix hides the label
+(everything after ``##`` is ID-only); use ``"label"`` instead to
+display it above the slider.
+
+Driving from outside
+====================
+
+Every slider exposes the same telemetry channel — ``imgui_set`` writes
+``state.pending_value`` which the next frame consumes:
+
+.. code-block:: bash
+
+   # Scalar:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"SLIDER_WIN/S_FLOAT","value":0.8}}' \
+        localhost:9090/command
+   # Vector — one number per component:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"SLIDER_WIN/S_VEC3","value":[1.0,2.0,3.0]}}' \
+        localhost:9090/command
+
+The dispatcher (``[widget_dispatch]`` on ``SliderStateFloat`` and
+friends) accepts the right JSON shape per state type — scalar number or
+array of numbers.
+
+Slider vs drag vs input
+=======================
+
+The three numeric-edit families differ in interaction shape:
+
+* **slider** — click and drag along a fixed-width track between
+  ``v_min`` / ``v_max``. Best for bounded percentages, settings sliders.
+* **drag** — click and scrub, no fixed track. Best for "tweak this
+  value" where the range is large or open-ended.
+* **input** — type the number, optionally with ``+`` / ``-`` step
+  buttons. Best for precise values where the user knows the number.
+
+All three families share the same vector / scalar / format conventions.
+See :ref:`tutorial_drag`.
+
+Caller-owned variant
+====================
+
+For sites where the value lives on an external scalar (not a widget
+state struct), use the ``edit_slider_*`` rail instead — it takes a
+``T?`` pointer via ``safe_addr`` and skips the state-struct allocation:
+
+.. code-block:: das
+
+   var g_volume : float = 0.5f
+   edit_slider_float(safe_addr(g_volume), (id = "VOLUME",
+                                           text = "volume",
+                                           v_min = 0.0f, v_max = 1.0f))
+
+See :ref:`tutorial_edit_external_tour`.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/slider.das <../../../examples/tutorial/slider.das>`
+
+   Features-side demo: ``examples/features/inputs_slider.das`` /
+   ``examples/features/edit_vsliders.das`` — every slider in one window,
+   useful for ``imgui_set`` smoke testing.
+
+   Sibling tutorial: :ref:`tutorial_drag`.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/examples/tutorial/drag.das
+++ b/examples/tutorial/drag.das
@@ -1,0 +1,124 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: drag widgets — click-and-scrub numeric editing.
+//
+//   drag_float(IDENT, (text = "..", speed = 0.01f, format = "%.3f",
+//                      flags = ImGuiSliderFlags....))
+//   drag_int / drag_float2/3/4 / drag_int2/3/4 / drag_float_range2 /
+//   drag_int_range2 — same shape; scalar / vector / range variants.
+//
+// Bounds live on the state struct (`IDENT.bounds = (lo, hi)`), set once per
+// frame from app code. Zero-init = unclamped (drag scrubs to any value).
+// `speed` is units-per-pixel of horizontal drag; `format` is the printf-style
+// label format.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/drag.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/drag.das
+//
+// DRIVE (when running live):
+//   # Set scalar value directly:
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"DRAG_WIN/D_FLOAT","value":0.75}}' \
+//        localhost:9090/command
+//   # Set vector value (one number per component):
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"DRAG_WIN/D_VEC3","value":[1.0,2.0,3.0]}}' \
+//        localhost:9090/command
+//   # Set range (lo, hi):
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"DRAG_WIN/D_RANGE","value":[10.0,40.0]}}' \
+//        localhost:9090/command
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui drag tutorial", 760, 520)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(720.0f, 480.0f), ImGuiCond.Always)
+    window(DRAG_WIN, (text = "drag tutorial", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+
+        text("Click and drag horizontally to scrub the value.")
+        text(D_HINT, (text = "Bounds set via IDENT.bounds = (lo, hi). Zero-init = unclamped."))
+        separator()
+
+        // ---- Stage 1: scalar float, clamped 0..1 ----
+        D_FLOAT.bounds = (0.0f, 1.0f)
+        drag_float(D_FLOAT, (text = "opacity", speed = 0.005f, format = "%.3f"))
+        text("D_FLOAT.value = {D_FLOAT.value}")
+        spacing()
+
+        // ---- Stage 2: scalar int ----
+        D_INT.bounds = (0, 100)
+        drag_int(D_INT, (text = "score", speed = 1.0f, format = "%d"))
+        text("D_INT.value = {D_INT.value}")
+        spacing()
+
+        // ---- Stage 3: vector — three components on one row ----
+        D_VEC3.bounds = (-10.0f, 10.0f)
+        drag_float3(D_VEC3, (text = "position", speed = 0.05f, format = "%.2f"))
+        text("D_VEC3.value = ({D_VEC3.value.x}, {D_VEC3.value.y}, {D_VEC3.value.z})")
+        spacing()
+
+        // ---- Stage 4: range — paired min/max scrubbing, lo <= hi enforced ----
+        D_RANGE.bounds = (0.0f, 100.0f)
+        drag_float_range2(D_RANGE, (text = "band", speed = 0.5f, format = "%.1f"))
+        text("D_RANGE.value = [{D_RANGE.value.x}, {D_RANGE.value.y}]")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/slider.das
+++ b/examples/tutorial/slider.das
@@ -1,0 +1,130 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: slider widgets — bounded numeric editing along a fixed track.
+//
+//   slider_float(IDENT, (text = "..", format = "%.3f",
+//                        flags = ImGuiSliderFlags....))
+//   slider_int / slider_float2/3/4 / slider_int2/3/4 / vslider_float /
+//   vslider_int — same shape; scalar / vector / vertical variants.
+//
+// Bounds REQUIRED — slider has a fixed-width track between
+// (state.bounds.min, state.bounds.max). Unlike drag, zero-init bounds
+// = (0, 0) collapses the track to a single value.
+//
+// vslider takes a `size : float2` arg (width, height) and renders the
+// track top-to-bottom; otherwise identical to slider_float.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/slider.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/slider.das
+//
+// DRIVE (when running live):
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"SLIDER_WIN/S_FLOAT","value":0.8}}' \
+//        localhost:9090/command
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"SLIDER_WIN/S_VEC3","value":[1.0,2.0,3.0]}}' \
+//        localhost:9090/command
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui slider tutorial", 760, 520)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(720.0f, 480.0f), ImGuiCond.Always)
+    window(SLIDER_WIN, (text = "slider tutorial", closable = false,
+                        flags = ImGuiWindowFlags.None)) {
+
+        text("Click anywhere on the track to jump; drag the handle to scrub.")
+        text(S_HINT, (text = "Bounds REQUIRED — track spans (lo, hi) literally."))
+        separator()
+
+        // ---- Stage 1: scalar float, 0..1 ----
+        S_FLOAT.bounds = (0.0f, 1.0f)
+        slider_float(S_FLOAT, (text = "volume", format = "%.2f"))
+        text("S_FLOAT.value = {S_FLOAT.value}")
+        spacing()
+
+        // ---- Stage 2: scalar int, 0..100 ----
+        S_INT.bounds = (0, 100)
+        slider_int(S_INT, (text = "percent", format = "%d%%"))
+        text("S_INT.value = {S_INT.value}")
+        spacing()
+
+        // ---- Stage 3: vector — three handles on one row ----
+        S_VEC3.bounds = (-1.0f, 1.0f)
+        slider_float3(S_VEC3, (text = "rotation", format = "%.2f"))
+        text("S_VEC3.value = ({S_VEC3.value.x}, {S_VEC3.value.y}, {S_VEC3.value.z})")
+        spacing()
+
+        // ---- Stage 4: vertical orientation — same state, different layout ----
+        text("Vertical sliders (vslider_float) share SliderStateFloat:")
+        V_LO.bounds = (0.0f, 1.0f)
+        V_MID.bounds = (0.0f, 1.0f)
+        V_HI.bounds = (0.0f, 1.0f)
+        vslider_float(V_LO, (text = "##lo",
+                             size = float2(36.0f, 140.0f), format = "%.2f"))
+        same_line(SLINE_1)
+        vslider_float(V_MID, (text = "##mid",
+                              size = float2(36.0f, 140.0f), format = "%.2f"))
+        same_line(SLINE_2)
+        vslider_float(V_HI, (text = "##hi",
+                             size = float2(36.0f, 140.0f), format = "%.2f"))
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/tests/integration/record_drag.das
+++ b/tests/integration/record_drag.das
@@ -1,0 +1,111 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``drag.apng`` against
+//! ``examples/tutorial/drag.das``. Tours four drag forms — scalar float,
+//! scalar int, vector float3, and float range pair — narrating each in
+//! turn and driving one value via ``imgui_set`` to show the bidirectional
+//! channel.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS        = 5000u      //! 5s read window per stage
+let SETTLE_MS      = 1500u      //! 1.5s cursor settle
+let SET_DWELL_MS   = 2200u      //! 2.2s post-imgui_set dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/drag.das",
+                       "drag.apng", 60) $(app) {
+        let T_FLOAT = "DRAG_WIN/D_FLOAT"
+        let T_INT   = "DRAG_WIN/D_INT"
+        let T_VEC3  = "DRAG_WIN/D_VEC3"
+        let T_RANGE = "DRAG_WIN/D_RANGE"
+
+        var snap = wait_for_widget(app, T_FLOAT, 10.0f)
+        if (snap == null) {
+            panic("{T_FLOAT} never registered — wrong app running?")
+        }
+        let p_float = widget_center(snap, T_FLOAT)
+        let p_int   = widget_center(snap, T_INT)
+        let p_vec3  = widget_center(snap, T_VEC3)
+        let p_range = widget_center(snap, T_RANGE)
+
+        //! Initial cursor placement.
+        move_to(app, p_float, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: narrate scalar float ----
+        post_command(app, "imgui_narrate", JV((
+            text = "drag_float(IDENT, (text, speed, format)) — click and drag horizontally to scrub. Bounds = (0, 1) clamps; speed = 0.005 means 0.005 units per pixel.",
+            target = T_FLOAT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: scalar int ----
+        move_to(app, p_int, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "drag_int — same shape, integer steps. format = \"%d\" by default; speed = 1 means one integer per pixel.",
+            target = T_INT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: vector float3 ----
+        move_to(app, p_vec3, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "drag_float3 — three components on one row. State carries float3 value; bounds clamp every component.",
+            target = T_VEC3,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: range pair ----
+        move_to(app, p_range, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "drag_float_range2 — two handles share one bar. value.x = lo, value.y = hi; ImGui enforces lo <= hi each frame.",
+            target = T_RANGE,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 5: drive from outside via imgui_set ----
+        post_command(app, "imgui_set", JV((target = T_FLOAT, value = 0.75f)))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_set", JV((target = T_RANGE, value = (20.0f, 65.0f))))
+        sleep(SET_DWELL_MS)
+        move_to(app, p_float, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_set writes through state.pending_value; next frame consumes it. Same channel for scalar (number) or range (two-number tuple).",
+            target = T_FLOAT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}

--- a/tests/integration/record_slider.das
+++ b/tests/integration/record_slider.das
@@ -1,0 +1,110 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``slider.apng`` against
+//! ``examples/tutorial/slider.das``. Tours four slider forms — scalar
+//! float, scalar int, vector float3, and vertical orientation — and
+//! drives one value via ``imgui_set`` to show the bidirectional channel.
+
+let NARRATE_FRAMES = 240        //! 4.0s visible at 60 fps app
+let READ_MS        = 5000u      //! 5s read window per stage
+let SETTLE_MS      = 1500u      //! 1.5s cursor settle
+let SET_DWELL_MS   = 2200u      //! 2.2s post-imgui_set dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/slider.das",
+                       "slider.apng", 60) $(app) {
+        let T_FLOAT = "SLIDER_WIN/S_FLOAT"
+        let T_INT   = "SLIDER_WIN/S_INT"
+        let T_VEC3  = "SLIDER_WIN/S_VEC3"
+        let T_VMID  = "SLIDER_WIN/V_MID"
+
+        var snap = wait_for_widget(app, T_FLOAT, 10.0f)
+        if (snap == null) {
+            panic("{T_FLOAT} never registered — wrong app running?")
+        }
+        let p_float = widget_center(snap, T_FLOAT)
+        let p_int   = widget_center(snap, T_INT)
+        let p_vec3  = widget_center(snap, T_VEC3)
+        let p_vmid  = widget_center(snap, T_VMID)
+
+        //! Initial cursor placement.
+        move_to(app, p_float, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: narrate scalar float ----
+        post_command(app, "imgui_narrate", JV((
+            text = "slider_float(IDENT, (text, format)) — fixed-width track between (lo, hi). Click track to jump; drag handle to scrub. Bounds REQUIRED.",
+            target = T_FLOAT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: scalar int ----
+        move_to(app, p_int, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "slider_int — same shape, integer steps. format = \"%d%%\" prints a percent suffix on the label.",
+            target = T_INT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: vector float3 ----
+        move_to(app, p_vec3, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "slider_float3 — three handles on one row. State carries float3 value; bounds apply to every component.",
+            target = T_VEC3,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: vertical orientation ----
+        move_to(app, p_vmid, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "vslider_float — same SliderStateFloat, vertical track. size = (width, height) specifies pixel geometry; everything else is identical.",
+            target = T_VMID,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 5: drive from outside via imgui_set ----
+        post_command(app, "imgui_set", JV((target = T_FLOAT, value = 0.8f)))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_set", JV((target = T_VEC3, value = (0.6f, -0.3f, 0.9f))))
+        sleep(SET_DWELL_MS)
+        move_to(app, p_float, 900)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_set writes state.pending_value; next frame consumes it. Same channel for scalar (number) or vector (per-component array).",
+            target = T_FLOAT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}


### PR DESCRIPTION
## Summary

First PR off the rewritten widget-tutorials-backfill plan — concept-grouped (one RST per family) instead of per-cpp-subsection grouped. Closes 20 of the 64 missing widget tutorials in two pages.

* **drag.rst** — drag_float / drag_int / vector forms / drag_float_range2 in four stages (10 [widget] rails)
* **slider.rst** — slider_float / slider_int / vector forms / vslider in four stages (10 [widget] rails). vslider shares state struct with the horizontal form
* Each tutorial = triad: `examples/tutorial/X.das` + `tests/integration/record_X.das` + `doc/source/tutorials/X.rst`
* APNGs published to `origin/assets` (drag.apng + slider.apng only — other 35 untouched)

## Test plan

- [x] `daslang -compile-only` clean on all 4 .das files
- [x] dasImgui lint: 4 files, 0 issues
- [x] das_source_formatter: all 4 already-formatted
- [x] APNGs recorded (37s / 996 frames drag, 37s / 998 frames slider, 0 dropped each)
- [x] Pre-push hook (formatter --verify + lint on changed files) passed
- [ ] Sphinx CI builds with the new APNGs from `origin/assets`
- [ ] Copilot review round
