### PR TITLE
tutorial: input_numeric + input_text triads (15 widgets, 2 pages)

### DIFF
--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -49,3 +49,5 @@ construction.
    drawlist.rst
    drag.rst
    slider.rst
+   input_numeric.rst
+   input_text.rst

--- a/doc/source/tutorials/input_numeric.rst
+++ b/doc/source/tutorials/input_numeric.rst
@@ -1,0 +1,190 @@
+.. _tutorial_input_numeric:
+
+#######################
+Input numeric widgets
+#######################
+
+The input_* numeric family is **type-the-number** editing: click to
+focus, type, Enter to commit. Optional ``+`` / ``-`` step buttons turn
+scalar forms into discrete-step editors. Same call shape spans scalar /
+vector / double-precision — nine widgets, one mental model.
+
+.. code-block:: das
+
+   input_float(IDENT, (text = "..", step = 0.0f, step_fast = 0.0f,
+                       format = "%.3f", flags = ImGuiInputTextFlags....))
+   input_int(IDENT, (text = "..", step = 1, step_fast = 100,
+                     flags = ImGuiInputTextFlags....))
+   input_double(IDENT, (text = "..", step = 0.0lf, step_fast = 0.0lf,
+                        format = "%.6f"))
+   input_float2 / input_float3 / input_float4   // vector — no step args
+   input_int2   / input_int3   / input_int4
+
+No bounds. ``input_*`` is for **typed entry**; if you need clamped
+scrubbing, use :ref:`tutorial_drag` or :ref:`tutorial_slider`.
+
+Source: ``examples/tutorial/input_numeric.das``.
+
+************
+Walkthrough
+************
+
+.. raw:: html
+
+   <video autoplay loop muted playsinline width="100%">
+     <source src="../_static/tutorials/input_numeric.mp4" type="video/mp4">
+     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/input_numeric.mp4">Download the recording</a>.
+   </video>
+
+.. literalinclude:: ../../../examples/tutorial/input_numeric.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_widgets_builtin`` — every ``input_*`` numeric rail.
+* ``imgui/imgui_boost_runtime`` — ``InputStateFloat`` / ``InputStateInt`` /
+  ``InputStateDouble`` (+ vector variants) state structs.
+
+Step buttons
+============
+
+Scalar forms (``input_float``, ``input_int``, ``input_double``) accept
+``step`` and ``step_fast``. Non-zero values surface ImGui's ``+`` / ``-``
+buttons on the right of the field:
+
+.. code-block:: das
+
+   input_float(MASS, (text = "mass (kg)",
+                      step = 0.1f, step_fast = 1.0f))    // +/- buttons visible
+   input_int(LEVEL, (text = "level",
+                     step = 1, step_fast = 100))         // defaults match this
+
+Plain click = ``step``. Ctrl-click = ``step_fast``. Defaults differ per
+type: ``input_int`` defaults ``step = 1`` / ``step_fast = 100`` (buttons
+visible by default); ``input_float`` and ``input_double`` default to
+``0.0`` (buttons hidden — pure text entry).
+
+Vector forms (``input_float2`` / ``3`` / ``4``, ``input_int2`` / etc.)
+**omit step args** — three or four +/- pairs would crowd the row.
+Component-wise editing only.
+
+Format
+======
+
+``format`` is the printf-style label format. Defaults are sane for most
+cases; bump precision when the user needs to see it:
+
+.. code-block:: das
+
+   input_float(MASS, (text = "mass", format = "%.6f"))   // 6 decimal places
+   input_int(LEVEL, (text = "level", format = "%03d"))   // 003, 042, etc.
+   input_double(EPOCH, (text = "epoch", format = "%.9f")) // sub-ns precision
+
+Vector forms
+============
+
+Same ``2`` / ``3`` / ``4`` convention — that many fields on one row.
+``state.value`` becomes ``float2`` / ``float3`` / ``float4`` (or
+``int2`` / ``int3`` / ``int4``). Tab cycles between components; Enter
+commits the whole row.
+
+.. code-block:: das
+
+   input_float3(POSITION, (text = "position", format = "%.2f"))
+   // POSITION.value.x, POSITION.value.y, POSITION.value.z
+
+Double precision
+================
+
+``input_double`` is the only path to double-precision values in the
+input family — drag and slider don't have a double variant. Use it for
+timestamps, geographic coordinates, anything that needs more than 7
+significant digits:
+
+.. code-block:: das
+
+   input_double(EPOCH_SEC, (text = "epoch",
+                            step = 1.0lf, step_fast = 60.0lf,
+                            format = "%.6f"))
+
+Default format ``"%.6f"`` (six places) vs ``input_float``'s ``"%.3f"``
+reflects the extra precision.
+
+Flags
+=====
+
+``flags : ImGuiInputTextFlags`` carries the standard text-input modifiers
+— ``CharsDecimal``, ``CharsHexadecimal``, ``CharsScientific``,
+``ReadOnly``, ``Password`` (rarely useful on numeric inputs but
+allowed), ``EscapeClearsAll``, etc. Composable via ``|``:
+
+.. code-block:: das
+
+   input_int(HEX_ADDR, (text = "addr",
+                        flags = ImGuiInputTextFlags.CharsHexadecimal,
+                        format = "0x%08X"))
+
+Driving from outside
+====================
+
+Every input_* widget exposes the same telemetry channel as drag and
+slider — ``imgui_set`` writes ``state.pending_value`` which the next
+frame consumes:
+
+.. code-block:: bash
+
+   # Scalar:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"IN_WIN/I_FLOAT","value":12.5}}' \
+        localhost:9090/command
+   # Vector — one number per component:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"IN_WIN/I_VEC3","value":[1.0,2.0,3.0]}}' \
+        localhost:9090/command
+
+The dispatcher (``[widget_dispatch]`` on ``InputStateFloat`` and
+friends) accepts the right JSON shape per state type.
+
+Input vs drag vs slider
+=======================
+
+The three numeric-edit families differ in interaction shape:
+
+* **input** — type the number, optionally with step buttons. Best for
+  precise values where the user already knows the number.
+* **drag** — click and scrub, no fixed track. Best for "tweak this
+  value" with open-ended range.
+* **slider** — click and drag along a fixed-width track between
+  ``v_min`` / ``v_max``. Best for bounded percentages, settings.
+
+All three families share vector / scalar / format conventions. See
+:ref:`tutorial_drag` and :ref:`tutorial_slider`.
+
+Caller-owned variant
+====================
+
+For sites where the value lives on an external scalar (not a widget
+state struct), use the ``edit_input_*`` rail instead — it takes a
+``T?`` pointer via ``safe_addr`` and skips the state-struct allocation:
+
+.. code-block:: das
+
+   var g_mass : float = 1.0f
+   edit_input_float(safe_addr(g_mass), (id = "MASS",
+                                        text = "mass", step = 0.1f))
+
+See :ref:`tutorial_edit_external_tour`.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/input_numeric.das <../../../examples/tutorial/input_numeric.das>`
+
+   Features-side demo: ``examples/features/inputs_numeric.das`` — every
+   numeric input in one window, useful for ``imgui_set`` smoke testing.
+
+   Sibling tutorials: :ref:`tutorial_drag`, :ref:`tutorial_slider`,
+   :ref:`tutorial_input_text`.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/doc/source/tutorials/input_text.rst
+++ b/doc/source/tutorials/input_text.rst
@@ -1,0 +1,199 @@
+.. _tutorial_input_text:
+
+#######################
+Input text widgets
+#######################
+
+The input_text family is **text editing** — single-line, multiline,
+grow-on-overflow, callback-driven, and the inline filter editor. Six
+widgets, one ``InputTextState`` (text_filter uses its own
+``TextFilterState``).
+
+.. code-block:: das
+
+   input_text(IDENT, (text = "..", flags = ImGuiInputTextFlags....))
+   input_text_with_hint(IDENT, (text, hint, flags))
+   input_text_multiline(IDENT, (text, size = float2(w, h), flags))
+   input_text_growable(IDENT, (text, flags))          // CallbackResize plumbed
+   input_text_callback(IDENT, text, flags, cb)        // user lambda on flagged events
+   text_filter(IDENT, (text, width)) + passes_filter(IDENT, line)
+
+Buffer-as-pointer path: state owns ``array<uint8> buffer`` + a string
+mirror. ``input_text_growable`` plumbs ImGui's ``CallbackResize`` through
+a daslang lambda + stack thunk so the buffer expands past
+``state.capacity`` automatically.
+
+Source: ``examples/tutorial/input_text.das``.
+
+************
+Walkthrough
+************
+
+.. raw:: html
+
+   <video autoplay loop muted playsinline width="100%">
+     <source src="../_static/tutorials/input_text.mp4" type="video/mp4">
+     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/input_text.mp4">Download the recording</a>.
+   </video>
+
+.. literalinclude:: ../../../examples/tutorial/input_text.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+Already in the baseline boost layer:
+
+* ``imgui/imgui_widgets_builtin`` — every ``input_text*`` rail +
+  ``text_filter`` + ``passes_filter``.
+* ``imgui/imgui_boost_runtime`` — ``InputTextState`` (buffer + mirror) and
+  ``TextFilterState`` (bound ``ImGuiTextFilter`` inline).
+* ``strings`` — for ``starts_with`` used in the callback completion stage.
+
+Basic and with_hint
+===================
+
+``input_text`` is the single-line editor backed by a fixed-size buffer
+(``state.capacity``, default 256 bytes). ``input_text_with_hint`` adds a
+placeholder rendered when the buffer is empty:
+
+.. code-block:: das
+
+   input_text(NAME, (text = "name"))
+   input_text_with_hint(EMAIL, (text = "email",
+                                hint = "you@example.com"))
+
+Both share ``InputTextState``. ``state.value`` is a clone of the buffer
+content updated each frame.
+
+Multiline
+=========
+
+``input_text_multiline`` accepts CR / LF and exposes a sized text box.
+``size = float2(0, 0)`` lets ImGui pick a default rect — wide and short.
+Pass an explicit ``(w, h)`` for editor-style panels:
+
+.. code-block:: das
+
+   input_text_multiline(BIO, (text = "bio",
+                              size = float2(0.0f, 90.0f)))  // 90px tall
+
+Growable
+========
+
+``input_text_growable`` is the same as ``input_text`` but the buffer
+**resizes itself** when the user types past ``state.capacity``. ImGui's
+``CallbackResize`` event is plumbed through a daslang lambda; the thunk
+holding ``(Context*, LineInfo*, lambda)`` lives on the C call stack for
+the duration of the ``ImGui::InputText`` call:
+
+.. code-block:: das
+
+   input_text_growable(FREE, (text = "free-form"))
+   // state.capacity grows as needed; state.buffer follows
+
+Use this when the input is genuinely free-form (notes, code, long
+URLs); use the fixed-size form when 256 bytes is enough (names, emails,
+identifiers).
+
+Callback
+========
+
+``input_text_callback`` takes an extra ``cb`` arg — a lambda fired by
+ImGui on flagged events. Wire the events you want via ``flags``:
+
+* ``CallbackCompletion`` — TAB pressed
+* ``CallbackHistory`` — Up/Down arrows
+* ``CallbackAlways`` — every frame the field is active
+* ``CallbackCharFilter`` — per-character; return non-zero to reject
+* ``CallbackEdit`` — buffer modified
+* ``CallbackResize`` — buffer overflow (use ``input_text_growable`` for
+  the standard impl)
+
+.. code-block:: das
+
+   input_text_callback(CMD, "command",
+                       ImGuiInputTextFlags.CallbackCompletion,
+                       @(var data : ImGuiInputTextCallbackData) =>
+                           completion_cb(data))
+
+The ``data : ImGuiInputTextCallbackData`` pointer is valid only inside
+the call. ``data.Buf`` is the current buffer; ``DeleteChars`` /
+``InsertChars`` are the in-place edit helpers. Cloning ``data.Buf`` to a
+daslang string + doing the matching in pure das is the common pattern.
+
+text_filter
+===========
+
+``text_filter`` renders an inline ``InputText`` editor whose buffer is
+parsed as comma-separated tokens:
+
+* ``foo,bar`` — pass lines containing ``foo`` OR ``bar``
+* ``-debug`` — exclude lines containing ``debug``
+* ``info,-debug`` — combine
+
+Pair with ``passes_filter(STATE, line) : bool`` to gate output:
+
+.. code-block:: das
+
+   text_filter(FILTER)
+   for (i in range(length(LOG_LINES))) {
+       if (passes_filter(FILTER, LOG_LINES[i])) {
+           text(LOG_LINE[i], (text = LOG_LINES[i]))
+       }
+   }
+
+While the filter expression is empty, ``passes_filter`` returns ``true``
+for every line — the filter is silently disabled until the user types.
+Use ``is_active(STATE)`` to branch on filter-empty vs filter-non-empty
+when you want a different code path (e.g. clipper-cull vs sequential
+scan).
+
+Indexed-form note
+=================
+
+The ``text(IDENT[i], (text = ...))`` form requires you to declare the
+table at module scope:
+
+.. code-block:: das
+
+   var private LOG_LINE : table<int; NarrativeState>
+
+The single-state form (``text(IDENT, (text = ...))``) auto-emits the
+state global from the macro. Indexed form does not — the table key type
+needs the user's hand.
+
+Driving from outside
+====================
+
+``imgui_set`` writes ``state.pending_value`` and the next frame
+overwrites the buffer:
+
+.. code-block:: bash
+
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"IT_WIN/IT_NAME","value":"hello"}}' \
+        localhost:9090/command
+   # Multiline content — embed \n in the JSON string:
+   curl -X POST -d '{"name":"imgui_set","args":{"target":"IT_WIN/IT_BIO","value":"line 1\nline 2"}}' \
+        localhost:9090/command
+
+For ``input_text_growable``, sending a payload longer than current
+``state.capacity`` triggers ``CallbackResize`` on the same frame the
+buffer is consumed.
+
+text_filter is currently **read-only** via telemetry — there's no
+``imgui_set`` path that writes the filter expression. Click the filter
+field and type directly to change it.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/input_text.das <../../../examples/tutorial/input_text.das>`
+
+   Features-side demos: ``examples/features/inputs_text.das`` (all five
+   non-filter forms) and ``examples/features/input_text_callback.das``
+   (canonical TAB-completion).
+
+   Sibling tutorial: :ref:`tutorial_input_numeric`.
+
+   :ref:`Boost macros <stdlib_imgui_boost_section>` — the macro layer.

