### PR TITLE
feat(live): imgui_mouse_click_at + set_user_control synth-IO commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to dasImgui are documented in this file. Format based on
 ## [Unreleased]
 
 ### Added
+- `imgui_mouse_click_at` live command (`widgets/imgui_live_core.das`) — atomic click at `(x, y)`: travel → press → release as one self-contained synth timeline, with a `button` arg (`0`=left, `1`=right, `2`=middle) and optional `travel_ms`. Callers no longer hand-build a `click_at` event array for `imgui_mouse_play`; one round-trip can't interleave with real input mid-gesture.
+- `set_user_control` live command (`widgets/imgui_live_core.das`) — `{enabled:false}` makes `imgui_synth_tick` clear the GLFW backend's queued mouse/keyboard each frame (via `GetIO().ClearEventsQueue()`) so ONLY synth IO drives the UI, with no real-input bleed-through racing the synth cursor; `{enabled:true}` releases synth ownership (stops playback, releases held buttons/keys, clears `synth_cursor_owned`) and hands control back. Defaults on — zero behavior change when never called. Public getter `user_control_enabled()`.
 - Live docs site at https://borisbat.github.io/dasImgui
 - GitHub repo link + daspkg install snippet on the docs landing page (`doc/source/index.rst`)
 - "Edit on GitHub" header link on every docs page (via `sphinx_rtd_theme.html_context` in `doc/source/conf.py`)

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -160,6 +160,7 @@ def document_module_imgui_live(root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Lifecycle",           mod, %regex~^(live_imgui_init|live_imgui_shutdown|live_imgui_.*)$%%),
         group_by_regex("Synth IO drivers",    mod, %regex~^(synth_|imgui_mouse_|imgui_key_|imgui_synth_|get_synth_|warn_if_synth_|reset_synth_).*%%),
+        group_by_regex("User input control",  mod, %regex~^(set_user_control|user_control_enabled)$%%),
         group_by_regex("Event timelines",     mod, %regex~^(MouseEventWire|KeyEventWire|sort_mouse_play_events|sort_key_play_events|.*_play)$%%),
         group_by_regex("Override hooks",      mod, %regex~^(apply_synth_io_override|effective_cursor_pos|effective_synth_click)$%%),
         group_by_regex("Status / introspection", mod, %regex~^(.*_status|.*Status).*%%),

--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -313,9 +313,12 @@ def set_user_control(input : JsonValue?) : JsonValue? {
         release_held_keys()
         synth_cursor_owned = false
     } else {
-        // Take over: release any real keys latched now — their release events
-        // would otherwise be dropped by the per-frame queue clear, leaving a
-        // stuck key. Synth-held keys (our own table) are re-asserted next tick.
+        // Take over: reset any real keys/mouse buttons latched right now —
+        // otherwise their release events get dropped by the per-frame queue
+        // clear, leaving ImGui with stuck input. ClearInputKeys() in imgui
+        // 1.90.6 also zeroes MouseDown[]/MousePos (imgui.cpp:1478), so this one
+        // call covers buttons too. Synth-held keys (our own table) re-assert
+        // next tick.
         var io & = unsafe(GetIO())
         io |> ClearInputKeys()
     }

--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -55,6 +55,11 @@ var public synth_click_action : int   = 0    // 1 = press, 0 = release
 var public synth_click_t      : float = -1.0
 var private synth_held_buttons : table<int>
 
+// When false (set via the `set_user_control` live command), imgui_synth_tick drops
+// the GLFW backend's per-frame input queue so ONLY synth IO drives the UI — the real
+// mouse/keyboard can't bleed through and race the synth timeline.
+var private g_user_control : bool = true
+
 def private synth_cursor_pos(x, y : float) {
     mouse_cursor_x = x
     mouse_cursor_y = y
@@ -171,6 +176,30 @@ def imgui_mouse_move_to(input : JsonValue?) : JsonValue? {
     return JV((duration_ms = args.duration_ms))
 }
 
+struct MouseClickAtArgs {
+    x : float = 0.0
+    y : float = 0.0
+    @optional button    : int = 0
+    @optional travel_ms : int = 250
+}
+
+[live_command(description="Atomic click: travel to (x,y) then press+release `button` (0=left,1=right,2=middle) as one self-contained timeline via ImGui bypass — no separate move/click round-trips to interleave with real input. Args: x, y, button?, travel_ms?")]
+def imgui_mouse_click_at(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<MouseClickAtArgs>)
+    let travel = max(1, args.travel_ms)
+    reset_mouse_timeline()
+    mouse_timeline |> reserve(5)
+    mouse_timeline |> push(MouseEvent(t_ms = 0,            kind = MEKind.move,   x = mouse_cursor_x,   y = mouse_cursor_y))
+    mouse_timeline |> push(MouseEvent(t_ms = travel,       kind = MEKind.move,   x = args.x,           y = args.y))
+    mouse_timeline |> push(MouseEvent(t_ms = travel + 200, kind = MEKind.button, button = args.button, action = 1))
+    mouse_timeline |> push(MouseEvent(t_ms = travel + 300, kind = MEKind.button, button = args.button, action = 0))
+    mouse_timeline |> push(MouseEvent(t_ms = travel + 500, kind = MEKind.move,   x = args.x,           y = args.y))
+    mouse_play_start = get_uptime()
+    mouse_playing    = true
+    warn_if_synth_tick_missing("imgui_mouse_click_at")
+    return JV((x = args.x, y = args.y, button = args.button, queued = length(mouse_timeline)))
+}
+
 struct MouseEventWire {
     @optional t_ms   : int    = 0
     kind             : string = "move"
@@ -262,6 +291,40 @@ def imgui_mouse_status(input : JsonValue?) : JsonValue? {
         held_count   = length(synth_held_buttons),
         cursor_owned = synth_cursor_owned
     ))
+}
+
+struct UserControlArgs {
+    @optional enabled : bool = true
+}
+
+[live_command(description="Toggle real user input. When disabled, imgui_synth_tick drops the GLFW backend's queued mouse/keyboard each frame so ONLY synth IO (imgui_mouse_*/imgui_key_*) drives the UI — no real-input bleed-through racing the synth timeline. Re-enable to hand control back. Requires apply_synth_io_override() in the loop. Args: enabled (bool)")]
+def set_user_control(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<UserControlArgs>)
+    g_user_control = args.enabled
+    if (args.enabled) {
+        // Hand control back: synth must fully let go. `synth_cursor_owned` is
+        // sticky, so imgui_synth_tick keeps re-asserting the synth cursor pos
+        // every frame and the real mouse can't move it. Stop any playback,
+        // release held inputs, then drop ownership (release_* re-arm it, so
+        // clear last).
+        reset_mouse_timeline()
+        release_held_buttons()
+        reset_key_timeline()
+        release_held_keys()
+        synth_cursor_owned = false
+    } else {
+        // Take over: release any real keys latched now — their release events
+        // would otherwise be dropped by the per-frame queue clear, leaving a
+        // stuck key. Synth-held keys (our own table) are re-asserted next tick.
+        var io & = unsafe(GetIO())
+        io |> ClearInputKeys()
+    }
+    return JV((user_control = g_user_control))
+}
+
+def public user_control_enabled() : bool {
+    //! False when ``set_user_control`` has disabled real input — :ref:`imgui_synth_tick <function-imgui_live_core_imgui_synth_tick>` is dropping the backend input queue each frame so synth fully owns IO.
+    return g_user_control
 }
 
 def private advance_mouse_timeline() {
@@ -702,6 +765,14 @@ var private g_synth_warned_no_override : bool = false
 def public imgui_synth_tick() {
     //! Per-frame entry point — advance synth mouse/key timelines and re-assert held state. Call between the backend's ``*_NewFrame()`` and ``ImGui::NewFrame()``; no-op when no synth command has fired.
     g_synth_tick_run_count++
+    if (!g_user_control) {
+        // Real input suppressed: drop everything the GLFW backend queued this frame
+        // (mouse pos from ImGui_ImplGlfw_NewFrame, buttons/keys/char from the poll
+        // callbacks) BEFORE the synth timeline re-queues its own events below, so
+        // NewFrame() drains synth-only. Toggled by the `set_user_control` command.
+        var io & = unsafe(GetIO())
+        io |> ClearEventsQueue()
+    }
     advance_mouse_timeline()
     advance_key_timeline()
     let synth_armed = synth_cursor_owned || !empty(synth_held_keys) || !empty(synth_held_buttons)


### PR DESCRIPTION
## Summary

Two additive `[live_command]`s in `widgets/imgui_live_core.das` that came out of driving the dasImguiNodeEditor example interactively. Both default-gated — **zero behavior change unless explicitly invoked.**

- **`imgui_mouse_click_at(x, y, button?, travel_ms?)`** — atomic click as one self-contained synth timeline (travel → press → release → dwell). `button` is `0`=left / `1`=right / `2`=middle. Previously callers had to hand-build a `click_at` event array and post `imgui_mouse_play`; splitting a click into separate `imgui_mouse_pos` + `imgui_mouse_click` round-trips let real input interleave and corrupt the press position. This is the gesture as one call.

- **`set_user_control(enabled)`** — `{enabled:false}` makes `imgui_synth_tick` clear the GLFW backend's queued mouse/keyboard each frame (`GetIO().ClearEventsQueue()`) **before** the synth timeline re-queues, so `NewFrame()` drains synth-only and the real mouse/keyboard can't bleed through and race the synth cursor. `{enabled:true}` releases synth ownership (stops playback, releases held buttons/keys, clears the sticky `synth_cursor_owned`) and hands control back. Public getter `user_control_enabled()`.

The clear lives at the top of `imgui_synth_tick` (between the backend's per-frame poll and `ImGui::NewFrame()`), gated on `g_user_control` (default `true`), so existing synth behavior is untouched when the new command is never called.

## Test plan

- [x] `compile_check` + `lint` clean on `widgets/imgui_live_core.das`
- [x] `tests/integration/test_imgui_synth_mouse.das` — PASS (headless)
- [x] `tests/integration/test_synth_io_override_warning.das` — PASS (headless, exercises the edited `imgui_synth_tick` warning path)
- [x] Verified live against the dasImguiNodeEditor `shader_graph` example: `set_user_control{enabled:false}` → synth right-click opened the Create-Node context menu and synth left-click spawned a node, entirely synth (no real-input race); `cursor_owned` flips back to `false` on re-enable
- [ ] CI matrix (ubuntu / macos / windows) via this draft PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)