### PR TITLE
ci+playwright: belt+suspenders fix for Windows test sweep timeouts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,11 +195,22 @@ jobs:
         run: |
           set -eux
           EXTRA_EXCLUDES=""
+          # dastest's total-sweep timeout defaults to 600s. The Windows runner
+          # is ~3-5x slower per test than local Windows (heavy daslang-live
+          # compile + GLFW shared_module load + ImGui ctx setup repeated per
+          # spawned subprocess); the full sweep takes ~10-11 min on a slow
+          # runner instance, which trips the default cap. Local Windows runs
+          # the same sweep in ~5 min. Bump to 1800s (30 min) to give slow
+          # runner instances headroom; on a fast instance the sweep finishes
+          # in ~5 min and the cap never matters.
+          DASTEST_TIMEOUT=600
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             EXTRA_EXCLUDES="--exclude inputs_drag --exclude inputs_numeric --exclude inputs_slider --exclude inputs_color --exclude inputs_choice --exclude inputs_text --exclude indexed_dynamic"
+            DASTEST_TIMEOUT=1800
           fi
           ${BIN_DIR}/daslang dastest/dastest.das -- \
             --test modules/dasImgui/tests/integration \
+            --timeout $DASTEST_TIMEOUT \
             --exclude glfw_synth \
             --exclude key_hud \
             $EXTRA_EXCLUDES \

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -29,7 +29,11 @@ let DEFAULT_RELOAD_TIMEOUT_SEC : float = 30.0f       // POST /reload to /status.
 let DEFAULT_FRAME_WAIT_SEC : float = 10.0f           // upper bound on "first frame to render the named widget"
 
 let READY_POLL_INTERVAL_MS : uint = 100u             // ms between /status polls — wait_until_ready and reload convergence
-let FRAME_POLL_INTERVAL_MS : uint = 50u              // ms between snapshot polls — ~3 polls/frame at 60fps
+let FRAME_POLL_INTERVAL_MS : uint = 100u             // ms between snapshot polls — 10 req/sec; under libhv's Windows
+                                                     // event-loop cap (~16 req/sec) that previously stalled the test
+                                                     // sweep on heavy imgui_demo harnesses (see tests.yml comment).
+                                                     // ~1.5 polls/frame at 60fps — still snappy in practice; most
+                                                     // wait_for_widget calls complete in 1-2 polls anyway.
 
 struct ImguiApp {
     base_url : string


### PR DESCRIPTION
## Summary

Master is red on Windows since PR #75 with `Test timed out after 600s` — dastest's **total-sweep cap** firing because the Windows GHA runner takes ~10-11 min for the full integration sweep on slow runner instances. Two complementary fixes:

**1. `playwright: throttle FRAME_POLL_INTERVAL_MS 50ms → 100ms`** (commit 310c49f)
- `wait_for_widget` / `wait_for_render` polled at 20 req/sec, over libhv's documented Windows ~16 req/sec event-loop cap (see `tests.yml:178-191`).
- 100ms = 10 req/sec gives 2× headroom under the cap. Most polls complete in 1-2 iterations; ~1.5 polls/frame at 60fps is still snappy.

**2. `ci: bump dastest total-sweep timeout 600s → 1800s on Windows`** (commit 02b517e)
- Windows GHA runner is 3-5× slower per test than local Windows (local sweep: 318s for 128 tests; CI Windows: 600s+ for the same sweep, hitting the cap).
- Pass `--timeout 1800` to dastest only on Windows; Linux/macOS keep the 600s default (they finish in 7-8 min).
- Belt + suspenders with the throttle: the throttle reduces sustained req rate, the timeout bump gives slow runner instances room.

## Root cause investigation

- Master is **red on Windows since PR #75 merge** — same `Test timed out after 600s` message.
- Two consecutive PR #77 reruns failed on **different tests** (`test_imgui_demo_widgets_smoke`, then `test_imgui_demo_style_editor_smoke`). Not test-specific.
- `Test timed out after 600s` is `dastest.das:532` `timeout_tests` — the **total-sweep cap** (default 600s in `dastest_clargs.das:19`), not per-test.
- `FAILED! (630.030323s)` matches the budget: 600s + cleanup.
- Local Windows repro: 128 tests / 318s — no timeout, no libhv stall. CI is just slow.

## Test plan

- [x] `daslang.exe -compile-only` clean on `widgets/imgui_playwright.das`.
- [x] `format_file` already_formatted.
- [x] Local Windows full sweep: 318s, 128 tests, no timeout.
- [ ] CI green on Windows with both fixes in place.

## Follow-up

Once this lands and master is green for several cycles, the Windows `EXTRA_EXCLUDES` list in `tests.yml` may be trimmable (the 7 tests on it were excluded for the same libhv-stall reason). Try re-including them in a separate PR.

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;