### PR TITLE
Generalize with_imgui_app (extra modules) + lock real input at the GLFW source

### DIFF
--- a/src/module_imgui_app.cpp
+++ b/src/module_imgui_app.cpp
@@ -59,6 +59,21 @@ DAS_MOD_API void das_imgui_synth_input_char ( uint32_t cp ) {
     ImGui::GetIO().AddInputCharacter(cp);
 }
 
+// Detach (false) / reattach (true) the GLFW backend's input callbacks for the
+// current-context window, so when imgui_live_core disables user control real
+// mouse/keyboard stop reaching ImGui AT THE SOURCE (no callbacks fire) — closing
+// the race a per-frame event-queue clear can't win. Synth IO uses io.Add*Event
+// directly and is unaffected. No-op when there is no current GLFW window (headless).
+// Caller toggles only on a state change, honoring ImGui_ImplGlfw's
+// InstalledCallbacks invariant (Install asserts when already installed, and
+// vice-versa). Must run on the render/main thread — glfwSet*Callback requires it.
+DAS_MOD_API void das_imgui_set_real_input_callbacks ( bool enabled ) {
+    GLFWwindow * w = glfwGetCurrentContext();
+    if ( !w ) return;
+    if ( enabled ) ImGui_ImplGlfw_InstallCallbacks(w);
+    else ImGui_ImplGlfw_RestoreCallbacks(w);
+}
+
 // making custom builtin module
 class Module_imgui_app : public Module {
     ModuleLibrary lib;
@@ -97,6 +112,10 @@ public:
             SideEffects::worstDefault, "ImGui_ImplGlfw_Shutdown");
         addExtern<DAS_BIND_FUN(ImGui_ImplGlfw_NewFrame)>(*this,lib,"ImGui_ImplGlfw_NewFrame",
             SideEffects::worstDefault, "ImGui_ImplGlfw_NewFrame");
+        // Detach/reattach the backend's GLFW input callbacks at runtime — used by
+        // imgui_live_core to suppress real input AT THE SOURCE when user control is off.
+        addExtern<DAS_BIND_FUN(das_imgui_set_real_input_callbacks)>(*this,lib,"imgui_set_real_input_callbacks",
+            SideEffects::worstDefault, "das_imgui_set_real_input_callbacks");
         addExtern<DAS_BIND_FUN(ImGui_ImplGlfw_MouseButtonCallback)>(*this,lib,"ImGui_ImplGlfw_MouseButtonCallback",
             SideEffects::worstDefault, "ImGui_ImplGlfw_MouseButtonCallback");
         addExtern<DAS_BIND_FUN(ImGui_ImplGlfw_ScrollCallback)>(*this,lib,"ImGui_ImplGlfw_ScrollCallback",
@@ -148,6 +167,7 @@ public:
         tw << "DAS_MOD_API void das_imgui_synth_mouse_wheel ( float dx, float dy );\n";
         tw << "DAS_MOD_API void das_imgui_synth_key ( int key, bool down );\n";
         tw << "DAS_MOD_API void das_imgui_synth_input_char ( uint32_t cp );\n";
+        tw << "DAS_MOD_API void das_imgui_set_real_input_callbacks ( bool enabled );\n";
         return ModuleAotType::cpp;
     }
 };

