### PR TITLE
integration tests: backfill 8 med+low priority gaps (PR-2)

### DIFF
--- a/tests/integration/test_align_text_to_frame_padding.das
+++ b/tests/integration/test_align_text_to_frame_padding.das
@@ -1,0 +1,58 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+require math
+
+//! Integration smoke for `align_text_to_frame_padding` — vertically aligns
+//! the next text() baseline with a framed sibling (button/input/slider) on
+//! the same row. Two rows: A (bare text + button, top-aligned) vs B (align
+//! prefix + text + button, baseline-shifted). Verifies the widget kind and
+//! the geometry contract: Row B's label/button vertical gap is smaller
+//! than Row A's because the align prefix lifts LABEL_B into the frame's
+//! vertical centre.
+
+let FEATURE = "modules/dasImgui/examples/features/align_text_to_frame_padding.das"
+
+[test]
+def test_align_text_to_frame_padding_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/LABEL_A", 15.0f)
+        t |> success(snap != null, "LABEL_A registers")
+        if (snap == null) return
+
+        let align = find_widget(snap, "MAIN_WIN/ALIGN_B")
+        t |> equal(align?["kind"] ?? "", "align_text_to_frame_padding",
+                   "ALIGN_B.kind == 'align_text_to_frame_padding'")
+
+        for (ident in ["LEAD", "BTN_A", "LABEL_B", "BTN_B"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "{ident} registers")
+        }
+
+        let lab_a_y = find_widget(snap, "MAIN_WIN/LABEL_A")?["bbox"]?["y"] ?? 0.0f
+        let lab_b_y = find_widget(snap, "MAIN_WIN/LABEL_B")?["bbox"]?["y"] ?? 0.0f
+        let btn_a_y = find_widget(snap, "MAIN_WIN/BTN_A")?["bbox"]?["y"] ?? 0.0f
+        let btn_b_y = find_widget(snap, "MAIN_WIN/BTN_B")?["bbox"]?["y"] ?? 0.0f
+
+        // Row B is on a later row than Row A.
+        t |> success(lab_b_y > lab_a_y,
+                     "LABEL_B.y ({lab_b_y}) > LABEL_A.y ({lab_a_y})")
+
+        // Row A: bare text sits at the line top — label.y == button.y.
+        // Row B: align_text_to_frame_padding shifts LABEL_B's baseline down
+        // by FramePadding.y so it aligns with BTN_B's vertical centre, so
+        // label.y > button.y. The shift delta is bigger in B than in A.
+        let row_a_shift = lab_a_y - btn_a_y
+        let row_b_shift = lab_b_y - btn_b_y
+        t |> success(row_b_shift > row_a_shift,
+                     "Row B label shifted down ({row_b_shift}) > Row A ({row_a_shift})")
+        t |> success(row_b_shift > 0.0f,
+                     "Row B label is below button top (shift {row_b_shift} > 0)")
+    }
+}

--- a/tests/integration/test_edit_collapsing_header.das
+++ b/tests/integration/test_edit_collapsing_header.das
@@ -1,0 +1,56 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `edit_collapsing_header` — closable CollapsingHeader
+//! bidir-bound to a caller-owned `bool? p_open`. Verifies kind, initial bool
+//! value, set_value dispatch through the [edit_widget] scalar-pointee path
+//! (sscan_json_at writes through *ptr), and recovery via the RESTORE_A button.
+
+let FEATURE = "modules/dasImgui/examples/features/edit_collapsing_header.das"
+
+[test]
+def test_edit_collapsing_header_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/HDR_A", 15.0f)
+        t |> success(snap != null, "HDR_A registers")
+        if (snap == null) return
+
+        let hdr_a = find_widget(snap, "MAIN_WIN/HDR_A")
+        t |> equal(hdr_a?["kind"] ?? "", "edit_collapsing_header",
+                   "HDR_A.kind == 'edit_collapsing_header'")
+        t |> success(widget_exists(snap, "MAIN_WIN/HDR_B"), "HDR_B registers")
+
+        // Initial state — both VISIBLE_A and VISIBLE_B start true; the bool
+        // payload echoes *ptr on every frame.
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/HDR_A", "value") ?? false,
+                   true,
+                   "HDR_A.value == true initially (VISIBLE_A = true)")
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/HDR_B", "value") ?? false,
+                   true,
+                   "HDR_B.value == true initially (VISIBLE_B = true)")
+
+        // Surrounding siblings + sentinel STATUS line render.
+        for (ident in ["LEAD", "SEP", "RESTORE_A", "RESTORE_B", "STATUS"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "{ident} registers")
+        }
+
+        // Bidir-bind A→false via imgui_set; scalar-pointee dispatcher writes
+        // through *ptr (VISIBLE_A := false), header hides next frame.
+        set_value(d, "MAIN_WIN/HDR_A", JV(false))
+        t |> success(wait_for_bool_value(d, "MAIN_WIN/HDR_A", "value", false, 300),
+                     "HDR_A.value flips to false after set_value")
+
+        // RESTORE_A button writes VISIBLE_A := true; reverse-direction proof.
+        click(d, "MAIN_WIN/RESTORE_A")
+        t |> success(wait_for_bool_value(d, "MAIN_WIN/HDR_A", "value", true, 300),
+                     "HDR_A.value back to true after RESTORE_A click")
+    }
+}