--- a/examples/tutorial/input_numeric.das
+++ b/examples/tutorial/input_numeric.das
@@ -1,0 +1,126 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: input_numeric widgets — type the number, optionally with
+// +/- step buttons.
+//
+//   input_float(IDENT, (text = "..", step = 0.0f, step_fast = 0.0f,
+//                       format = "%.3f", flags = ImGuiInputTextFlags....))
+//   input_int(IDENT, (text = "..", step = 1, step_fast = 100,
+//                     flags = ImGuiInputTextFlags....))
+//   input_double / input_float2/3/4 / input_int2/3/4 — same shape;
+//   scalar / vector / double-precision variants.
+//
+// Scalar forms get step / step_fast args — non-zero shows ImGui's +/-
+// buttons, click = step, ctrl-click = step_fast. Vector forms (2/3/4)
+// have no step args — the buttons would crowd the row.
+//
+// Default int step = 1 / step_fast = 100; float defaults are 0.0 (no
+// buttons). input_double defaults to 0.0lf (no buttons) with format
+// "%.6f" for the extra precision.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/input_numeric.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/input_numeric.das
+//
+// DRIVE (when running live):
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"IN_WIN/I_FLOAT","value":12.5}}' \
+//        localhost:9090/command
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"IN_WIN/I_VEC3","value":[1.0,2.0,3.0]}}' \
+//        localhost:9090/command
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui input_numeric tutorial", 760, 560)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(720.0f, 520.0f), ImGuiCond.Always)
+    window(IN_WIN, (text = "input_numeric tutorial", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        text("Click to focus, type the number, Enter to commit.")
+        text(I_HINT, (text = "Scalar forms have step / step_fast — non-zero shows +/- buttons."))
+        separator()
+
+        // ---- Stage 1: scalar float with step buttons ----
+        input_float(I_FLOAT, (text = "mass (kg)",
+                              step = 0.1f, step_fast = 1.0f,
+                              format = "%.3f"))
+        text("I_FLOAT.value = {I_FLOAT.value}")
+        spacing()
+
+        // ---- Stage 2: scalar int with step buttons ----
+        input_int(I_INT, (text = "level",
+                          step = 1, step_fast = 100))
+        text("I_INT.value = {I_INT.value}")
+        spacing()
+
+        // ---- Stage 3: vector float3 — no step buttons (vector forms omit them) ----
+        input_float3(I_VEC3, (text = "position", format = "%.2f"))
+        text("I_VEC3.value = ({I_VEC3.value.x}, {I_VEC3.value.y}, {I_VEC3.value.z})")
+        spacing()
+
+        // ---- Stage 4: double precision ----
+        input_double(I_DOUBLE, (text = "epoch (s)",
+                                step = 1.0lf, step_fast = 60.0lf,
+                                format = "%.6f"))
+        text("I_DOUBLE.value = {I_DOUBLE.value}")
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/tutorial/input_text.das
+++ b/examples/tutorial/input_text.das
@@ -1,0 +1,161 @@
+options gen2
+
+require imgui
+require imgui_app
+require glfw/glfw_boost
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live/opengl_live
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+require strings
+
+// =============================================================================
+// TUTORIAL: input_text family — text editing widgets.
+//
+//   input_text(IDENT, (text = "..", flags = ImGuiInputTextFlags....))
+//   input_text_with_hint(IDENT, (text, hint, flags))
+//   input_text_multiline(IDENT, (text, size = float2(w, h), flags))
+//   input_text_growable(IDENT, (text, flags))         — auto-grows buffer
+//   input_text_callback(IDENT, text, flags, cb)       — user callback
+//   text_filter(IDENT, (text, width)) + passes_filter(IDENT, line)
+//
+// Six widgets, six modalities sharing one InputTextState struct (text_filter
+// uses TextFilterState — different shape, integrates with the family).
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/input_text.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/input_text.das
+//
+// DRIVE (when running live):
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"IT_WIN/IT_NAME","value":"hello"}}' \
+//        localhost:9090/command
+//   curl -X POST -d '{"name":"imgui_set","args":{"target":"IT_WIN/IT_BIO","value":"line1\nline2"}}' \
+//        localhost:9090/command
+// =============================================================================
+
+let private COMMANDS <- ["help", "history", "clear", "classify", "echo", "exit"]
+
+let private LOG_LINES <- [
+    "[info] startup complete",
+    "[warn] cache miss for key=42",
+    "[info] connected to api.example.com",
+    "[error] failed to write tmp/foo: disk full",
+    "[info] saved settings",
+    "[debug] frame budget = 16.6ms"
+]
+
+//! Indexed-form text widget requires explicit table declaration at module scope.
+var private IT_LINE : table<int; NarrativeState>
+
+
+def private completion_cb(var data : ImGuiInputTextCallbackData) : int {
+    if (data.EventFlag == ImGuiInputTextFlags.CallbackCompletion) {
+        let prefix = clone_string(data.Buf)
+        var matches <- [for (c in COMMANDS); c; where c |> starts_with(prefix)]
+        if (length(matches) == 1) {
+            data |> DeleteChars(0, data.BufTextLen)
+            data |> InsertChars(0, matches[0])
+        }
+        delete matches
+    }
+    return 0
+}
+
+[export]
+def init() {
+    live_create_window("dasImgui input_text tutorial", 760, 760)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(720.0f, 720.0f), ImGuiCond.Always)
+    window(IT_WIN, (text = "input_text tutorial", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        // ---- Stage 1: basic input_text ----
+        input_text(IT_NAME, (text = "name"))
+        text("IT_NAME.value = '{IT_NAME.value}'  (capacity={IT_NAME.capacity})")
+        spacing()
+
+        // ---- Stage 2: with_hint — placeholder when empty ----
+        input_text_with_hint(IT_EMAIL, (text = "email",
+                                        hint = "you@example.com"))
+        text("IT_EMAIL.value = '{IT_EMAIL.value}'")
+        spacing()
+
+        // ---- Stage 3: multiline — CR/LF tolerant, sized box ----
+        input_text_multiline(IT_BIO, (text = "bio",
+                                      size = float2(0.0f, 90.0f)))
+        text("IT_BIO length = {length(IT_BIO.value)} bytes")
+        spacing()
+
+        // ---- Stage 4: growable — buffer expands past `capacity` automatically ----
+        input_text_growable(IT_FREE, (text = "free-form"))
+        text("IT_FREE capacity = {IT_FREE.capacity}, length = {length(IT_FREE.value)}")
+        spacing()
+
+        // ---- Stage 5: callback — TAB completes against COMMANDS dictionary ----
+        text("Type a prefix (h/cla/ex) and press TAB:")
+        if (input_text_callback(IT_CMD, "command",
+                                ImGuiInputTextFlags.CallbackCompletion,
+                                @(var data : ImGuiInputTextCallbackData) =>
+                                    completion_cb(data))) {}
+        spacing()
+        separator()
+
+        // ---- Stage 6: text_filter — incl,-excl token filter ----
+        text("text_filter — type 'info' or '-debug' to filter the log:")
+        text_filter(IT_FILTER)
+        for (i in range(length(LOG_LINES))) {
+            if (passes_filter(IT_FILTER, LOG_LINES[i])) {
+                text(IT_LINE[i], (text = LOG_LINES[i]))
+            }
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -72,8 +72,9 @@ $env:DASLANG_EXE = "D:/Work/daScript/bin/Release/daslang.exe"
 
 # Whole sweep (all drivers found via glob, ~20 min):
 pwsh tests/integration/rerecord_all.ps1
-# OR single driver:
-daslang.exe -project_root . tests/integration/record_X.das
+# OR single driver (uses the env var set above; works whether or
+# not daslang.exe is on PATH):
+& $env:DASLANG_EXE -project_root . tests/integration/record_X.das
 ```
 
 Step 2 — eyeball-review the resulting `.apng` files in
@@ -116,10 +117,11 @@ Get-ChildItem *.apng | ForEach-Object {
 }
 ```
 
-Step 4 — stage + push:
+Step 4 — stage, commit, push:
 
 ```bash
 git add doc/source/_static/tutorials/*.mp4
+git commit -m "docs: re-record tutorial videos"
 git push -u origin <branch>
 ```
 
@@ -143,7 +145,8 @@ For a new tutorial `foo`:
 3. Eyeball-review. ffmpeg-extract frames if needed.
 4. ffmpeg-convert `foo.apng` → `foo.mp4` (see step 3 of the workflow above).
 5. Write `doc/source/tutorials/foo.rst` + add to `index.rst` toctree.
-6. `git add foo.mp4 record_foo.das foo.rst index.rst` + push.
+6. Stage + commit + push: `git add foo.mp4 record_foo.das foo.rst index.rst`,
+   `git commit -m "tutorial: foo"`, `git push -u origin <branch>`.
 
 ### Historical note: orphan `assets` branch
 

--- a/tests/integration/record_input_numeric.das
+++ b/tests/integration/record_input_numeric.das
@@ -1,0 +1,124 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``input_numeric.apng`` against
+//! ``examples/tutorial/input_numeric.das``. Tours four numeric-input
+//! forms — scalar float, scalar int, vector float3, double — and drives
+//! ``imgui_set`` on each so the on-screen values visibly change during
+//! the narration window.
+//!
+//! Recorder fps = 30 (halved from 60) — input fields don't animate
+//! between events, so 30 fps keeps the file tight without visible
+//! jitter.
+
+let NARRATE_FRAMES = 180        //! 6s visible at the app's 30 fps target
+let READ_MS        = 3500u      //! 3.5s read window per stage
+let SETTLE_MS      = 1200u      //! 1.2s cursor settle
+let SET_DWELL_MS   = 1500u      //! 1.5s post-imgui_set dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/input_numeric.das",
+                       "input_numeric.apng", 50, 30) $(app) {
+        let T_FLOAT  = "IN_WIN/I_FLOAT"
+        let T_INT    = "IN_WIN/I_INT"
+        let T_VEC3   = "IN_WIN/I_VEC3"
+        let T_DOUBLE = "IN_WIN/I_DOUBLE"
+
+        var snap = wait_for_widget(app, T_FLOAT, 10.0f)
+        if (snap == null) {
+            panic("{T_FLOAT} never registered — wrong app running?")
+        }
+        let p_float  = widget_center(snap, T_FLOAT)
+        let p_int    = widget_center(snap, T_INT)
+        let p_vec3   = widget_center(snap, T_VEC3)
+        let p_double = widget_center(snap, T_DOUBLE)
+
+        //! Initial cursor placement.
+        move_to(app, p_float, 500)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: scalar float — narrate AND drive value ----
+        post_command(app, "imgui_set", JV((target = T_FLOAT, value = 2.5f)))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_float — click to focus, type, Enter to commit. step / step_fast surface +/- buttons; ctrl-click = step_fast.",
+            target = T_FLOAT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: scalar int ----
+        move_to(app, p_int, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_INT, value = 42)))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_int — defaults step=1, step_fast=100. Buttons visible by default.",
+            target = T_INT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: vector float3 ----
+        move_to(app, p_vec3, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_VEC3, value = (1.0f, 2.0f, 3.0f))))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_float3 — three text fields, no step args. Tab cycles components; Enter commits the row.",
+            target = T_VEC3,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: double precision ----
+        move_to(app, p_double, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_DOUBLE, value = 6.283185lf)))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_double — same shape as input_float, double precision (default format %.6f). For time / coords past 7 digits.",
+            target = T_DOUBLE,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 5: drive all to fresh values to show channel ----
+        move_to(app, p_float, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_FLOAT, value = 0.5f)))
+        post_command(app, "imgui_set", JV((target = T_INT, value = 7)))
+        post_command(app, "imgui_set", JV((target = T_VEC3, value = (4.0f, 5.0f, 6.0f))))
+        post_command(app, "imgui_set", JV((target = T_DOUBLE, value = 3.141592lf)))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "imgui_set writes state.pending_value; next frame consumes it. Same channel for scalar, vector, double.",
+            target = T_FLOAT,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}

