### PR TITLE
docs: add goatcounter analytics with /dasimgui path prefix

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -30,3 +30,11 @@
   {%- include "searchbox.html" %}
 
 {%- endblock %}
+
+{%- block extrahead %}
+{{ super() }}
+<!-- Analytics -->
+<script data-goatcounter="https://borisbat.goatcounter.com/count"
+        data-goatcounter-settings='{"path": function(p){return "/dasimgui"+p}}'
+        async src="//gc.zgo.at/count.js"></script>
+{%- endblock %}


### PR DESCRIPTION
Routes hits to the same borisbat.goatcounter.com counter as daslang.io but prefixes paths with /dasimgui/ so the two domains don't collide on the Pages chart.