--- a/tests/integration/test_imgui_synth_keys.das
+++ b/tests/integration/test_imgui_synth_keys.das
@@ -1,0 +1,41 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the ImGui-bypass synthetic keyboard driver —
+//! exercises `imgui_focus` + `imgui_key_type` (and the underlying
+//! `imgui_key_*` event-queue layer in `widgets/imgui_live_core.das`).
+//! Distinct from `test_glfw_synth_keys.das` which drives the GLFW backend
+//! layer; this one bypasses GLFW entirely and feeds chars straight into
+//! ImGui's input queue.
+
+let FEATURE = "modules/dasImgui/examples/features/imgui_synth_keys.das"
+
+[test]
+def test_imgui_synth_keys_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/NAME_INPUT", 15.0f)
+        t |> success(snap != null, "NAME_INPUT registers")
+        if (snap == null) return
+
+        let input = find_widget(snap, "MAIN_WIN/NAME_INPUT")
+        t |> equal(input?["kind"] ?? "", "input_text",
+                   "NAME_INPUT.kind == 'input_text'")
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/NAME_INPUT", "value") ?? "?",
+                   "",
+                   "NAME_INPUT.value initially empty")
+
+        // Focus then type via the ImGui-bypass path.
+        post_command(d, "imgui_focus", JV((target = "MAIN_WIN/NAME_INPUT")))
+        post_command(d, "imgui_key_type", JV((text = "Hello", per_char_ms = 30)))
+        t |> success(wait_for_key_idle(d, 4.0f), "key timeline drains")
+        t |> success(wait_for_string_value(d, "MAIN_WIN/NAME_INPUT", "value", "Hello", 300),
+                     "NAME_INPUT.value == 'Hello' after imgui_key_type")
+    }
+}

--- a/tests/integration/test_imgui_synth_mouse.das
+++ b/tests/integration/test_imgui_synth_mouse.das
@@ -1,0 +1,46 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the ImGui-bypass synthetic mouse driver — exercises
+//! `imgui_mouse_pos` + `imgui_mouse_click` (raw event-queue layer in
+//! `widgets/imgui_live_core.das`). Distinct from `test_glfw_synth_mouse.das`
+//! (GLFW layer) and from the higher-level `click()` helper (widget-resolution
+//! layer); this one feeds raw screen-space mouse events to ImGui directly.
+
+let FEATURE = "modules/dasImgui/examples/features/imgui_synth_mouse.das"
+
+[test]
+def test_imgui_synth_mouse_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "SYNTH_WIN/SYNTH_BTN", 15.0f)
+        t |> success(snap != null, "SYNTH_BTN registers")
+        if (snap == null) return
+
+        let btn = find_widget(snap, "SYNTH_WIN/SYNTH_BTN")
+        t |> equal(btn?["kind"] ?? "", "button",
+                   "SYNTH_BTN.kind == 'button'")
+        t |> equal(widget_payload_field(snap, "SYNTH_WIN/SYNTH_BTN", "click_count") ?? -1,
+                   0,
+                   "SYNTH_BTN.click_count == 0 initially")
+
+        // Read bbox to compute mouse target — robust against geometry drift.
+        let bbox = btn?["bbox"]
+        let bx = ((bbox?["x"] ?? 0.0f) + (bbox?["z"] ?? 0.0f)) * 0.5f
+        let by = ((bbox?["y"] ?? 0.0f) + (bbox?["w"] ?? 0.0f)) * 0.5f
+
+        // Bypass mouse to button centre then press+release LMB.
+        post_command(d, "imgui_mouse_pos", JV((x = bx, y = by)))
+        post_command(d, "imgui_mouse_click", JV((button = 0, action = "press")))
+        post_command(d, "imgui_mouse_click", JV((button = 0, action = "release")))
+        t |> success(wait_for_mouse_idle(d, 4.0f), "mouse timeline drains")
+        t |> success(wait_for_int_value(d, "SYNTH_WIN/SYNTH_BTN", "click_count", 1, 300),
+                     "SYNTH_BTN.click_count == 1 after bypass click")
+    }
+}