--- a/tests/integration/record_input_text.das
+++ b/tests/integration/record_input_text.das
@@ -1,0 +1,131 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require imgui public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Driver script: record ``input_text.apng`` against
+//! ``examples/tutorial/input_text.das``. Tours six text-input forms —
+//! basic, with_hint, multiline, growable, callback (TAB completion),
+//! and text_filter — and drives one buffer via ``imgui_set``.
+
+let NARRATE_FRAMES = 180        //! 6s visible at the app's 30 fps target
+let READ_MS        = 3500u      //! 3.5s read window per stage
+let SETTLE_MS      = 1200u      //! 1.2s cursor settle
+let SET_DWELL_MS   = 1500u      //! 1.5s post-imgui_set dwell
+
+def widget_bbox(var snap : JsonValue?; ident : string) : float4 {
+    var b = snap?["globals"]?[ident]?["bbox"]
+    return float4(
+        b?["x"] ?? 0.0f,
+        b?["y"] ?? 0.0f,
+        b?["z"] ?? 0.0f,
+        b?["w"] ?? 0.0f
+    )
+}
+
+def widget_center(var snap : JsonValue?; ident : string) : tuple<float; float> {
+    let b = widget_bbox(snap, ident)
+    return ((b.x + b.z) * 0.5f, (b.y + b.w) * 0.5f)
+}
+
+[export]
+def main {
+    with_recording_app("examples/tutorial/input_text.das",
+                       "input_text.apng", 60, 30) $(app) {
+        let T_NAME   = "IT_WIN/IT_NAME"
+        let T_EMAIL  = "IT_WIN/IT_EMAIL"
+        let T_BIO    = "IT_WIN/IT_BIO"
+        let T_FREE   = "IT_WIN/IT_FREE"
+        let T_CMD    = "IT_WIN/IT_CMD"
+        let T_FILTER = "IT_WIN/IT_FILTER"
+
+        var snap = wait_for_widget(app, T_NAME, 10.0f)
+        if (snap == null) {
+            panic("{T_NAME} never registered — wrong app running?")
+        }
+        let p_name   = widget_center(snap, T_NAME)
+        let p_email  = widget_center(snap, T_EMAIL)
+        let p_bio    = widget_center(snap, T_BIO)
+        let p_free   = widget_center(snap, T_FREE)
+        let p_cmd    = widget_center(snap, T_CMD)
+        let p_filter = widget_center(snap, T_FILTER)
+
+        //! Initial cursor placement.
+        move_to(app, p_name, 600)
+        sleep(SETTLE_MS)
+
+        // ---- Stage 1: basic input_text — drive a value during narration ----
+        post_command(app, "imgui_set", JV((target = T_NAME, value = "Ada Lovelace")))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_text(IDENT, (text)) — single-line, fixed 256-byte buffer. state.value mirrors the C++ buffer each frame.",
+            target = T_NAME,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 2: with_hint — set then clear to show placeholder ----
+        move_to(app, p_email, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_EMAIL, value = "ada@analytical.engine")))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_text_with_hint — extra 'hint' arg shows as placeholder when the buffer is empty.",
+            target = T_EMAIL,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 3: multiline ----
+        move_to(app, p_bio, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_BIO, value = "Note No. 1: Charles Babbage\nNote No. 2: Analytical Engine\nNote No. 3: First algorithm")))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_text_multiline — CR/LF tolerant. size = (w, h); (0, 0) lets ImGui pick a default wide-short rect.",
+            target = T_BIO,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 4: growable — drive payload past 256B to trigger CallbackResize ----
+        move_to(app, p_free, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_FREE,
+                                           value = "The Analytical Engine has no pretensions whatever to originate anything. It can do whatever we know how to order it to perform. It can follow analysis; but it has no power of anticipating any analytical relations or truths.")))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_text_growable — buffer auto-resizes past state.capacity via ImGui's CallbackResize. Plumbed through a daslang lambda + stack thunk.",
+            target = T_FREE,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 5: callback (TAB completion) ----
+        move_to(app, p_cmd, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_set", JV((target = T_CMD, value = "cla")))
+        sleep(SET_DWELL_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "input_text_callback — user lambda fires on flagged events. CallbackCompletion = TAB; CallbackHistory = Up/Down. data pointer valid inside the call.",
+            target = T_CMD,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+
+        // ---- Stage 6: text_filter ----
+        move_to(app, p_filter, 800)
+        sleep(SETTLE_MS)
+        post_command(app, "imgui_narrate", JV((
+            text = "text_filter — inline InputText editor that parses comma-separated incl,-excl tokens. Pair with passes_filter(STATE, line) to gate output.",
+            target = T_FILTER,
+            frames = NARRATE_FRAMES
+        )))
+        sleep(READ_MS)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **two new widget tutorial triads** (`examples/tutorial/X.das` + `tests/integration/record_X.das` + `doc/source/tutorials/X.rst`) covering 15 widgets across 2 pages:
  - **input_numeric** — 4 stages: scalar float w/ step buttons, scalar int, vector float3, double
  - **input_text** — 6 stages: input_text, with_hint, multiline, growable, callback (TAB completion), text_filter
- Lands on top of #73 (APNG→MP4): both RSTs embed `<video>` with accessibility fallback; the `.mp4` files ship in-tree (~165 KB + ~274 KB).
- Bundles 2 PR #73 Copilot R2 nits for `tests/integration/README.md` (per the bundle-with-next-PR rule):
  - Step 1 single-driver example switched from `daslang.exe …` (PATH-dependent) to `& $env:DASLANG_EXE …`, consistent with the env var set one block above.
  - Steps 4 and 6 said "stage + push" but omitted `git commit`. Added explicit `git commit -m "…"` lines.

(One R2 comment skipped: it claimed the bash workflow blocks were miscategorized as powershell — already correctly tagged `bash` after PR #73's R1 fix.)

## Test plan

- [x] `sphinx-build -W -b html doc/source` — clean, no warnings.
- [x] Drivers re-recorded at 30 fps with `imgui_set` interleaved per stage so narration reads as the value visibly changes.
- [x] MP4s preview correctly in browser; `<video>` fallback text renders for users without H.264 support.
- [ ] CI green.

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;