### PR TITLE
integration tests: parallel 4-way via per-worker live-API port

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,6 +162,15 @@ jobs:
         # get_user_args(); playwright forwards it to every spawned daslang-live
         # via popen_argv. No xvfb wrapper needed — no display is opened.
         #
+        # --isolated-mode + --isolated-mode-threads 4: each test runs in its
+        # own subprocess, with 4 in parallel. dastest (PR #2894) brands each
+        # subprocess cmd with `--worker-index N` (N in 0..3); imgui_playwright
+        # reads that flag via get_user_args() and derives a per-worker live-API
+        # port (9090 + N), passed to daslang-live as `--live-port`. Without
+        # the per-worker port, all 4 daslang-live children would race to bind
+        # port 9090. With it, ports 9090/9091/9092/9093 are independent and
+        # workers don't collide. Expected ~3× wall-time reduction vs sequential.
+        #
         # DASLIVE_HV_LOG=stderr: redirect libhv's logger to stderr so we see
         # event-loop/accept diagnostics in CI output. Env propagates to the
         # spawned daslang-live subprocess via popen_argv's inherited env.
@@ -211,6 +220,8 @@ jobs:
           ${BIN_DIR}/daslang dastest/dastest.das -- \
             --test modules/dasImgui/tests/integration \
             --timeout $DASTEST_TIMEOUT \
+            --isolated-mode \
+            --isolated-mode-threads 4 \
             --exclude glfw_synth \
             --exclude key_hud \
             $EXTRA_EXCLUDES \

--- a/doc/source/stdlib/handmade/module-imgui_playwright.rst
+++ b/doc/source/stdlib/handmade/module-imgui_playwright.rst
@@ -3,8 +3,10 @@ process, configures a transport (HTTP by default), and runs a test block
 against the live registry — click a widget by path, set a value, await
 quiescence, snapshot the surface, expect a value or render state. The
 ``with_imgui_app(...) { ... }`` lifecycle handles launch / handshake /
-shutdown so each test stays a single block; ``with_imgui_app_opt`` is the
-variant that returns instead of panicking on launch failure.
+shutdown so each test stays a single block. The live-API port is derived
+from ``DEFAULT_LIVE_PORT + worker_index`` (dastest's isolated-mode flag
+``--worker-index N``), so N parallel workers land on distinct ports and
+never collide.
 
 Locators (``find_widget``, ``widget_exists``, ``widget_payload_field``,
 ``widget_rendered``) resolve via the same path keys the boost registry

--- a/skills/recording.md
+++ b/skills/recording.md
@@ -128,7 +128,7 @@ The `widgets/imgui_playwright.das` module exposes:
 
 - `with_recording_app(feature_path, output_basename, max_seconds, body)` — 3-arg form (fps=30 default). Spawns daslang-live for `<dasimgui>/<feature_path>`, posts record_start/stop bracket around `body`, shuts down. APNG lands at `<dasimgui>/doc/source/_static/tutorials/<output_basename>`.
 - `with_recording_app(feature_path, output_basename, max_seconds, fps, body)` — 4-arg form for explicit fps (typically 20 for long captures).
-- `with_imgui_app(feature_path, body)` / `with_imgui_app_opt(...)` — the playwright-test cousin (for `[test] def …(t : T?)` files). Forwards `--headless` from the parent. Recording uses the `_recording_` variant instead because it needs the GL framebuffer.
+- `with_imgui_app(feature_path, body)` — the playwright-test cousin (for `[test] def …(t : T?)` files). Forwards `--headless` from the parent; derives the live-API port from `DEFAULT_LIVE_PORT + worker_index` so dastest's `--isolated-mode --isolated-mode-threads N` parallel workers don't collide. Recording uses the `_recording_` variant instead because it needs the GL framebuffer.
 - `move_to(app, pos, duration_ms = 600)` — lerps cursor from last tracked position to `pos`; updates the tracked pos for the next call.
 - `click_at(var events, t_ms, pos, travel_ms = 500, button = 0)` — appends lerp + press + release + dwell to an events array. Call `post_command(app, "imgui_mouse_play", JV((events = events)))` to fire.
 - `drag_along(var events, t_ms, from_pos, to_pos, drag_ms, approach_ms = 400)` — lerp-to-start + press + drag + release.