--- a/tests/integration/test_log_to_text.das
+++ b/tests/integration/test_log_to_text.das
@@ -1,0 +1,48 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `log_to_clipboard` / `log_text` / `log_finish` —
+//! ImGui log capture rail. All three are imperatives (no snapshot kind);
+//! the test value is "no panic on the call chain when the COPY_BTN fires
+//! all three imperatives back-to-back, surrounding widgets still register."
+
+let FEATURE = "modules/dasImgui/examples/features/log_to_text.das"
+
+[test]
+def test_log_to_text_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/COPY_BTN", 15.0f)
+        t |> success(snap != null, "COPY_BTN registers")
+        if (snap == null) return
+
+        let btn = find_widget(snap, "MAIN_WIN/COPY_BTN")
+        t |> equal(btn?["kind"] ?? "", "button",
+                   "COPY_BTN.kind == 'button'")
+
+        for (ident in ["LEAD", "SEP", "STATIC_1", "STATIC_2"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "{ident} registers")
+        }
+
+        // Click COPY_BTN — fires the log_to_clipboard / 3× log_text /
+        // log_finish sequence. Clipboard contents not snapshot-visible.
+        // Value here = no panic on the imperative chain.
+        click(d, "MAIN_WIN/COPY_BTN")
+        t |> success(wait_for_int_value(d, "MAIN_WIN/COPY_BTN", "click_count", 1, 300),
+                     "COPY_BTN.click_count == 1 after click (log chain non-fatal)")
+
+        // STATIC_1/2 still register the frame after the log session closes.
+        var snap_after = snapshot(d)
+        t |> success(widget_exists(snap_after, "MAIN_WIN/STATIC_1"),
+                     "STATIC_1 still registers after log session")
+        t |> success(widget_exists(snap_after, "MAIN_WIN/STATIC_2"),
+                     "STATIC_2 still registers after log session")
+    }
+}