--- a/tests/integration/test_user_control.das
+++ b/tests/integration/test_user_control.das
@@ -1,0 +1,53 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration regression for set_user_control's real-input ownership toggle and
+//! the GLFW-callback detach/reattach path added to imgui_synth_tick (the fix for
+//! "real clicks sometimes still select while the canvas is locked" — a per-frame
+//! event-queue clear couldn't fully close that race, so we now detach the backend
+//! input callbacks AT THE SOURCE).
+//!
+//! Real-input *blocking* needs a physical mouse, so it's verified manually. This
+//! guards the toggle's observable contract: the command round-trips, the per-frame
+//! tick runs through BOTH transitions (detach + reattach) without crashing or
+//! wedging — in headless CI the source-detach is a no-op (no current GLFW window),
+//! which also exercises the helper's null-guard — and the UI stays responsive.
+
+let FEATURE = "modules/dasImgui/examples/features/active_widget.das"
+
+[test]
+def test_user_control_toggle(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        t |> success(wait_for_widget(d, "MAIN_WIN/DEMO_BTN", 15.0f) != null,
+                     "app rendered (ImGui context up)")
+
+        // Disable: subsequent ticks detach the GLFW input callbacks at the source.
+        let r_off = post_command(d, "set_user_control", JV((enabled = false)))
+        t |> equal(r_off?["user_control"] ?? true, false, "control disabled")
+
+        // Frames keep advancing cleanly while disabled (the per-frame detach +
+        // ClearEventsQueue path runs without crashing or wedging).
+        t |> success(wait_for_widget(d, "MAIN_WIN/DEMO_BTN", 5.0f) != null,
+                     "still rendering while control disabled")
+
+        // Re-enable: subsequent ticks reattach the callbacks.
+        let r_on = post_command(d, "set_user_control", JV((enabled = true)))
+        t |> equal(r_on?["user_control"] ?? false, true, "control re-enabled")
+
+        // Repeated toggle must remain stable (no double install/restore wedge)...
+        post_command(d, "set_user_control", JV((enabled = false)))
+        let r_on2 = post_command(d, "set_user_control", JV((enabled = true)))
+        t |> equal(r_on2?["user_control"] ?? false, true, "stable after repeated toggles")
+
+        // ...and the UI is still responsive afterward (L3 click round-trips).
+        let click_after = click(d, "MAIN_WIN/DEMO_BTN")
+        t |> equal(click_after?["ok"] ?? false, true, "UI responsive after toggles")
+    }
+}

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -160,7 +160,7 @@ def document_module_imgui_live(root : string) {
     var groups <- array<DocGroup>(
         group_by_regex("Lifecycle",           mod, %regex~^(live_imgui_init|live_imgui_shutdown|live_imgui_.*)$%%),
         group_by_regex("Synth IO drivers",    mod, %regex~^(synth_|imgui_mouse_|imgui_key_|imgui_synth_|get_synth_|warn_if_synth_|reset_synth_).*%%),
-        group_by_regex("User input control",  mod, %regex~^(set_user_control|user_control_enabled)$%%),
+        group_by_regex("User input control",  mod, %regex~^(set_user_control.*|user_control_enabled)$%%),
         group_by_regex("Event timelines",     mod, %regex~^(MouseEventWire|KeyEventWire|sort_mouse_play_events|sort_key_play_events|.*_play)$%%),
         group_by_regex("Override hooks",      mod, %regex~^(apply_synth_io_override|effective_cursor_pos|effective_synth_click)$%%),
         group_by_regex("Status / introspection", mod, %regex~^(.*_status|.*Status).*%%),

--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -9,7 +9,7 @@ module imgui_live_core shared public
 // per-frame imgui_synth_tick. Re-exported by imgui_live.
 
 require imgui public
-require imgui_app
+require imgui_app           // imgui_set_real_input_callbacks — detach/reattach GLFW input at source
 require daslib/json public
 require daslib/json_boost public
 require daslib/utf8_utils
@@ -55,10 +55,15 @@ var public synth_click_action : int   = 0    // 1 = press, 0 = release
 var public synth_click_t      : float = -1.0
 var private synth_held_buttons : table<int>
 
-// When false (set via the `set_user_control` live command), imgui_synth_tick drops
-// the GLFW backend's per-frame input queue so ONLY synth IO drives the UI — the real
-// mouse/keyboard can't bleed through and race the synth timeline.
+// When false (set via the `set_user_control` live command), imgui_synth_tick detaches
+// the GLFW backend's input callbacks (and drops any queued input) so ONLY synth IO
+// drives the UI — the real mouse/keyboard can't reach ImGui and race the synth timeline.
 var private g_user_control : bool = true
+// Tracks whether the backend's GLFW input callbacks are currently attached, so
+// imgui_synth_tick toggles them only on a g_user_control transition (matching
+// ImGui_ImplGlfw's InstalledCallbacks invariant). True at startup: the windowed
+// host installs them via ImGui_ImplGlfw_InitForOpenGL(window, true).
+var private g_input_callbacks_installed : bool = true
 
 def private synth_cursor_pos(x, y : float) {
     mouse_cursor_x = x
@@ -297,11 +302,13 @@ struct UserControlArgs {
     @optional enabled : bool = true
 }
 
-[live_command(description="Toggle real user input. When disabled, imgui_synth_tick drops the GLFW backend's queued mouse/keyboard each frame so ONLY synth IO (imgui_mouse_*/imgui_key_*) drives the UI — no real-input bleed-through racing the synth timeline. Re-enable to hand control back. Requires apply_synth_io_override() in the loop. Args: enabled (bool)")]
-def set_user_control(input : JsonValue?) : JsonValue? {
-    let args = from_JV(input, type<UserControlArgs>)
-    g_user_control = args.enabled
-    if (args.enabled) {
+def public set_user_control_enabled(enabled : bool) {
+    //! Programmatic form of the `set_user_control` live command — toggle whether real
+    //! mouse/keyboard reach the UI. The actual GLFW-callback detach/reattach (source-level
+    //! suppression) happens on the next `imgui_synth_tick` transition, so this is safe to
+    //! call off the render thread.
+    g_user_control = enabled
+    if (enabled) {
         // Hand control back: synth must fully let go. `synth_cursor_owned` is
         // sticky, so imgui_synth_tick keeps re-asserting the synth cursor pos
         // every frame and the real mouse can't move it. Stop any playback,
@@ -322,6 +329,12 @@ def set_user_control(input : JsonValue?) : JsonValue? {
         var io & = unsafe(GetIO())
         io |> ClearInputKeys()
     }
+}
+
+[live_command(description="Toggle real user input. When disabled, imgui_synth_tick detaches the GLFW backend's input callbacks (and drops queued input) so ONLY synth IO (imgui_mouse_*/imgui_key_*) drives the UI — no real-input bleed-through racing the synth timeline. Re-enable to hand control back. Requires apply_synth_io_override() in the loop. Args: enabled (bool)")]
+def set_user_control(input : JsonValue?) : JsonValue? {
+    let args = from_JV(input, type<UserControlArgs>)
+    set_user_control_enabled(args.enabled)
     return JV((user_control = g_user_control))
 }
 
@@ -768,6 +781,20 @@ var private g_synth_warned_no_override : bool = false
 def public imgui_synth_tick() {
     //! Per-frame entry point — advance synth mouse/key timelines and re-assert held state. Call between the backend's ``*_NewFrame()`` and ``ImGui::NewFrame()``; no-op when no synth command has fired.
     g_synth_tick_run_count++
+    // Real-input suppression, applied at the GLFW SOURCE. We run here (not in the
+    // set_user_control command handler) because glfwSet*Callback must run on the
+    // render/main thread, and this tick does. On a g_user_control transition,
+    // detach/reattach the backend's input callbacks so real mouse/keyboard never
+    // reach ImGui's event queue at all — synth IO uses io.Add*Event directly and is
+    // unaffected. This closes the race a per-frame queue clear can't win (Windows
+    // dispatches some button messages outside the top-of-frame poll, e.g. during the
+    // vsync swap), which let real clicks occasionally still select. No-op in headless
+    // (no current GLFW window). The ClearEventsQueue below stays as belt-and-suspenders
+    // for whatever was queued on the transition frame itself.
+    if (g_user_control != g_input_callbacks_installed) {
+        imgui_set_real_input_callbacks(g_user_control)
+        g_input_callbacks_installed = g_user_control
+    }
     if (!g_user_control) {
         // Real input suppressed: drop everything the GLFW backend queued this frame
         // (mouse pos from ImGui_ImplGlfw_NewFrame, buttons/keys/char from the poll

--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -820,6 +820,20 @@ def public imgui_synth_tick() {
     }
 }
 
+[before_reload]
+def reattach_real_input_before_reload() {
+    // Live reload reuses the ImGui context (live_imgui_init skips InitForOpenGL on
+    // reload) but resets module globals — the new program starts with g_user_control
+    // and g_input_callbacks_installed back at their `true` defaults. If real input was
+    // detached at reload time, the callbacks would stay restored while the new program
+    // believes they're installed → real input permanently dead until restart. Re-attach
+    // now so the handoff state matches the post-reload defaults (installed + enabled).
+    if (!g_input_callbacks_installed) {
+        imgui_set_real_input_callbacks(true)
+        g_input_callbacks_installed = true
+    }
+}
+
 def public synth_tick_run_count() : int {
     //! Number of times :ref:`imgui_synth_tick <function-imgui_live_core_imgui_synth_tick>` has run this process. Zero means ``apply_synth_io_override()`` has never fired — any queued synth event will silently no-op.
     return g_synth_tick_run_count

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -151,10 +151,13 @@ def private dasimgui_module_root() : string {
     return dir_name(get_this_module_dir())
 }
 
-def private resolve_feature_path(path : string) : string {
+def private resolve_feature_path(path : string; feature_root : string; feature_prefix : string) : string {
     if (is_absolute(path)) return path
-    // Strip the `modules/dasImgui/` prefix and resolve under the runtime
-    // module root so tests find feature files regardless of layout.
+    // Caller-supplied root/prefix first — lets another package (e.g. dasImguiNodeEditor)
+    // resolve its own feature files under its own module root via `with_imgui_app`.
+    if (feature_prefix != "" && path |> starts_with(feature_prefix)) return path_join(feature_root, slice(path, length(feature_prefix)))
+    // Then dasImgui's own layout: strip `modules/dasImgui/` and resolve under the
+    // runtime module root so tests find feature files regardless of layout.
     let prefix = "modules/dasImgui/"
     if (path |> starts_with(prefix)) return path_join(dasimgui_module_root(), slice(path, length(prefix)))
     return path_join(get_das_root(), path)
@@ -616,9 +619,28 @@ def private playwright_worker_index() : int {
 
 def public with_imgui_app(feature_path : string;
                           body : block<(app : ImguiApp) : void>) {
-    //! Spawn ``daslang-live <feature_path>``; runs ``body`` while alive, then
-    //! POSTs ``/shutdown`` and drains stdout. Panics on non-zero exit code,
-    //! ready-timeout, or test-timeout so the surrounding ``[test]`` fails.
+    //! Spawn ``daslang-live <feature_path>`` with the dasImgui module loaded; runs
+    //! ``body`` while alive, then POSTs ``/shutdown`` and drains stdout. Panics on
+    //! non-zero exit code, ready-timeout, or test-timeout so the surrounding
+    //! ``[test]`` fails. The common case — for a feature whose ``require`` chain
+    //! needs ONLY dasImgui. Delegates to the 5-arg overload with no extra modules.
+    let no_extra : array<string>
+    with_imgui_app(feature_path, no_extra, "", "", body)
+}
+
+def public with_imgui_app(feature_path : string;
+                          extra_module_roots : array<string>;
+                          feature_root : string;
+                          feature_prefix : string;
+                          body : block<(app : ImguiApp) : void>) {
+    //! Full form — spawn ``daslang-live`` for a feature whose ``require`` chain
+    //! needs dasImgui PLUS the modules at ``extra_module_roots`` (each gets its own
+    //! ``-load_module``, appended after dasImgui's so dependency order holds). A
+    //! relative ``feature_path`` starting with ``feature_prefix`` resolves under
+    //! ``feature_root`` (pass ``""``/``""`` to use dasImgui's default resolution).
+    //! This is how another package (e.g. dasImguiNodeEditor) drives its own app
+    //! without duplicating the spawn/port/headless/ready/shutdown machinery — the
+    //! extra-module config is threaded through args, not module globals.
     //!
     //! Port is always DEFAULT_LIVE_PORT + worker_index — sequential runs (no
     //! --worker-index in argv) get 9090; dastest's isolated mode brands each
@@ -631,16 +653,24 @@ def public with_imgui_app(feature_path : string;
     let port = DEFAULT_LIVE_PORT + playwright_worker_index()
     let ready_timeout_sec = DEFAULT_READY_TIMEOUT_SEC
     let test_timeout_sec = DEFAULT_TEST_TIMEOUT_SEC
-    let app_path = resolve_feature_path(feature_path)
+    let app_path = resolve_feature_path(feature_path, feature_root, feature_prefix)
     // -load_module points the spawned daslang-live at the dasImgui module so
     // the feature's `require imgui/...` chain resolves regardless of layout.
     // In CI dasImgui is in the standard module search path so this is a
-    // harmless duplicate; locally it's load-bearing.
+    // harmless duplicate; locally it's load-bearing. Extra roots follow, so a
+    // dependent module (e.g. node-editor, which requires dasImgui) loads after it.
     //
     // --live-port pins the spawned daslang-live's HTTP API to the same port
     // playwright's base_url targets, so daslang-live's single-instance-lock
     // keys off the same port playwright dials.
-    var argv <- [exe, "-load_module", dasimgui_module_root(), "--live-port={port}", app_path]
+    var argv <- [exe, "-load_module", dasimgui_module_root()]
+    argv |> reserve(length(argv) + length(extra_module_roots) * 2)
+    for (root in extra_module_roots) {
+        argv |> push("-load_module")
+        argv |> push(root)
+    }
+    argv |> push("--live-port={port}")
+    argv |> push(app_path)
     if (playwright_wants_headless()) {
         argv |> push("--")
         argv |> push("--headless")


### PR DESCRIPTION
Two dasImgui changes, one per commit.

## 1. `with_imgui_app` — extra modules + feature root (`imgui_playwright.das`)

Adds a 5-arg overload:

```
with_imgui_app(feature_path, extra_module_roots, feature_root, feature_prefix, body)
```

- Each root in `extra_module_roots` gets its own `-load_module` (appended **after** dasImgui's, so a dependent module loads after it).
- A relative `feature_path` matching `feature_prefix` resolves under `feature_root` (else dasImgui's own layout, then das_root).
- The existing `with_imgui_app(feature_path, body)` stays as a delegate — **unchanged behavior** for every current caller.

This lets another package drive its own app through the shared spawn / port / headless / worker / ready / shutdown machinery instead of duplicating it — config threaded through **args, not module globals**. `dasImguiNodeEditor`'s `with_node_editor_app` (which was a 1:1 copy of all that machinery) collapses to a one-line delegate over this — that's a follow-up PR in the node-editor repo (it depends on this landing first).

## 2. Lock real input at the GLFW source when user control is off (`module_imgui_app.cpp`, `imgui_live_core.das`)

**Bug:** with `set_user_control{enabled:false}`, real mouse buttons *sometimes* still worked — you could occasionally still select nodes in the live editor while "locked."

**Root cause:** suppression was a per-frame `io.ClearEventsQueue()` in `imgui_synth_tick` — queue-only, and it loses a race on Windows where the OS dispatches some mouse-button messages outside the top-of-frame `glfwPollEvents` (e.g. during the vsync swap), so a real click survives into a `NewFrame`.

**Fix:** detach the backend's GLFW input callbacks **at the source** while control is off, reattach when it's back.
- New C++ helper `imgui_set_real_input_callbacks(bool)` (imgui_app module) wraps `ImGui_ImplGlfw_Install/RestoreCallbacks` on the current-context window; **no-op when there's no GLFW window** (headless).
- `imgui_synth_tick` applies it on a `g_user_control` transition — on the render thread (where `glfwSet*Callback` must run), honoring ImGui_ImplGlfw's `InstalledCallbacks` invariant.
- Synth IO is unaffected — it calls `io.Add*Event` directly, bypassing the callbacks. `ClearEventsQueue` stays as belt-and-suspenders for the transition frame.
- Extracted `set_user_control_enabled(bool)` (public) from the live command so the toggle is callable/testable directly.

**Verified manually** in the live node editor: with control locked, real click/drag/right-click/box-select are now fully ignored, and re-enabling restores them cleanly.

## Tests

`tests/integration/test_user_control.das` — integration regression: the command round-trips, the per-frame tick runs through **both** transitions (detach + reattach, incl. repeated toggles) without crashing or wedging, and the UI stays responsive. (Real-input *blocking* is window+mouse-only → verified manually; in headless CI the source-detach is a no-op, which also covers the helper's null-guard.) Existing `test_synth_io_override_warning` + `test_active_widget` still green; node-editor `test_topology` green against the rebuilt module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)