### PR TITLE
15-API backfill: 7 feature demos + 7 integration tests

### DIFF
--- a/examples/features/edit_tab_item.das
+++ b/examples/features/edit_tab_item.das
@@ -1,0 +1,74 @@
+options gen2
+
+require daslib/safe_addr
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: edit_tab_item — closable TabItem on a caller-owned visibility bool.
+// SHOWS:   `edit_tab_item(safe_addr(open_bool), (id="..", text="..", flags=..))`
+//          binds to an external bool*. The X close button writes
+//          `*p_open = false`; when false, the entire tab (chrome + body) is
+//          skipped. External siblings (the edit_checkbox row at the top)
+//          drive the SAME bools — bidir-bound shared state.
+// DRIVE:   curl -X POST -d '{"name":"imgui_set","args":{"target":"MAIN_WIN/BAR/TAB_A","value":false}}' \
+//              localhost:9090/command
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/edit_tab_item.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/edit_tab_item.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/edit_tab_item.das
+// =============================================================================
+
+var private g_tab_a_open : bool = true
+var private g_tab_b_open : bool = true
+
+[export]
+def init() {
+    harness_init("edit_tab_item — closable tab bound to bool", 640, 360)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(600.0, 320.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "edit_tab_item", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Each tab's X button writes the bound bool. The checkboxes drive the same bools."))
+
+        edit_checkbox(safe_addr(g_tab_a_open), (id = "CHECK_A", text = "show A"))
+        same_line()
+        edit_checkbox(safe_addr(g_tab_b_open), (id = "CHECK_B", text = "show B"))
+        separator()
+
+        tab_bar(BAR, (text = "MyBar",
+                      flags = ImGuiTabBarFlags.FittingPolicyResizeDown)) {
+            edit_tab_item(safe_addr(g_tab_a_open),
+                          (id = "TAB_A", text = "alpha",
+                           flags = ImGuiTabItemFlags.None)) {
+                text(BODY_A, (text = "alpha tab body — close me with the X."))
+            }
+            edit_tab_item(safe_addr(g_tab_b_open),
+                          (id = "TAB_B", text = "beta",
+                           flags = ImGuiTabItemFlags.None)) {
+                text(BODY_B, (text = "beta tab body — close me with the X."))
+            }
+        }
+        text(STATUS, (text = "a={g_tab_a_open} b={g_tab_b_open}"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/focus_control.das
+++ b/examples/features/focus_control.das
@@ -1,0 +1,65 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: focus_control — set_keyboard_focus_here + set_item_default_focus.
+// SHOWS:   `set_item_default_focus()` after the first input claims focus on
+//          window first-open (typing starts there). `set_keyboard_focus_here(0)`
+//          before a widget schedules focus to LAND on that widget next frame
+//          — clicking REFOCUS_NAME moves focus to NAME_INPUT; REFOCUS_EMAIL
+//          moves it to EMAIL_INPUT. Compare against the `focus` field in each
+//          input's snapshot payload to see who currently has keyboard focus.
+// DRIVE:   curl -X POST -d '{"name":"imgui_click","args":{"target":"MAIN_WIN/REFOCUS_EMAIL"}}' \
+//              localhost:9090/command
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/focus_control.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/focus_control.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/focus_control.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("focus_control — keyboard focus rail", 560, 360)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(520.0, 300.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "focus control", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "set_item_default_focus claims NAME_INPUT on first frame; the refocus buttons move it."))
+
+        if (button(REFOCUS_NAME, (text = "Focus Name"))) {
+            set_keyboard_focus_here(0)
+        }
+        input_text(NAME_INPUT, (text = "Name"))
+        // First frame only: this input is the default focus target.
+        set_item_default_focus()
+
+        if (button(REFOCUS_EMAIL, (text = "Focus Email"))) {
+            set_keyboard_focus_here(0)
+        }
+        input_text(EMAIL_INPUT, (text = "Email"))
+
+        text(STATUS, (text = "name='{NAME_INPUT.value}' email='{EMAIL_INPUT.value}'"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/open_popup_on_item_click.das
+++ b/examples/features/open_popup_on_item_click.das
@@ -1,0 +1,70 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: open_popup_on_item_click — right-click an item to open a popup.
+// SHOWS:   The stateful overload — `open_popup_on_item_click(POPUP_STATE,
+//          flags)` — checks IsMouseReleased + IsItemHovered on the previously
+//          submitted widget and queues `state.pending_open` on the bound
+//          `popup(IDENT, ...)` container. The container then opens itself
+//          inside its own PushID(IDENT) scope on the next frame. Trigger by
+//          right-clicking BTN_TARGET; the popup's BTN_OK click increments a
+//          counter rendered into STATUS.
+// DRIVE:   curl -X POST -d '{"name":"imgui_click","args":{"target":"MAIN_WIN/BTN_TARGET","button":1}}' \
+//              localhost:9090/command
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/open_popup_on_item_click.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/open_popup_on_item_click.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/open_popup_on_item_click.das
+// =============================================================================
+
+var private g_picks = 0
+
+[export]
+def init() {
+    harness_init("open_popup_on_item_click", 520, 360)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 320.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "open_popup_on_item_click", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Right-click the button below to open a popup."))
+
+        if (button(BTN_TARGET, (text = "Right-click me"))) {}
+        // Stateful binding: pairs with the `popup(MENU, ...)` below.
+        open_popup_on_item_click(MENU, ImGuiPopupFlags.MouseButtonRight)
+
+        popup(MENU, (text = "MyPopup", flags = ImGuiWindowFlags.None)) {
+            text(POPUP_LEAD, (text = "Pick one:"))
+            if (button(BTN_OK, (text = "Pick OK"))) {
+                g_picks++
+            }
+            same_line()
+            if (button(BTN_CANCEL, (text = "Cancel"))) {}
+        }
+
+        text(STATUS, (text = "picks = {g_picks}"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/scroll_here_y.das
+++ b/examples/features/scroll_here_y.das
@@ -1,0 +1,78 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: set_scroll_here_y — scroll the parent so a freshly-submitted
+//          widget lands at a chosen vertical fraction of the visible area.
+// SHOWS:   When JUMP_TARGET changes (via Top / Middle / Bottom buttons), the
+//          loop that renders ROW[0..199] inside a 360px child fires
+//          `set_scroll_here_y(0.5)` right after drawing ROW[JUMP_TARGET].
+//          The child's scroll_y snaps so that row sits mid-viewport on the
+//          next frame. Snapshot `MAIN_WIN/SCROLL_AREA.scroll.y` to see it
+//          land near the row's static y-offset.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/scroll_here_y.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/scroll_here_y.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/scroll_here_y.das
+// =============================================================================
+
+var private ROW : table<int; NarrativeState>
+let private ITEM_COUNT = 200
+var private g_jump_target = -1
+
+[export]
+def init() {
+    harness_init("set_scroll_here_y — jump-to-row", 540, 540)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(500.0, 500.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "set_scroll_here_y", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Pick a target row; the child scrolls so that row sits mid-viewport."))
+
+        if (button(JUMP_TOP, (text = "Top (row 0)"))) {
+            g_jump_target = 0
+        }
+        same_line()
+        if (button(JUMP_MIDDLE, (text = "Middle (row 100)"))) {
+            g_jump_target = 100
+        }
+        same_line()
+        if (button(JUMP_BOTTOM, (text = "Bottom (row 199)"))) {
+            g_jump_target = 199
+        }
+
+        child(SCROLL_AREA, (text = "rows", size = float2(460.0f, 360.0f),
+                            child_flags = ImGuiChildFlags.Border,
+                            window_flags = ImGuiWindowFlags.None)) {
+            for (i in range(ITEM_COUNT)) {
+                text(ROW[i], (text = "row {i}"))
+                if (i == g_jump_target) {
+                    set_scroll_here_y(0.5f)
+                    g_jump_target = -1
+                }
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/set_window_size_runtime.das
+++ b/examples/features/set_window_size_runtime.das
@@ -1,0 +1,63 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: set_window_size — runtime window-size mutation.
+// SHOWS:   `set_window_size(float2(w, h), ImGuiCond.Always)` resizes the
+//          current/last window mid-frame. Three buttons (Small / Medium /
+//          Large) each post a different size; the window snaps to the new
+//          dimensions on the next frame and the displayed size readout
+//          updates. The `[export] def init` uses SetNextWindowSize with
+//          ImGuiCond.FirstUseEver so the runtime mutation isn't overwritten
+//          on subsequent frames.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/set_window_size_runtime.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/set_window_size_runtime.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/set_window_size_runtime.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("set_window_size runtime mutation", 720, 480)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(480.0, 320.0), ImGuiCond.FirstUseEver)
+    window(MAIN_WIN, (text = "set_window_size", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Click a size button to resize this window via set_window_size()."))
+        if (button(BTN_SMALL, (text = "Small (320x200)"))) {
+            set_window_size(float2(320.0f, 200.0f), ImGuiCond.Always)
+        }
+        same_line()
+        if (button(BTN_MEDIUM, (text = "Medium (480x320)"))) {
+            set_window_size(float2(480.0f, 320.0f), ImGuiCond.Always)
+        }
+        same_line()
+        if (button(BTN_LARGE, (text = "Large (640x440)"))) {
+            set_window_size(float2(640.0f, 440.0f), ImGuiCond.Always)
+        }
+        let sz = GetWindowSize()
+        text(SIZE_READOUT, (text = "current = ({sz.x}, {sz.y})"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/table_custom_headers.das
+++ b/examples/features/table_custom_headers.das
@@ -1,0 +1,126 @@
+options gen2
+
+require imgui/imgui_harness
+require imgui/imgui_table_builtin
+
+// =============================================================================
+// FEATURE: table_header + table_angled_headers_row — custom header rendering.
+// SHOWS:   Two tables side-by-side. CUSTOM_TABLE submits a manual header row
+//          via `table_next_row(Headers)` + `table_set_column_index(i)` +
+//          `table_header("X")` per column — full control over cell label and
+//          alignment. ANGLED_TABLE sets `ImGuiTableColumnFlags.AngledHeader`
+//          on each column and submits the row with one
+//          `table_angled_headers_row()` call — labels render rotated to the
+//          ImGuiStyle.TableAngledHeadersAngle (default 35°).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/table_custom_headers.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/table_custom_headers.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/table_custom_headers.das
+// =============================================================================
+
+var private CUSTOM_CELL_X : table<int; NarrativeState>
+var private CUSTOM_CELL_Y : table<int; NarrativeState>
+var private CUSTOM_CELL_Z : table<int; NarrativeState>
+var private ANGLED_CELL_A : table<int; NarrativeState>
+var private ANGLED_CELL_B : table<int; NarrativeState>
+var private ANGLED_CELL_C : table<int; NarrativeState>
+var private ANGLED_CELL_D : table<int; NarrativeState>
+
+let private ROW_COUNT = 4
+
+[export]
+def init() {
+    harness_init("table_header + table_angled_headers_row", 720, 480)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(680.0, 440.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "custom + angled headers", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Top: manual table_header() per column. Bottom: table_angled_headers_row()."))
+
+        // ---- Custom headers via table_header() ----
+        data_table(CUSTOM_TABLE, (text = "custom", columns = 3,
+                                  flags = ImGuiTableFlags.Borders |
+                                          ImGuiTableFlags.RowBg,
+                                  outer_size = float2(0.0f, 140.0f),
+                                  inner_width = 0.0f)) {
+            table_setup_column("XX")
+            table_setup_column("YY")
+            table_setup_column("ZZ")
+            table_next_row(ImGuiTableRowFlags.Headers)
+            if (table_set_column_index(0)) {
+                table_header("X (custom)")
+            }
+            if (table_set_column_index(1)) {
+                table_header("Y (custom)")
+            }
+            if (table_set_column_index(2)) {
+                table_header("Z (custom)")
+            }
+            for (i in range(ROW_COUNT)) {
+                table_next_row()
+                if (table_set_column_index(0)) {
+                    text(CUSTOM_CELL_X[i], (text = "x{i}"))
+                }
+                if (table_next_column()) {
+                    text(CUSTOM_CELL_Y[i], (text = "y{i}"))
+                }
+                if (table_next_column()) {
+                    text(CUSTOM_CELL_Z[i], (text = "z{i}"))
+                }
+            }
+        }
+
+        // ---- Angled headers via table_angled_headers_row() ----
+        data_table(ANGLED_TABLE, (text = "angled", columns = 4,
+                                  flags = ImGuiTableFlags.Borders |
+                                          ImGuiTableFlags.RowBg,
+                                  outer_size = float2(0.0f, 200.0f),
+                                  inner_width = 0.0f)) {
+            table_setup_column("Alpha",   ImGuiTableColumnFlags.AngledHeader |
+                                          ImGuiTableColumnFlags.WidthFixed, 60.0f)
+            table_setup_column("Bravo",   ImGuiTableColumnFlags.AngledHeader |
+                                          ImGuiTableColumnFlags.WidthFixed, 60.0f)
+            table_setup_column("Charlie", ImGuiTableColumnFlags.AngledHeader |
+                                          ImGuiTableColumnFlags.WidthFixed, 60.0f)
+            table_setup_column("Delta",   ImGuiTableColumnFlags.AngledHeader |
+                                          ImGuiTableColumnFlags.WidthFixed, 60.0f)
+            table_angled_headers_row()
+            for (i in range(ROW_COUNT)) {
+                table_next_row()
+                if (table_set_column_index(0)) {
+                    text(ANGLED_CELL_A[i], (text = "a{i}"))
+                }
+                if (table_next_column()) {
+                    text(ANGLED_CELL_B[i], (text = "b{i}"))
+                }
+                if (table_next_column()) {
+                    text(ANGLED_CELL_C[i], (text = "c{i}"))
+                }
+                if (table_next_column()) {
+                    text(ANGLED_CELL_D[i], (text = "d{i}"))
+                }
+            }
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/visual_aids_dashboard.das
+++ b/examples/features/visual_aids_dashboard.das
@@ -1,0 +1,66 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: visual_aids_dashboard — stage for the 7 [live_command] overlays.
+// SHOWS:   The named widgets (TARGET_BTN, TARGET_INPUT, TARGET_CHECK) act as
+//          targets for the visual aid overlays in `widgets/imgui_visual_aids.das`:
+//            * imgui_highlight     — flash colored rect on target.bbox
+//            * imgui_mouse_trail   — fading dotted line behind cursor
+//            * imgui_narrate       — callout box w/ optional connector to target
+//            * imgui_auto_highlight — auto-flash on every accepted command
+//            * imgui_cursor_sprite — synth-cursor pointer sprite
+//            * imgui_key_hud       — bottom-center keycap + modifier strip
+//            * imgui_focus_rect    — rect around io.active_widget
+//          The demo is a passive host; drive overlays via post_command from
+//          tests or curl. The bottom STATUS line surfaces interaction state.
+// DRIVE:   curl -X POST -d '{"name":"imgui_highlight","args":{"target":"MAIN_WIN/TARGET_BTN","frames":120}}' \
+//              localhost:9090/command
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/visual_aids_dashboard.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/visual_aids_dashboard.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/visual_aids_dashboard.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("visual_aids dashboard", 640, 360)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_apply_synth_io()
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(600.0, 320.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "visual_aids stage", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Targets below — drive imgui_highlight / narrate / focus_rect against them."))
+
+        if (button(TARGET_BTN, (text = "Target button"))) {}
+        same_line()
+        checkbox(TARGET_CHECK, (text = "Target check"))
+
+        input_text(TARGET_INPUT, (text = "Target input"))
+
+        separator()
+        text(STATUS, (text = "btn_clicks={TARGET_BTN.click_count} check={TARGET_CHECK.value}"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/tests/integration/test_edit_tab_item.das
+++ b/tests/integration/test_edit_tab_item.das
@@ -1,0 +1,53 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `edit_tab_item`. Demo binds two closable tabs
+//! (TAB_A, TAB_B) to module-scope bools via safe_addr. Verify both render
+//! initially, both bodies register, and `imgui_set TAB_A false` flips A's
+//! bool — body and header disappear, the linked CHECK_A also unchecks
+//! (bidir bind), and STATUS reflects "a=false b=true".
+
+let FEATURE = "modules/dasImgui/examples/features/edit_tab_item.das"
+
+[test]
+def test_edit_tab_item_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/BAR/TAB_A", 15.0f)
+        t |> success(snap != null, "TAB_A registers")
+        if (snap == null) return
+
+        t |> equal(find_widget(snap, "MAIN_WIN/BAR/TAB_A")?["kind"] ?? "", "edit_tab_item",
+                   "TAB_A.kind == edit_tab_item")
+        for (ident in ["LEAD", "CHECK_A", "CHECK_B", "STATUS"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "MAIN_WIN/{ident} registers")
+        }
+        t |> success(widget_exists(snap, "MAIN_WIN/BAR/TAB_B"), "TAB_B registers")
+
+        // Initially both open: A is selected by default; BODY_A visible.
+        t |> success(widget_exists(snap, "MAIN_WIN/BAR/TAB_A/BODY_A"),
+                     "BODY_A visible when alpha tab is active")
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/STATUS", "value") ?? "",
+                   "a=true b=true",
+                   "STATUS == 'a=true b=true' initially")
+
+        // Flip A closed via the external bool dispatcher; body+chrome vanish.
+        set_value(d, "MAIN_WIN/BAR/TAB_A", JV(false))
+        t |> success(wait_for_string_value(d, "MAIN_WIN/STATUS", "value",
+                                           "a=false b=true", 300),
+                     "STATUS reflects A closed after set_value(TAB_A, false)")
+
+        // Restore A via the linked checkbox; bidir bind makes the tab reappear.
+        set_value(d, "MAIN_WIN/CHECK_A", JV(true))
+        t |> success(wait_for_string_value(d, "MAIN_WIN/STATUS", "value",
+                                           "a=true b=true", 300),
+                     "STATUS reflects A restored after set_value(CHECK_A, true)")
+    }
+}

--- a/tests/integration/test_focus_control.das
+++ b/tests/integration/test_focus_control.das
@@ -1,0 +1,48 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `set_keyboard_focus_here` + `set_item_default_focus`.
+//! Clicking REFOCUS_EMAIL routes keyboard focus to EMAIL_INPUT; the snapshot
+//! payload's `focus` field flips true on the target input. Mirror with
+//! REFOCUS_NAME -> NAME_INPUT. `set_item_default_focus` first-frame behaviour
+//! is implementation-detail (headless harness may not preserve it cleanly
+//! across test boots), so we don't gate on it here.
+
+let FEATURE = "modules/dasImgui/examples/features/focus_control.das"
+
+[test]
+def test_focus_control_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/EMAIL_INPUT", 15.0f)
+        t |> success(snap != null, "EMAIL_INPUT registers")
+        if (snap == null) return
+
+        for (ident in ["LEAD", "REFOCUS_NAME", "NAME_INPUT", "REFOCUS_EMAIL",
+                       "EMAIL_INPUT", "STATUS"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "MAIN_WIN/{ident} registers")
+        }
+
+        // Click REFOCUS_EMAIL -> set_keyboard_focus_here(0) before EMAIL_INPUT
+        // -> EMAIL_INPUT.focus becomes true next frame.
+        click(d, "MAIN_WIN/REFOCUS_EMAIL")
+        let email_focused = wait_until(d, 120) $(var s) {
+            return s?["globals"]?["MAIN_WIN/EMAIL_INPUT"]?["focus"] ?? false
+        }
+        t |> success(email_focused != null, "EMAIL_INPUT.focus == true after REFOCUS_EMAIL click")
+
+        // Now flip back: click REFOCUS_NAME -> NAME_INPUT focus.
+        click(d, "MAIN_WIN/REFOCUS_NAME")
+        let name_focused = wait_until(d, 120) $(var s) {
+            return s?["globals"]?["MAIN_WIN/NAME_INPUT"]?["focus"] ?? false
+        }
+        t |> success(name_focused != null, "NAME_INPUT.focus == true after REFOCUS_NAME click")
+    }
+}

--- a/tests/integration/test_open_popup_on_item_click.das
+++ b/tests/integration/test_open_popup_on_item_click.das
@@ -1,0 +1,51 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `open_popup_on_item_click` (stateful overload). The
+//! demo binds right-click on BTN_TARGET to open the MENU popup via the
+//! stateful trigger. We verify wiring by opening the popup directly via
+//! `open(d, "MAIN_WIN/MENU")` (the L2 dispatch) — the popup chrome + body
+//! widgets register, BTN_OK click increments g_picks, STATUS updates.
+//! (The right-click-to-open path itself depends on synth-cursor + IsItemHovered
+//! frame-timing in the GLFW backend; that's covered by record_*.das drivers.)
+
+let FEATURE = "modules/dasImgui/examples/features/open_popup_on_item_click.das"
+
+[test]
+def test_open_popup_on_item_click_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/BTN_TARGET", 15.0f)
+        t |> success(snap != null, "BTN_TARGET registers")
+        if (snap == null) return
+
+        t |> success(widget_exists(snap, "MAIN_WIN/MENU"),
+                     "MENU popup container registers")
+        t |> equal(find_widget(snap, "MAIN_WIN/MENU")?["kind"] ?? "", "popup",
+                   "MENU.kind == popup")
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/STATUS", "value") ?? "",
+                   "picks = 0", "initial STATUS = 'picks = 0'")
+
+        // L2 open the popup directly (mirrors the trigger that the
+        // open_popup_on_item_click sets when fired). Popup body registers.
+        open_widget(d, "MAIN_WIN/MENU")
+        var open_snap = wait_for_widget(d, "MAIN_WIN/MENU/BTN_OK", 5.0f)
+        t |> success(open_snap != null, "BTN_OK registers once popup is open")
+        if (open_snap == null) return
+
+        t |> success(widget_exists(open_snap, "MAIN_WIN/MENU/POPUP_LEAD"),
+                     "POPUP_LEAD registers inside popup")
+
+        // Click OK; g_picks++ -> STATUS updates.
+        click(d, "MAIN_WIN/MENU/BTN_OK")
+        t |> success(wait_for_string_value(d, "MAIN_WIN/STATUS", "value",
+                                           "picks = 1", 300),
+                     "STATUS reflects 'picks = 1' after BTN_OK click")
+    }
+}

--- a/tests/integration/test_scroll_here_y.das
+++ b/tests/integration/test_scroll_here_y.das
@@ -1,0 +1,57 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `set_scroll_here_y`. The feature renders 200 rows
+//! inside a 360px scrollable child. Initial scroll_y is 0 (top); clicking
+//! JUMP_MIDDLE sets g_jump_target = 100 -> the next frame's loop fires
+//! `set_scroll_here_y(0.5)` after drawing row 100 -> child's scroll.y snaps
+//! to ~mid-content (~1700px). Asserting on `>= 1000` keeps the test robust
+//! against font/padding variance.
+
+let FEATURE = "modules/dasImgui/examples/features/scroll_here_y.das"
+
+[test]
+def test_scroll_here_y_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/SCROLL_AREA", 15.0f)
+        t |> success(snap != null, "SCROLL_AREA child registers")
+        if (snap == null) return
+
+        for (ident in ["LEAD", "JUMP_TOP", "JUMP_MIDDLE", "JUMP_BOTTOM"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "MAIN_WIN/{ident} registers")
+        }
+        t |> success(widget_exists(snap, "MAIN_WIN/SCROLL_AREA/ROW[0]"),
+                     "ROW[0] in initial visible chunk")
+
+        // Initial scroll: child opens at top.
+        let initial_y = find_widget(snap, "MAIN_WIN/SCROLL_AREA")?["payload"]?["scroll"]?["y"] ?? -1.0f
+        t |> success(initial_y == 0.0f,
+                     "initial SCROLL_AREA.scroll.y = {initial_y}")
+
+        // Click JUMP_MIDDLE -> set_scroll_here_y(0.5) after row 100 -> scroll snaps.
+        click(d, "MAIN_WIN/JUMP_MIDDLE")
+        let scrolled = wait_until(d, 120) $(var s) {
+            let y = s?["globals"]?["MAIN_WIN/SCROLL_AREA"]?["payload"]?["scroll"]?["y"] ?? 0.0f
+            return y >= 1000.0f
+        }
+        t |> success(scrolled != null,
+                     "SCROLL_AREA.scroll.y >= 1000 after JUMP_MIDDLE click")
+
+        // JUMP_TOP returns to top.
+        click(d, "MAIN_WIN/JUMP_TOP")
+        let back_to_top = wait_until(d, 120) $(var s) {
+            let y = s?["globals"]?["MAIN_WIN/SCROLL_AREA"]?["payload"]?["scroll"]?["y"] ?? 1.0f
+            return y == 0.0f
+        }
+        t |> success(back_to_top != null,
+                     "SCROLL_AREA.scroll.y == 0 after JUMP_TOP click")
+    }
+}

--- a/tests/integration/test_set_window_size_runtime.das
+++ b/tests/integration/test_set_window_size_runtime.das
@@ -1,0 +1,46 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `set_window_size` — runtime window-size mutation.
+//! The feature renders three buttons; clicking BTN_LARGE calls
+//! `set_window_size(float2(640, 440), Always)`. set_window_size is an
+//! imperative pass-through (no [widget] state), so we verify the button
+//! click_count rises (proves the call site fires) AND poll the
+//! SIZE_READOUT text payload for the post-resize string.
+
+let FEATURE = "modules/dasImgui/examples/features/set_window_size_runtime.das"
+
+[test]
+def test_set_window_size_runtime_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/BTN_LARGE", 15.0f)
+        t |> success(snap != null, "BTN_LARGE registers")
+        if (snap == null) return
+
+        for (ident in ["BTN_SMALL", "BTN_MEDIUM", "BTN_LARGE", "SIZE_READOUT", "LEAD"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "MAIN_WIN/{ident} registers")
+        }
+
+        // Click LARGE -> set_window_size(640, 440) -> SIZE_READOUT updates.
+        click(d, "MAIN_WIN/BTN_LARGE")
+        t |> success(wait_for_int_value(d, "MAIN_WIN/BTN_LARGE", "click_count", 1, 300),
+                     "BTN_LARGE.click_count == 1 after click")
+        t |> success(wait_for_string_value(d, "MAIN_WIN/SIZE_READOUT", "value",
+                                           "current = (640, 440)", 300),
+                     "SIZE_READOUT reflects 640x440 after BTN_LARGE click")
+
+        // Click MEDIUM -> 480x320 (round-trip back from LARGE).
+        click(d, "MAIN_WIN/BTN_MEDIUM")
+        t |> success(wait_for_string_value(d, "MAIN_WIN/SIZE_READOUT", "value",
+                                           "current = (480, 320)", 300),
+                     "SIZE_READOUT reflects 480x320 after BTN_MEDIUM click")
+    }
+}

--- a/tests/integration/test_table_custom_headers.das
+++ b/tests/integration/test_table_custom_headers.das
@@ -1,0 +1,54 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `table_header` + `table_angled_headers_row`. Two
+//! tables: CUSTOM_TABLE submits manual header cells via table_header();
+//! ANGLED_TABLE submits the row via table_angled_headers_row() with
+//! AngledHeader flag per column. Both are imperative (no [widget] state),
+//! so we verify the surrounding data_table container kind + body cells.
+
+let FEATURE = "modules/dasImgui/examples/features/table_custom_headers.das"
+
+[test]
+def test_table_custom_headers_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/CUSTOM_TABLE", 15.0f)
+        t |> success(snap != null, "CUSTOM_TABLE registers")
+        if (snap == null) return
+
+        t |> equal(find_widget(snap, "MAIN_WIN/CUSTOM_TABLE")?["kind"] ?? "", "data_table",
+                   "CUSTOM_TABLE.kind == data_table")
+        t |> equal(find_widget(snap, "MAIN_WIN/ANGLED_TABLE")?["kind"] ?? "", "data_table",
+                   "ANGLED_TABLE.kind == data_table")
+        t |> success(widget_exists(snap, "MAIN_WIN/LEAD"), "LEAD registers")
+
+        // 4 rows * 3 cells in CUSTOM_TABLE.
+        for (i in range(4)) {
+            for (col in ["CUSTOM_CELL_X", "CUSTOM_CELL_Y", "CUSTOM_CELL_Z"]) {
+                t |> success(widget_exists(snap, "MAIN_WIN/CUSTOM_TABLE/{col}[{i}]"),
+                             "MAIN_WIN/CUSTOM_TABLE/{col}[{i}] registers")
+            }
+        }
+
+        // 4 rows * 4 cells in ANGLED_TABLE.
+        for (i in range(4)) {
+            for (col in ["ANGLED_CELL_A", "ANGLED_CELL_B", "ANGLED_CELL_C", "ANGLED_CELL_D"]) {
+                t |> success(widget_exists(snap, "MAIN_WIN/ANGLED_TABLE/{col}[{i}]"),
+                             "MAIN_WIN/ANGLED_TABLE/{col}[{i}] registers")
+            }
+        }
+
+        // Cell content sanity (per-row label echoes).
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/CUSTOM_TABLE/CUSTOM_CELL_X[0]", "value") ?? "",
+                   "x0", "CUSTOM[0,X].value == 'x0'")
+        t |> equal(widget_payload_field(snap, "MAIN_WIN/ANGLED_TABLE/ANGLED_CELL_D[3]", "value") ?? "",
+                   "d3", "ANGLED[3,D].value == 'd3'")
+    }
+}

--- a/tests/integration/test_visual_aids_dashboard.das
+++ b/tests/integration/test_visual_aids_dashboard.das
@@ -1,0 +1,77 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the 7 visual-aid [live_command] wrappers in
+//! widgets/imgui_visual_aids.das. The dashboard demo is a passive stage
+//! with named widget targets (TARGET_BTN, TARGET_CHECK, TARGET_INPUT).
+//! We post each of the 7 verbs and assert ok=true on the response,
+//! verifying dispatch wiring. Visual correctness is exercised by the
+//! per-overlay tests (test_visual_aids_focus_rect.das,
+//! test_visual_aids_narrate.das) and the record_*.das drivers.
+
+let FEATURE = "modules/dasImgui/examples/features/visual_aids_dashboard.das"
+
+[test]
+def test_visual_aids_dashboard_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/TARGET_BTN", 15.0f)
+        t |> success(snap != null, "TARGET_BTN registers")
+        if (snap == null) return
+
+        for (ident in ["LEAD", "TARGET_BTN", "TARGET_CHECK", "TARGET_INPUT", "STATUS"]) {
+            t |> success(widget_exists(snap, "MAIN_WIN/{ident}"),
+                         "MAIN_WIN/{ident} registers")
+        }
+
+        // 1. imgui_highlight — flash colored rect on target.bbox.
+        let hl = post_command(d, "imgui_highlight",
+                              JV((target = "MAIN_WIN/TARGET_BTN", frames = 60)))
+        t |> equal(hl?["ok"] ?? false, true, "imgui_highlight ok=true")
+
+        // 2. imgui_mouse_trail — fading dotted line behind cursor.
+        let mt = post_command(d, "imgui_mouse_trail", JV((enabled = true)))
+        t |> equal(mt?["ok"] ?? false, true, "imgui_mouse_trail ok=true")
+
+        // 3. imgui_narrate — callout box w/ optional connector to target.
+        let nr = post_command(d, "imgui_narrate",
+                              JV((text = "stage smoke", target = "MAIN_WIN/TARGET_BTN",
+                                  frames = 30)))
+        t |> equal(nr?["ok"] ?? false, true, "imgui_narrate ok=true")
+
+        // 4. imgui_auto_highlight — flag toggle for auto-flash on every command.
+        let ah = post_command(d, "imgui_auto_highlight", JV((enabled = true)))
+        t |> equal(ah?["ok"] ?? false, true, "imgui_auto_highlight ok=true")
+
+        // 5. imgui_cursor_sprite — synth-cursor pointer.
+        let cs = post_command(d, "imgui_cursor_sprite", JV((enabled = true)))
+        t |> equal(cs?["ok"] ?? false, true, "imgui_cursor_sprite ok=true")
+
+        // 6. imgui_key_hud — bottom-center keycap + modifier strip.
+        let kh = post_command(d, "imgui_key_hud",
+                              JV((enabled = true, show_modifiers = true)))
+        t |> equal(kh?["ok"] ?? false, true, "imgui_key_hud ok=true")
+
+        // 7. imgui_focus_rect — rect around io.active_widget.
+        let fr = post_command(d, "imgui_focus_rect", JV((enabled = true)))
+        t |> equal(fr?["ok"] ?? false, true, "imgui_focus_rect ok=true")
+
+        // Symmetric disable on the four toggle-style commands.
+        let mt_off = post_command(d, "imgui_mouse_trail", JV((enabled = false)))
+        t |> equal(mt_off?["enabled"] ?? true, false, "imgui_mouse_trail off")
+        let cs_off = post_command(d, "imgui_cursor_sprite", JV((enabled = false)))
+        t |> equal(cs_off?["enabled"] ?? true, false, "imgui_cursor_sprite off")
+        let kh_off = post_command(d, "imgui_key_hud", JV((enabled = false)))
+        t |> equal(kh_off?["enabled"] ?? true, false, "imgui_key_hud off")
+        let fr_off = post_command(d, "imgui_focus_rect", JV((enabled = false)))
+        t |> equal(fr_off?["enabled"] ?? true, false, "imgui_focus_rect off")
+        let ah_off = post_command(d, "imgui_auto_highlight", JV((enabled = false)))
+        t |> equal(ah_off?["enabled"] ?? true, false, "imgui_auto_highlight off")
+    }
+}


### PR DESCRIPTION
## Summary

Backfill demos + integration tests for 15 widget/helper APIs that previously had no driver. Same shape as #81 / #82 — small focused harness demos under `examples/features/` paired 1:1 with smokes under `tests/integration/`.

## What lands

7 feature demos + 7 integration tests covering 15 APIs:

| Demo | API(s) |
|---|---|
| `set_window_size_runtime.das` | `set_window_size` |
| `focus_control.das` | `set_keyboard_focus_here`, `set_item_default_focus` |
| `scroll_here_y.das` | `set_scroll_here_y` |
| `table_custom_headers.das` | `table_header`, `table_angled_headers_row` |
| `edit_tab_item.das` | `edit_tab_item` (closable tab bound to external `bool?`) |
| `open_popup_on_item_click.das` | `open_popup_on_item_click` (stateful overload + `popup` container pair) |
| `visual_aids_dashboard.das` | `imgui_highlight`, `imgui_mouse_trail`, `imgui_narrate`, `imgui_auto_highlight`, `imgui_cursor_sprite`, `imgui_key_hud`, `imgui_focus_rect` (7 `[live_command]` overlays in one stage) |

Each demo is `~50 LOC`. Each test boots it via `with_imgui_app(FEATURE) $(d)` and asserts widget registration + payload roundtrip via the playwright helpers (`click`, `set_value`, `open_widget`, `wait_for_string_value`, etc.).

## Notes on test design

- **`test_set_window_size_runtime`**: drops a brittle initial-size assertion (headless harness vs windowed-harness defaults differ); covers the click-then-resize round-trip on `BTN_LARGE` and `BTN_MEDIUM`. Uses `wait_for_string_value` on `SIZE_READOUT.value` for assertion.
- **`test_focus_control`**: doesn't gate on `set_item_default_focus` first-frame behaviour (implementation-detail across boots); covers `set_keyboard_focus_here` by clicking `REFOCUS_NAME`/`REFOCUS_EMAIL` and polling the target input's `focus` field.
- **`test_open_popup_on_item_click`**: the right-click-to-open path depends on synth-cursor `IsItemHovered` frame timing in the GLFW backend; test uses `open_widget(d, "MAIN_WIN/MENU")` (L2 dispatch) to open the popup, then verifies body widgets register + `BTN_OK` click increments the bound counter. Visual right-click is exercised by `record_*.das` drivers.
- **`test_visual_aids_dashboard`**: 7 `post_command` verbs against the passive stage; asserts `ok=true` on each + `enabled` round-trip on the 4 toggle-style commands. Visual correctness already covered by per-overlay tests.

## Test plan

- [x] Lint clean (`utils/lint`) on all 14 new `.das` files
- [x] Format clean (`mcp__daslang__format_file`) on all 14 new `.das` files
- [x] Eyeball pass on each of the 7 demos via `daslang-live` + `screenshot`
- [x] Headless dastest sweep with Windows exclude set: **148/148 PASS, 0 failed, 0 errors**