--- a/tests/integration/test_narrate_placement.das
+++ b/tests/integration/test_narrate_placement.das
@@ -1,0 +1,53 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the narrate-placement harness — 4×5 = 20 indexed
+//! buttons in a 1280×720 viewport. narrate()/highlight() don't register in
+//! the snapshot (they push into module-scope arrays painted by the visual
+//! aids overlay), so the test verifies the checkbox + all 20 indexed
+//! buttons register, and that click-to-select registers as expected.
+
+let FEATURE = "modules/dasImgui/examples/features/narrate_placement.das"
+
+[test]
+def test_narrate_placement_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/SHOW_NARRATION", 15.0f)
+        t |> success(snap != null, "SHOW_NARRATION registers")
+        if (snap == null) return
+
+        let cb = find_widget(snap, "MAIN_WIN/SHOW_NARRATION")
+        t |> equal(cb?["kind"] ?? "", "checkbox",
+                   "SHOW_NARRATION.kind == 'checkbox'")
+
+        // All 20 grid buttons register with literal index keys.
+        for (idx in range(20)) {
+            t |> success(widget_exists(snap, "MAIN_WIN/GRID_BTN[{idx}]"),
+                         "GRID_BTN[{idx}] registers")
+        }
+
+        // Click GRID_BTN[0] — click_count increments; the click-through wire
+        // is independent of narrate() banner painting (which isn't snapshot
+        // visible).
+        click(d, "MAIN_WIN/GRID_BTN[0]")
+        t |> success(wait_for_int_value(d, "MAIN_WIN/GRID_BTN[0]", "click_count", 1, 300),
+                     "GRID_BTN[0].click_count == 1 after click")
+
+        // Click another button — its count increments, the first stays at 1
+        // (retarget routes, doesn't stack on the previous).
+        click(d, "MAIN_WIN/GRID_BTN[7]")
+        t |> success(wait_for_int_value(d, "MAIN_WIN/GRID_BTN[7]", "click_count", 1, 300),
+                     "GRID_BTN[7].click_count == 1 after retarget")
+        var snap_after = snapshot(d)
+        t |> equal(widget_payload_field(snap_after, "MAIN_WIN/GRID_BTN[0]", "click_count") ?? -1,
+                   1,
+                   "GRID_BTN[0].click_count still 1 (no extra fire on retarget)")
+    }
+}

--- a/tests/integration/test_popup_context_window.das
+++ b/tests/integration/test_popup_context_window.das
@@ -1,0 +1,88 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `popup_context_window` — right-click context menu
+//! over the host window. Verifies kind, right_click opens the popup, menu
+//! items register at container-nested paths, and selecting items updates
+//! the LAST_PICK display state.
+
+let FEATURE = "modules/dasImgui/examples/features/popup_context_window.das"
+
+[test]
+def test_popup_context_window_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/CTX", 15.0f)
+        t |> success(snap != null, "CTX container registers")
+        if (snap == null) return
+
+        let ctx = find_widget(snap, "MAIN_WIN/CTX")
+        t |> equal(ctx?["kind"] ?? "", "popup_context_window",
+                   "CTX.kind == 'popup_context_window'")
+
+        // STATUS reflects no pick yet.
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/STATUS", "value") ?? "",
+                   "last pick: (none yet)",
+                   "STATUS shows '(none yet)' initially")
+
+        // Body widgets do NOT register while the popup is closed (per
+        // imgui_containers_builtin's stateless_finalize gated on im_open).
+        t |> success(!widget_exists(snap, "MAIN_WIN/CTX/ITEM_NEW"),
+                     "ITEM_NEW absent while popup closed")
+
+        // Right-click somewhere in the window body. playwright's right_click
+        // helper falls through L1 with button hardcoded to 0 (left), so we
+        // use the raw imgui_mouse_* bypass with button=1 explicitly. Anchor
+        // at LEAD's bbox center — guaranteed body-interior, not title bar.
+        let lead_bbox = find_widget(snap, "MAIN_WIN/LEAD")?["bbox"]
+        let lead_x = ((lead_bbox?["x"] ?? 0.0f) + (lead_bbox?["z"] ?? 0.0f)) * 0.5f
+        let lead_y = ((lead_bbox?["y"] ?? 0.0f) + (lead_bbox?["w"] ?? 0.0f)) * 0.5f
+        post_command(d, "imgui_mouse_pos", JV((x = lead_x, y = lead_y)))
+        post_command(d, "imgui_mouse_click", JV((button = 1, action = "press")))
+        post_command(d, "imgui_mouse_click", JV((button = 1, action = "release")))
+        t |> success(wait_for_mouse_idle(d, 4.0f), "RMB timeline drains")
+        var snap_open = wait_for_widget(d, "MAIN_WIN/CTX/ITEM_NEW", 5.0f)
+        t |> success(snap_open != null, "ITEM_NEW registers after right-click")
+        if (snap_open == null) return
+
+        // Pick "New" — ImGui auto-closes the popup on mouse-move-outside, so
+        // a path-resolved click() can land outside the popup window. Use
+        // raw imgui_mouse_* at ITEM_NEW's bbox center (still inside popup
+        // since the cursor stays there).
+        let new_bbox = find_widget(snap_open, "MAIN_WIN/CTX/ITEM_NEW")?["bbox"]
+        let new_x = ((new_bbox?["x"] ?? 0.0f) + (new_bbox?["z"] ?? 0.0f)) * 0.5f
+        let new_y = ((new_bbox?["y"] ?? 0.0f) + (new_bbox?["w"] ?? 0.0f)) * 0.5f
+        post_command(d, "imgui_mouse_pos", JV((x = new_x, y = new_y)))
+        post_command(d, "imgui_mouse_click", JV((button = 0, action = "press")))
+        post_command(d, "imgui_mouse_click", JV((button = 0, action = "release")))
+        t |> success(wait_for_mouse_idle(d, 4.0f), "LMB on ITEM_NEW drains")
+        t |> success(wait_for_string_value(d, "MAIN_WIN/STATUS", "value",
+                                           "last pick: New", 300),
+                     "STATUS reflects 'New' after menu pick")
+
+        // Re-open + pick "Quit" — verifies the popup can be re-opened.
+        post_command(d, "imgui_mouse_pos", JV((x = lead_x, y = lead_y)))
+        post_command(d, "imgui_mouse_click", JV((button = 1, action = "press")))
+        post_command(d, "imgui_mouse_click", JV((button = 1, action = "release")))
+        t |> success(wait_for_mouse_idle(d, 4.0f), "second RMB timeline drains")
+        var snap_open2 = wait_for_widget(d, "MAIN_WIN/CTX/ITEM_QUIT", 5.0f)
+        t |> success(snap_open2 != null, "ITEM_QUIT registers on re-open")
+        if (snap_open2 == null) return
+        let quit_bbox = find_widget(snap_open2, "MAIN_WIN/CTX/ITEM_QUIT")?["bbox"]
+        let quit_x = ((quit_bbox?["x"] ?? 0.0f) + (quit_bbox?["z"] ?? 0.0f)) * 0.5f
+        let quit_y = ((quit_bbox?["y"] ?? 0.0f) + (quit_bbox?["w"] ?? 0.0f)) * 0.5f
+        post_command(d, "imgui_mouse_pos", JV((x = quit_x, y = quit_y)))
+        post_command(d, "imgui_mouse_click", JV((button = 0, action = "press")))
+        post_command(d, "imgui_mouse_click", JV((button = 0, action = "release")))
+        t |> success(wait_for_mouse_idle(d, 4.0f), "LMB on ITEM_QUIT drains")
+        t |> success(wait_for_string_value(d, "MAIN_WIN/STATUS", "value",
+                                           "last pick: Quit", 300),
+                     "STATUS reflects 'Quit' after second menu pick")
+    }
+}

