### PR TITLE
docs: categorize all generated functions + CI Uncategorized-gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -130,6 +130,16 @@ jobs:
             exit 1
           fi
 
+      - name: "Uncategorized-gate: every function must belong to a named group"
+        working-directory: ${{ github.workspace }}/daslang-src/modules/dasImgui
+        run: |
+          set -eux
+          if grep -rl '^Uncategorized$' doc/source/stdlib/generated/; then
+            echo "ERROR: Found 'Uncategorized' sections in generated docs."
+            echo "Add the function(s) to a group_by_regex() in utils/imgui2rst.das."
+            exit 1
+          fi
+
       - name: "Build Sphinx HTML"
         working-directory: ${{ github.workspace }}/daslang-src/modules/dasImgui
         run: |

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -42,10 +42,14 @@ def document_module_imgui_boost_runtime(root : string) {
     var mod = find_module("imgui_boost_runtime")
     var groups <- array<DocGroup>(
         group_by_regex("Widget state types",      mod, %regex~.*State(Float|Int|Float2|Float3|Float4|Int2|Int3|Int4)?$%%),
-        group_by_regex("Per-frame registry",      mod, %regex~^(WidgetEntry|WidgetMeta|begin_frame|end_frame|register_widget|lookup_widget).*%%),
+        group_by_regex("Per-frame registry",      mod, %regex~^(WidgetEntry|WidgetMeta|begin_frame|end_frame|end_of_frame|register_widget|register_focusable|register_end_of_frame_hook|register_post_command_hook|lookup_widget|lookup_state_addr|clear_module_widgets|widget_registered|widget_prelude|widget_rect|with_state|id_to_path|id_to_bbox).*%%),
+        group_by_regex("Path machinery",          mod, %regex~^(container_path_push|container_path_pop|widget_path_key|container_path_key|active_widget_path)$%%),
+        group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
+        group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|set|open|close|focus|await|drag|type_text)$%%),
         group_by_regex("Await modifiers",         mod, %regex~^(AwaitModifiers|AwaitArgs|AwaitResult|with_await)$%%),
-        group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|to_JV|from_JV).*%%),
+        group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|state_jv|to_JV|from_JV|JV|serialize).*%%),
+        hide_group(group_by_regex("Finalizers",   mod, %regex~^.*_finalize$%%)),
         hide_group(group_by_regex("Internal",     mod, %regex~^(_|priv_).*%%))
     )
     document("Boost runtime — widget state structs, registry, and dispatcher", mod, "imgui_boost_runtime.rst", groups)
@@ -59,9 +63,13 @@ def document_module_imgui_widgets_builtin(root : string) {
         group_by_regex("Drag inputs",     mod, %regex~^drag.*%%),
         group_by_regex("Text input",      mod, %regex~^(input_text|input_text_multiline|input_int|input_float|input_int2|input_int3|input_int4|input_float2|input_float3|input_float4)$%%),
         group_by_regex("Color pickers",   mod, %regex~^(color_edit|color_picker|color_button)$%%),
-        group_by_regex("Selection",       mod, %regex~^(combo|list_box|selectable)$%%),
+        group_by_regex("Selection",       mod, %regex~^(combo|list_box|selectable|passes_filter)$%%),
         group_by_regex("Plot helpers",    mod, %regex~^(plot_lines|plot_histogram|progress_bar)$%%),
         group_by_regex("Output",          mod, %regex~^(text_show|text_input|label_text|bullet_text|help_marker)$%%),
+        group_by_regex("Focus & scrolling", mod, %regex~^(set_scroll_here_y|set_keyboard_focus_here|set_item_default_focus)$%%),
+        group_by_regex("Logging",         mod, %regex~^(log_to_clipboard|log_finish|log_text)$%%),
+        group_by_regex("Status queries",  mod, %regex~^is_active$%%),
+        hide_group(group_by_regex("Finalizers", mod, %regex~^.*_finalize$%%)),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )
     document("Built-in widgets — inputs, selection, color, plots, output", mod, "imgui_widgets_builtin.rst", groups)