--- a/tests/integration/test_lifecycle.das
+++ b/tests/integration/test_lifecycle.das
@@ -15,8 +15,8 @@ let TRIGGERS_FEATURE = "modules/dasImgui/examples/features/triggers.das"
 
 [test]
 def test_spawn_and_shutdown(t : T?) {
-    with_imgui_app_opt(TRIGGERS_FEATURE, 9090, 30.0f, 30.0f) $(d) {
-        // Body intentionally empty. with_imgui_app_opt's prelude already gated
+    with_imgui_app(TRIGGERS_FEATURE) $(d) {
+        // Body intentionally empty. with_imgui_app's prelude already gated
         // on /status; the postlude POSTs /shutdown and drains. If we get
         // here, daslang-live is alive and answering HV.
     }

--- a/tests/integration/test_snapshot.das
+++ b/tests/integration/test_snapshot.das
@@ -19,7 +19,7 @@ let TRIGGERS_FEATURE = "modules/dasImgui/examples/features/triggers.das"
 
 [test]
 def test_one_snapshot(t : T?) {
-    with_imgui_app_opt(TRIGGERS_FEATURE, 9090, 30.0f, 30.0f) $(d) {
+    with_imgui_app(TRIGGERS_FEATURE) $(d) {
         var snap = wait_for_widget(d, "MAIN_WIN/SAVE_BTN", 15.0f)
         t |> success(snap != null, "snapshot returned non-null payload with MAIN_WIN/SAVE_BTN registered")
     }

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -579,16 +579,6 @@ def public reload(app : ImguiApp; timeout_sec : float = DEFAULT_RELOAD_TIMEOUT_S
     panic("reload did not converge on a clean compile within {timeout_sec}s")
 }
 
-def public with_imgui_app(feature_path : string; body : block<(app : ImguiApp) : void>) {
-    //! Convenience form using the module-level default port + timeouts.
-    //! For non-default knobs, use `with_imgui_app_opt`.
-    with_imgui_app_opt(feature_path,
-                       DEFAULT_LIVE_PORT,
-                       DEFAULT_READY_TIMEOUT_SEC,
-                       DEFAULT_TEST_TIMEOUT_SEC,
-                       body)
-}
-
 var private g_headless_parsed : bool = false
 var private g_headless_cached : bool = false
 
@@ -606,29 +596,58 @@ def private playwright_wants_headless() : bool {
     return g_headless_cached
 }
 
-def public with_imgui_app_opt(feature_path : string;
-                              port : int;
-                              ready_timeout_sec : float;
-                              test_timeout_sec : float;
-                              body : block<(app : ImguiApp) : void>) {
-    //! Spawn ``daslang-live <feature_path>``; runs ``body`` while alive, then POSTs ``/shutdown`` and drains stdout.
-    //! Panics on non-zero exit code, ready-timeout, or test-timeout so the surrounding ``[test]`` fails.
+var private g_worker_index_parsed : bool = false
+var private g_worker_index_cached : int = 0
+
+def private playwright_worker_index() : int {
+    //! ``--worker-index N`` forwarded from dastest's isolated-mode worker.
+    //! Lazily parsed once. Used by ``with_imgui_app`` to derive a per-worker
+    //! live-API port (DEFAULT_LIVE_PORT + worker_index), so N parallel
+    //! dastest workers don't collide on the same TCP port. Defaults to 0
+    //! when absent (sequential mode), giving the same port the codebase has
+    //! always used.
+    if (g_worker_index_parsed) return g_worker_index_cached
+    g_worker_index_parsed = true
+    let args <- get_user_args()
+    let raw = find_flag_raw_value(args, "--worker-index") |> unwrap_or("0")
+    g_worker_index_cached = to_int(raw)
+    return g_worker_index_cached
+}
+
+def public with_imgui_app(feature_path : string;
+                          body : block<(app : ImguiApp) : void>) {
+    //! Spawn ``daslang-live <feature_path>``; runs ``body`` while alive, then
+    //! POSTs ``/shutdown`` and drains stdout. Panics on non-zero exit code,
+    //! ready-timeout, or test-timeout so the surrounding ``[test]`` fails.
+    //!
+    //! Port is always DEFAULT_LIVE_PORT + worker_index — sequential runs (no
+    //! --worker-index in argv) get 9090; dastest's isolated mode brands each
+    //! worker's subprocess argv with --worker-index N so N parallel workers
+    //! land on distinct ports (9090..9090+N-1) and don't collide.
+    //!
     //! Forwards ``--headless`` (read from this process's ``get_user_args()``)
     //! into the spawn so the harness's headless arm fires inside the subprocess.
     let exe = daslang_live_exe()
+    let port = DEFAULT_LIVE_PORT + playwright_worker_index()
+    let ready_timeout_sec = DEFAULT_READY_TIMEOUT_SEC
+    let test_timeout_sec = DEFAULT_TEST_TIMEOUT_SEC
     let app_path = resolve_feature_path(feature_path)
     // -load_module points the spawned daslang-live at the dasImgui module so
     // the feature's `require imgui/...` chain resolves regardless of layout.
     // In CI dasImgui is in the standard module search path so this is a
     // harmless duplicate; locally it's load-bearing.
-    var argv <- [exe, "-load_module", dasimgui_module_root(), app_path]
+    //
+    // --live-port pins the spawned daslang-live's HTTP API to the same port
+    // playwright's base_url targets, so daslang-live's single-instance-lock
+    // keys off the same port playwright dials.
+    var argv <- [exe, "-load_module", dasimgui_module_root(), "--live-port={port}", app_path]
     if (playwright_wants_headless()) {
         argv |> push("--")
         argv |> push("--headless")
         // Cascade guard: harness self-exits a few seconds before the popen
         // watchdog gives up. If body panics and /shutdown is never sent
         // (e.g. expect_value timeout — daslang's `finally` is skipped on
-        // panic), the subprocess still releases port 9090 before the next
+        // panic), the subprocess still releases its port before the next
         // test spawns, instead of zombifying.
         let harness_budget = test_timeout_sec - 5.0f
         if (harness_budget > 5.0f) {


### PR DESCRIPTION
## Summary

CI integration sweep currently runs sequentially (~10-11 min on slow Windows runners). This PR flips it to `--isolated-mode --isolated-mode-threads 4` for ~3× wall-time reduction.

The blocker was port collision: every spawned daslang-live tries to bind port 9090 (from `widgets/imgui_playwright.das`). 4 parallel workers → only one wins the per-port single-instance lock, the other three fail. Fix has two halves:

- **dastest side (daslang [PR #2894](https://github.com/GaijinEntertainment/daScript/pull/2894), merged)**: brand each isolated-mode subprocess cmd with `--worker-index N`. Also bundles `--headless` forwarding (latent bug — isolated mode + headless never combined before).
- **playwright side (this PR)**: read `--worker-index N` from `get_user_args()`, derive port as `DEFAULT_LIVE_PORT + worker_index`, push `--live-port={port}` into the spawned daslang-live argv so its C++ single-instance lock and playwright's HTTP base_url see the same port.

## API simplification — `with_imgui_app_opt` removed

`test_lifecycle.das` and `test_snapshot.das` were calling `with_imgui_app_opt(TRIGGERS, 9090, 30.0f, 30.0f)` — hardcoded port = default, ready_timeout = default, test_timeout = 30s (only real override). No actual need for any of it. Both collapse to the simple `with_imgui_app(feature)` form like every other integration test. Removing the API surface that let them hardcode anything kills the foot-gun.

## CI

`.github/workflows/tests.yml`: add `--isolated-mode --isolated-mode-threads 4`, plus a comment block explaining the worker-index → port plumbing.

## Required upstream PRs (both merged to daslang master)

- **[GaijinEntertainment/daScript#2894](https://github.com/GaijinEntertainment/daScript/pull/2894)** (merged): dastest forwards `--worker-index N` + `--headless` in isolated-mode subprocess cmd.
- **[GaijinEntertainment/daScript#2897](https://github.com/GaijinEntertainment/daScript/pull/2897)** (pending merge): dastest preserves every pre-`--` daslang flag (needed for local `-load_module` workflows; CI doesn't exercise this path, so PR-I CI is unblocked once #2894 is in master, which it is).

## Test plan

- [x] 4-test controlled sweep: 4/4 pass in 12s (worker_index 0/1/2/3 → ports 9090/9091/9092/9093).
- [x] Full 127-test sweep with CI exclusions (`--isolated-mode --isolated-mode-threads 4 --headless`): 127/127 pass, 0 failures, 0 errors.
- [x] Sequential mode still works (no `--worker-index` in argv → default port 9090).
- [x] Lint clean on all changed `.das` files.
- [ ] CI green on Ubuntu / macOS / Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)