--- a/tests/integration/test_tree_node_open_manual.das
+++ b/tests/integration/test_tree_node_open_manual.das
@@ -1,0 +1,45 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `tree_node_open` + `tree_pop` — the manual-pair
+//! tree node primitives. `tree_node_open` is imperative (no [widget] kind,
+//! no IDENT-bound path), so the test verifies the surrounding [widget]
+//! siblings register in the expected closed-state shape: SETTINGS_RESET
+//! same_line button + SEP1 + NOTE present, body widgets absent.
+
+let FEATURE = "modules/dasImgui/examples/features/tree_node_open_manual.das"
+
+[test]
+def test_tree_node_open_manual_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/LEAD", 15.0f)
+        t |> success(snap != null, "LEAD registers")
+        if (snap == null) return
+
+        // Same-line sibling rendered AFTER the imperative tree_node_open
+        // header — proves the imperative didn't unbalance the ID stack.
+        let reset = find_widget(snap, "MAIN_WIN/SETTINGS_RESET")
+        t |> equal(reset?["kind"] ?? "", "button",
+                   "SETTINGS_RESET registers as 'button'")
+
+        // Trailing widgets after the optional `tree_pop()`.
+        t |> success(widget_exists(snap, "MAIN_WIN/SEP1"),  "SEP1 registers")
+        t |> success(widget_exists(snap, "MAIN_WIN/NOTE"),  "NOTE registers")
+
+        // Closed-state — body widgets gated on `if (node_open)` do NOT
+        // register. (tree_node_open default is closed; no DefaultOpen flag.)
+        t |> success(!widget_exists(snap, "MAIN_WIN/BODY_HINT"),
+                     "BODY_HINT absent while node closed")
+        t |> success(!widget_exists(snap, "MAIN_WIN/BODY_LINE_1"),
+                     "BODY_LINE_1 absent while node closed")
+        t |> success(!widget_exists(snap, "MAIN_WIN/BODY_LINE_2"),
+                     "BODY_LINE_2 absent while node closed")
+    }
+}