@@ -70,11 +78,12 @@ def document_module_imgui_widgets_builtin(root : string) {
 def document_module_imgui_containers_builtin(root : string) {
     var mod = find_module("imgui_containers_builtin")
     var groups <- array<DocGroup>(
-        group_by_regex("Windows",       mod, %regex~^(window|child|group)$%%),
+        group_by_regex("Windows",       mod, %regex~^(window|child|group|child_scroll_reenter|set_window_size|viewport_center|is_mouse_pos_valid)$%%),
         group_by_regex("Tabs",          mod, %regex~^(tab_bar|tab_item)$%%),
         group_by_regex("Trees",         mod, %regex~^(tree_node|collapsing_header)$%%),
         group_by_regex("Menus",         mod, %regex~^(menu_bar|menu|menu_item)$%%),
-        group_by_regex("Popups",        mod, %regex~^(popup|modal|tooltip)$%%),
+        group_by_regex("Popups",        mod, %regex~^(popup|modal|tooltip|open_popup|open_popup_on_item_click|close_current_popup|is_popup_open)$%%),
+        hide_group(group_by_regex("Finalizers", mod, %regex~^.*_finalize$%%)),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )
     document("Built-in containers — windows, child regions, tabs, menus, popups", mod, "imgui_containers_builtin.rst", groups)
@@ -94,9 +103,11 @@ def document_module_imgui_layout_builtin(root : string) {
     var mod = find_module("imgui_layout_builtin")
     var groups <- array<DocGroup>(
         group_by_regex("Splits",        mod, %regex~^split_.*%%),
-        group_by_regex("Columns",       mod, %regex~^columns$%%),
+        group_by_regex("Columns",       mod, %regex~^(columns|columns_open|columns_close|next_col)$%%),
         group_by_regex("Dock helpers",  mod, %regex~^dock_.*%%),
         group_by_regex("Spacing",       mod, %regex~^(same_line|spacing|new_line|separator|indent|unindent)$%%),
+        group_by_regex("Trees",         mod, %regex~^(tree_pop|tree_node_open)$%%),
+        group_by_regex("List clipping", mod, %regex~^list_clipper$%%),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )
     document("Layout helpers — splits, columns, docking, spacing", mod, "imgui_layout_builtin.rst", groups)
@@ -116,11 +127,14 @@ def document_module_imgui_style_builtin(root : string) {
 def document_module_imgui_visual_aids(root : string) {
     var mod = find_module("imgui_visual_aids")
     var groups <- array<DocGroup>(
-        group_by_regex("Highlight overlay", mod, %regex~^(imgui_highlight|highlight|paint_highlight).*%%),
+        group_by_regex("Highlight overlay", mod, %regex~^(imgui_highlight|imgui_auto_highlight|highlight|paint_highlight).*%%),
         group_by_regex("Mouse trail",       mod, %regex~^(imgui_mouse_trail|mouse_trail|paint_mouse_trail).*%%),
-        group_by_regex("Narration",         mod, %regex~^(narrate|paint_narrate|paint_callout).*%%),
-        group_by_regex("HUD",               mod, %regex~^(paint_key_hud|glyph_for_imgui_key|paint_hud).*%%),
-        group_by_regex("Serve / lifecycle", mod, %regex~^(imgui_visual_aids_serve|render_visual_aids|effective_).*%%),
+        group_by_regex("Narration",         mod, %regex~^(narrate|imgui_narrate|paint_narrate|paint_callout|compute_narrate_anchor|compute_connector_).*%%),
+        group_by_regex("HUD",               mod, %regex~^(paint_key_hud|glyph_for_imgui_key|paint_hud|imgui_key_hud|imgui_focus_rect).*%%),
+        group_by_regex("Cursor sprite",     mod, %regex~^(cursor_sprite|imgui_cursor_sprite)$%%),
+        group_by_regex("Override hooks",    mod, %regex~^apply_synth_io_override$%%),
+        group_by_regex("Color utilities",   mod, %regex~^rgba$%%),
+        group_by_regex("Serve / lifecycle", mod, %regex~^(imgui_visual_aids_serve|visual_aids_init|render_visual_aids|effective_).*%%),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )
     document("Visual aids — tutorial-mode overlays, mouse trail, narration, key HUD", mod, "imgui_visual_aids.rst", groups)
@@ -129,11 +143,12 @@ def document_module_imgui_visual_aids(root : string) {
 def document_module_imgui_playwright(root : string) {
     var mod = find_module("imgui_playwright")
     var groups <- array<DocGroup>(
-        group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown).*%%),
-        group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered)$%%),
-        group_by_regex("Actions",           mod, %regex~^(click|type_text|set_value|drag|focus|open_widget|close_widget|reload)$%%),
+        group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
+        group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|get_text)$%%),
+        group_by_regex("Actions",           mod, %regex~^(click|click_at|right_click|type_text|key_tap|set_value|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|move_to|reset_cursor_pos|resize_window|say)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|expect_value|expect_render).*%%),
-        group_by_regex("Polling / await",   mod, %regex~^(wait_until|wait_for_payload_value|await_quiescent|await_probe)$%%),
+        group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe)$%%),
+        group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),
         group_by_regex("Transport plumbing", mod, %regex~^(post_command|send_imgui_command|receive_imgui_command).*%%),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )
@@ -144,8 +159,8 @@ def document_module_imgui_live(root : string) {
     var mod = [find_module("imgui_live"), find_module("imgui_live_core")]
     var groups <- array<DocGroup>(
         group_by_regex("Lifecycle",           mod, %regex~^(live_imgui_init|live_imgui_shutdown|live_imgui_.*)$%%),
-        group_by_regex("Synth IO drivers",    mod, %regex~^(synth_|imgui_mouse_|imgui_key_|imgui_synth_).*%%),
-        group_by_regex("Event timelines",     mod, %regex~^(MouseEventWire|KeyEventWire|sort_mouse_play_events|.*_play)$%%),
+        group_by_regex("Synth IO drivers",    mod, %regex~^(synth_|imgui_mouse_|imgui_key_|imgui_synth_|get_synth_|warn_if_synth_|reset_synth_).*%%),
+        group_by_regex("Event timelines",     mod, %regex~^(MouseEventWire|KeyEventWire|sort_mouse_play_events|sort_key_play_events|.*_play)$%%),
         group_by_regex("Override hooks",      mod, %regex~^(apply_synth_io_override|effective_cursor_pos|effective_synth_click)$%%),
         group_by_regex("Status / introspection", mod, %regex~^(.*_status|.*Status).*%%),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
@@ -158,7 +173,8 @@ def document_module_imgui_transport(root : string) {
     var mod = find_module("imgui_transport")
     var groups <- array<DocGroup>(
         group_by_regex("Transport construction", mod, %regex~^(live_api_transport|make_transport|with_transport)$%%),
-        group_by_regex("Send / receive",         mod, %regex~^(send_imgui_command|receive_imgui_command|post_command)$%%),
+        group_by_regex("Send / receive",         mod, %regex~^(send_imgui_command|receive_imgui_command|receive_imgui_snapshot|post_command)$%%),
+        group_by_regex("Awaiting",               mod, %regex~^(await_imgui|await_imgui_frame|send_with_await)$%%),
         group_by_regex("Framing / encoding",     mod, %regex~^(encode_|decode_|frame_).*%%),
         hide_group(group_by_regex("Internal",    mod, %regex~^(_|priv_).*%%))
     )
@@ -166,15 +182,24 @@ def document_module_imgui_transport(root : string) {
 }
 
 
+// dasImgui repo root, derived from a loaded module's own source path so docs
+// generate correctly under both -load_module (dev) and daspkg-install (CI),
+// without assuming dasImgui lives under <das_root>/modules/.
+def dasimgui_root() : string {
+    let m = find_module("imgui_boost_v2")
+    assert(m != null, "imgui_boost_v2 not loaded — cannot locate dasImgui root")
+    return dir_name(dir_name(string(m.fileName)))
+}
+
 [export]
 def main {
     disable_profiler(this_context())
     disable_profiler_log(this_context())
     ast_gc_guard() {
-        let dasimgui_doc = get_das_root() + "/modules/dasImgui/doc/source/stdlib"
+        let dasimgui_doc = dasimgui_root() + "/doc/source/stdlib"
         topic_root = "{dasimgui_doc}/generated"
         handmade_root = dasimgui_doc
-        
+
         let root = topic_root
         document_module_imgui_boost_v2(root)
         document_module_imgui_boost_runtime(root)


### PR DESCRIPTION
## Summary

- **Categorize every generated function.** Extended `group_by_regex()` patterns in `utils/imgui2rst.das` across 8 modules and added new groups (Path machinery, Coroutines, Window control, Trees, List clipping, Pause control, Awaiting, Color utilities, Cursor sprite, Override hooks, Focus & scrolling, Logging, Status queries) plus hidden `Finalizers` groups for the `*_finalize` macro-machinery helpers. Result: **zero `Uncategorized` sections** in the generated stdlib RSTs.
- **Fix the doc generator's output path.** `imgui2rst.das` previously hardcoded `get_das_root() + "/modules/dasImgui/..."`, which only resolves when dasImgui is daspkg-installed under the daslang tree (CI). Under the `-load_module` dev workflow it wrote to a phantom `<das_root>/modules/dasImgui` directory — a path that must never exist (daslang's `modules/` is reserved for the stdlib). The root is now derived from a loaded module's own source path via `Module.fileName`, so regeneration works identically in CI and locally.
- **Add a CI Uncategorized-gate.** New `docs.yml` step fails the build if any generated RST still contains an `Uncategorized` section, so future un-grouped functions are caught at PR time instead of silently shipping.

## Notes

- Generated RSTs under `doc/source/stdlib/generated/` are gitignored (CI regenerates them), so this diff is just the generator + workflow.
- The new groups required no new handmade stub files — all affected functions were already documented.

## Test plan

- [x] `imgui2rst.das` regenerates with **zero** `Uncategorized` (verified locally against freshly-rebuilt shared modules)
- [x] No phantom `<das_root>/modules/dasImgui` directory created on regen
- [x] `sphinx-build -W --keep-going` builds clean (mirrors CI)
- [x] `imgui2rst.das` passes formatter + lint
- [ ] CI `docs.yml` green (build + new gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)