### PR DESCRIPTION
## Summary

Closes the remaining 8 features that had zero integration coverage after PR #81 landed the 5 high-priority ones. **Audit complete: 13/13 gap features now have a `test_*.das`.**

| Test | Feature | Gates |
|---|---|---|
| `test_edit_collapsing_header` | edit_collapsing_header | bidir-bind round-trip via [edit_widget] scalar-pointee dispatcher (`sscan_json_at` writes through `*ptr`), reverse direction via RESTORE_A click |
| `test_popup_context_window` | popup_context_window | right-click opens popup, menu pick updates LAST_PICK. Uses raw `imgui_mouse_*` bypass with `button=1` because `playwright.right_click` falls through L1 with button hardcoded to 0 |
| `test_tree_node_open_manual` | tree_node_open + tree_pop | imperatives (no [widget] kind); verifies surrounding [widget] siblings + closed-state body-absent invariant |
| `test_log_to_text` | log_to_clipboard/log_text/log_finish | imperatives; smoke = no panic on button-fired log chain, surrounding widgets still register |
| `test_align_text_to_frame_padding` | align_text_to_frame_padding | geometry proof: `(lab_b.y - btn_b.y) > (lab_a.y - btn_a.y)` — align prefix shifts LABEL_B baseline down |
| `test_narrate_placement` | narrate_placement | 20-button indexed grid registers; click retarget routes (doesn't stack click_count on prior target) |
| `test_imgui_synth_keys` | imgui_synth_keys | `imgui_focus` + `imgui_key_type` (ImGui-bypass layer), distinct from `test_glfw_synth_keys` (GLFW backend) |
| `test_imgui_synth_mouse` | imgui_synth_mouse | `imgui_mouse_pos` + `imgui_mouse_click` (raw bypass), distinct from GLFW layer and from `click()` (widget-resolution layer) |

## Known synthesis quirks documented in test code

- **`playwright.right_click` is broken for non-dispatcher targets.** L1 hex_id fallback in `imgui_boost_runtime.das:1362` hardcodes `button=0`, so right_click on a window kind silently sends a left click. `test_popup_context_window` falls back to raw `imgui_mouse_click` with `button=1`. Worth a follow-up to plumb button through L1.
- **Popup menu items auto-close on mouse-move-outside.** A path-resolved `click()` on `CTX/ITEM_NEW` doesn't land — the popup window is gone by the time the L1 click coro fires. Solution: snapshot ITEM_NEW bbox while popup is open, post raw `imgui_mouse_*` at the menu item centre.
- **`narrate`/`highlight` are not snapshot-visible.** They push into module-scope arrays painted by the visual_aids overlay; tests assert button click-count + retarget behavior instead of banner placement.
- **`align_text_to_frame_padding` geometry is intuitive once measured.** Without prefix: `lab.y == btn.y` (both at line top). With prefix: `lab.y > btn.y` (label shifted DOWN by FramePadding.y). The plan's initial assertion direction was wrong — fixed during prework.

## Test plan

- [x] Each test passes locally headless.
- [x] PR-2 8-test sub-sweep, 4-way isolated mode: 8/8 pass, ~25s wall.
- [x] Lint clean (0 issues across all 8 files).
- [x] Format clean.
- [ ] CI green on Ubuntu / macOS / Windows.

## Audit closeout

Before PR #81: 90 features, 108 tests, 14 features with no test (13 real gaps + 1 lint-education excluded).

After PR-2 merges: 90 features, **121 tests, 0 real gaps**. `widget_no_ident` stays excluded (STYLE001 lint education with `options _allow_imgui_legacy = true` opt-out; lint coverage already in `test_imgui_lint_allow.das` / `test_imgui_lint_off.das`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)