### PR TITLE
boost_runtime: screen-space snapshot via a push/pop item-transform stack

### DIFF
--- a/examples/features/snapshot_transform.das
+++ b/examples/features/snapshot_transform.das
@@ -1,0 +1,56 @@
+options gen2
+
+require imgui/imgui_harness
+require imgui/imgui_boost_runtime
+
+// =============================================================================
+// FEATURE: snapshot_transform — exercises the snapshot item-transform hook in
+//          isolation (no node-editor needed). A custom canvas would normally set
+//          this from its coordinate mapping; here we set a known synthetic affine
+//          around ONE widget so a test can assert the contract directly:
+//            - widget under the transform: bbox = local*scale + offset, plus a
+//              canvas_bbox carrying the original (screen-native) rect;
+//            - widgets before it / after clear: screen-native bbox, no canvas_bbox.
+// DRIVE:   tests/integration/test_snapshot_transform.das
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/snapshot_transform.das
+// =============================================================================
+
+let XFORM_SCALE  = float2(2.0, 3.0)
+let XFORM_OFFSET = float2(100.0, 50.0)
+
+[export]
+def init() {
+    harness_init("Snapshot item-transform", 640, 480)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+    window(MAIN_WIN, (text = "Snapshot item-transform", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        // No active transform — screen-native bbox, no canvas_bbox.
+        button(PLAIN_BTN, (text = "plain"))
+        // Active transform — interior widget reports screen-space bbox + canvas_bbox.
+        set_snapshot_item_transform(XFORM_SCALE, XFORM_OFFSET)
+        button(XFORM_BTN, (text = "xform"))
+        clear_snapshot_item_transform()
+        // Cleared — back to screen-native, no canvas_bbox.
+        button(AFTER_BTN, (text = "after"))
+    }
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/snapshot_transform.das
+++ b/examples/features/snapshot_transform.das
@@ -4,13 +4,13 @@ require imgui/imgui_harness
 require imgui/imgui_boost_runtime
 
 // =============================================================================
-// FEATURE: snapshot_transform — exercises the snapshot item-transform hook in
-//          isolation (no node-editor needed). A custom canvas would normally set
-//          this from its coordinate mapping; here we set a known synthetic affine
+// FEATURE: snapshot_transform — exercises the snapshot item-transform stack in
+//          isolation (no node-editor needed). A custom canvas would normally push
+//          this from its coordinate mapping; here we push a known synthetic affine
 //          around ONE widget so a test can assert the contract directly:
 //            - widget under the transform: bbox = local*scale + offset, plus a
 //              canvas_bbox carrying the original (screen-native) rect;
-//            - widgets before it / after clear: screen-native bbox, no canvas_bbox.
+//            - widgets before the push / after the pop: screen-native bbox, no canvas_bbox.
 // DRIVE:   tests/integration/test_snapshot_transform.das
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/snapshot_transform.das
 // =============================================================================
@@ -34,6 +34,14 @@ def update() {
         // Active transform — interior widget reports screen-space bbox + canvas_bbox.
         push_snapshot_item_transform(XFORM_SCALE, XFORM_OFFSET)
         button(XFORM_BTN, (text = "xform"))
+        // A CONTAINER header (tab_item) under the transform: its bbox is captured via
+        // current_item_bbox(), so it must also report screen-space, not canvas-local.
+        tab_bar(XFORM_TABS, (text = "xform-tabs", flags = ImGuiTabBarFlags.None)) {
+            tab_item(XFORM_TAB, (text = "T", closable = false,
+                                 flags = ImGuiTabItemFlags.None)) {
+                text("body")
+            }
+        }
         pop_snapshot_item_transform()
         // Popped — back to screen-native, no canvas_bbox.
         button(AFTER_BTN, (text = "after"))

--- a/examples/features/snapshot_transform.das
+++ b/examples/features/snapshot_transform.das
@@ -32,10 +32,10 @@ def update() {
         // No active transform — screen-native bbox, no canvas_bbox.
         button(PLAIN_BTN, (text = "plain"))
         // Active transform — interior widget reports screen-space bbox + canvas_bbox.
-        set_snapshot_item_transform(XFORM_SCALE, XFORM_OFFSET)
+        push_snapshot_item_transform(XFORM_SCALE, XFORM_OFFSET)
         button(XFORM_BTN, (text = "xform"))
-        clear_snapshot_item_transform()
-        // Cleared — back to screen-native, no canvas_bbox.
+        pop_snapshot_item_transform()
+        // Popped — back to screen-native, no canvas_bbox.
         button(AFTER_BTN, (text = "after"))
     }
     harness_end_frame()

--- a/tests/integration/test_snapshot_transform.das
+++ b/tests/integration/test_snapshot_transform.das
@@ -1,0 +1,60 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Contract test for the snapshot item-transform hook (set/clear_snapshot_item_transform).
+//! Drives examples/features/snapshot_transform.das, which wraps ONE button in a known
+//! synthetic affine (scale (2,3), offset (100,50)) with plain buttons before it and
+//! after the clear. Asserts:
+//!   - the transformed button reports bbox = canvas_bbox*scale + offset (the captured
+//!     local rect mapped to screen), with canvas_bbox carrying the local rect;
+//!   - widgets with no active transform (before, and after clear) report a screen-native
+//!     bbox and NO canvas_bbox — i.e. clear restores the default behavior.
+
+let FEATURE = "modules/dasImgui/examples/features/snapshot_transform.das"
+
+def private near(a : float; b : float; tol : float) : bool {
+    let d = a - b
+    return d <= tol && d >= -tol
+}
+
+[test]
+def test_snapshot_transform(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_widget(d, "MAIN_WIN/XFORM_BTN", 15.0f)
+        t |> success(snap != null, "snapshot returned with the transformed button registered")
+        if (snap == null) return
+
+        // ---- no active transform before: screen-native, no canvas_bbox ----
+        t |> success(widget_exists(snap, "MAIN_WIN/PLAIN_BTN"), "plain button present")
+        let plain_cbb = find_widget(snap, "MAIN_WIN/PLAIN_BTN")?["canvas_bbox"]?["z"] ?? -1.0f
+        t |> success(plain_cbb < 0.0f, "plain button carries no canvas_bbox (no active transform)")
+
+        // ---- under the transform: bbox = local*scale + offset, canvas_bbox = local ----
+        let xf = find_widget(snap, "MAIN_WIN/XFORM_BTN")
+        let lx = xf?["canvas_bbox"]?["x"] ?? -1.0f
+        let ly = xf?["canvas_bbox"]?["y"] ?? -1.0f
+        let lz = xf?["canvas_bbox"]?["z"] ?? -1.0f
+        let lw = xf?["canvas_bbox"]?["w"] ?? -1.0f
+        t |> success(lx >= 0.0f && lz > lx, "xform button carries a canvas_bbox (local rect)")
+        let bx = xf?["bbox"]?["x"] ?? 0.0f
+        let by = xf?["bbox"]?["y"] ?? 0.0f
+        let bz = xf?["bbox"]?["z"] ?? 0.0f
+        let bw = xf?["bbox"]?["w"] ?? 0.0f
+        t |> success(near(bx, lx * 2.0f + 100.0f, 0.5f), "bbox.x == local.x*2 + 100")
+        t |> success(near(by, ly * 3.0f + 50.0f, 0.5f), "bbox.y == local.y*3 + 50")
+        t |> success(near(bz, lz * 2.0f + 100.0f, 0.5f), "bbox.z == local.z*2 + 100")
+        t |> success(near(bw, lw * 3.0f + 50.0f, 0.5f), "bbox.w == local.w*3 + 50")
+
+        // ---- after clear: screen-native again, no canvas_bbox ----
+        t |> success(widget_exists(snap, "MAIN_WIN/AFTER_BTN"), "after-clear button present")
+        let after_cbb = find_widget(snap, "MAIN_WIN/AFTER_BTN")?["canvas_bbox"]?["z"] ?? -1.0f
+        t |> success(after_cbb < 0.0f, "after-clear button carries no canvas_bbox (clear restored identity)")
+    }
+}

--- a/tests/integration/test_snapshot_transform.das
+++ b/tests/integration/test_snapshot_transform.das
@@ -52,14 +52,18 @@ def test_snapshot_transform(t : T?) {
         t |> success(near(bz, lz * 2.0f + 100.0f, 0.5f), "bbox.z == local.z*2 + 100")
         t |> success(near(bw, lw * 3.0f + 50.0f, 0.5f), "bbox.w == local.w*3 + 50")
 
-        // ---- a CONTAINER header under the transform is also screen-space ----
-        // tab_item captures its header via current_item_bbox(); offset.x = 100 and
-        // local.x >= 0, so a transformed header has bbox.x >= 100. Without the
-        // current_item_bbox transform it would be raw window-local (< 100).
+        // ---- a CONTAINER header under the transform is also screen-space + canvas_bbox ----
+        // tab_item captures its header via current_item_bbox(), routed through the same
+        // capture_item_bbox chokepoint as leaf widgets — so it gets the screen-mapped bbox
+        // AND a canvas_bbox, identical to the contract for leaf widgets.
         t |> success(widget_exists(snap, "MAIN_WIN/XFORM_TABS/XFORM_TAB"),
                      "tab_item header present under transform")
-        let tab_bx = find_widget(snap, "MAIN_WIN/XFORM_TABS/XFORM_TAB")?["bbox"]?["x"] ?? 0.0f
-        t |> success(tab_bx >= 100.0f, "tab_item header bbox.x carries the transform offset (got {tab_bx})")
+        let tab = find_widget(snap, "MAIN_WIN/XFORM_TABS/XFORM_TAB")
+        let tcx = tab?["canvas_bbox"]?["x"] ?? -1.0f
+        t |> success(tcx >= 0.0f, "tab_item header carries canvas_bbox under transform")
+        let tbx = tab?["bbox"]?["x"] ?? 0.0f
+        t |> success(near(tbx, tcx * 2.0f + 100.0f, 0.5f),
+                     "tab_item header bbox.x == canvas_bbox.x*2 + 100 (screen-mapped)")
 
         // ---- after pop: screen-native again, no canvas_bbox ----
         t |> success(widget_exists(snap, "MAIN_WIN/AFTER_BTN"), "after-pop button present")

--- a/tests/integration/test_snapshot_transform.das
+++ b/tests/integration/test_snapshot_transform.das
@@ -52,6 +52,15 @@ def test_snapshot_transform(t : T?) {
         t |> success(near(bz, lz * 2.0f + 100.0f, 0.5f), "bbox.z == local.z*2 + 100")
         t |> success(near(bw, lw * 3.0f + 50.0f, 0.5f), "bbox.w == local.w*3 + 50")
 
+        // ---- a CONTAINER header under the transform is also screen-space ----
+        // tab_item captures its header via current_item_bbox(); offset.x = 100 and
+        // local.x >= 0, so a transformed header has bbox.x >= 100. Without the
+        // current_item_bbox transform it would be raw window-local (< 100).
+        t |> success(widget_exists(snap, "MAIN_WIN/XFORM_TABS/XFORM_TAB"),
+                     "tab_item header present under transform")
+        let tab_bx = find_widget(snap, "MAIN_WIN/XFORM_TABS/XFORM_TAB")?["bbox"]?["x"] ?? 0.0f
+        t |> success(tab_bx >= 100.0f, "tab_item header bbox.x carries the transform offset (got {tab_bx})")
+
         // ---- after pop: screen-native again, no canvas_bbox ----
         t |> success(widget_exists(snap, "MAIN_WIN/AFTER_BTN"), "after-pop button present")
         let after_cbb = find_widget(snap, "MAIN_WIN/AFTER_BTN")?["canvas_bbox"]?["z"] ?? -1.0f

--- a/tests/integration/test_snapshot_transform.das
+++ b/tests/integration/test_snapshot_transform.das
@@ -8,14 +8,14 @@ require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
 
-//! Contract test for the snapshot item-transform hook (set/clear_snapshot_item_transform).
+//! Contract test for the snapshot item-transform stack (push/pop_snapshot_item_transform).
 //! Drives examples/features/snapshot_transform.das, which wraps ONE button in a known
 //! synthetic affine (scale (2,3), offset (100,50)) with plain buttons before it and
-//! after the clear. Asserts:
+//! after the pop. Asserts:
 //!   - the transformed button reports bbox = canvas_bbox*scale + offset (the captured
 //!     local rect mapped to screen), with canvas_bbox carrying the local rect;
-//!   - widgets with no active transform (before, and after clear) report a screen-native
-//!     bbox and NO canvas_bbox — i.e. clear restores the default behavior.
+//!   - widgets with no active transform (before the push, and after the pop) report a
+//!     screen-native bbox and NO canvas_bbox — i.e. the pop restores the default.
 
 let FEATURE = "modules/dasImgui/examples/features/snapshot_transform.das"
 
@@ -52,9 +52,9 @@ def test_snapshot_transform(t : T?) {
         t |> success(near(bz, lz * 2.0f + 100.0f, 0.5f), "bbox.z == local.z*2 + 100")
         t |> success(near(bw, lw * 3.0f + 50.0f, 0.5f), "bbox.w == local.w*3 + 50")
 
-        // ---- after clear: screen-native again, no canvas_bbox ----
-        t |> success(widget_exists(snap, "MAIN_WIN/AFTER_BTN"), "after-clear button present")
+        // ---- after pop: screen-native again, no canvas_bbox ----
+        t |> success(widget_exists(snap, "MAIN_WIN/AFTER_BTN"), "after-pop button present")
         let after_cbb = find_widget(snap, "MAIN_WIN/AFTER_BTN")?["canvas_bbox"]?["z"] ?? -1.0f
-        t |> success(after_cbb < 0.0f, "after-clear button carries no canvas_bbox (clear restored identity)")
+        t |> success(after_cbb < 0.0f, "after-pop button carries no canvas_bbox (pop restored identity)")
     }
 }

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -47,6 +47,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
         group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|set|open|close|focus|await|drag|type_text)$%%),
+        group_by_regex("Snapshot transform",      mod, %regex~^(set_snapshot_item_transform|clear_snapshot_item_transform)$%%),
         group_by_regex("Await modifiers",         mod, %regex~^(AwaitModifiers|AwaitArgs|AwaitResult|with_await)$%%),
         group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|state_jv|to_JV|from_JV|JV|serialize).*%%),
         hide_group(group_by_regex("Finalizers",   mod, %regex~^.*_finalize$%%)),

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -47,7 +47,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
         group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|set|open|close|focus|await|drag|type_text)$%%),
-        group_by_regex("Snapshot transform",      mod, %regex~^(push_snapshot_item_transform|pop_snapshot_item_transform|snapshot_item_screen)$%%),
+        group_by_regex("Snapshot transform",      mod, %regex~^(push_snapshot_item_transform|pop_snapshot_item_transform|capture_item_bbox)$%%),
         group_by_regex("Await modifiers",         mod, %regex~^(AwaitModifiers|AwaitArgs|AwaitResult|with_await)$%%),
         group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|state_jv|to_JV|from_JV|JV|serialize).*%%),
         hide_group(group_by_regex("Finalizers",   mod, %regex~^.*_finalize$%%)),

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -47,7 +47,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
         group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|set|open|close|focus|await|drag|type_text)$%%),
-        group_by_regex("Snapshot transform",      mod, %regex~^(set_snapshot_item_transform|clear_snapshot_item_transform)$%%),
+        group_by_regex("Snapshot transform",      mod, %regex~^(push_snapshot_item_transform|pop_snapshot_item_transform)$%%),
         group_by_regex("Await modifiers",         mod, %regex~^(AwaitModifiers|AwaitArgs|AwaitResult|with_await)$%%),
         group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|state_jv|to_JV|from_JV|JV|serialize).*%%),
         hide_group(group_by_regex("Finalizers",   mod, %regex~^.*_finalize$%%)),

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -47,7 +47,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
         group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|set|open|close|focus|await|drag|type_text)$%%),
-        group_by_regex("Snapshot transform",      mod, %regex~^(push_snapshot_item_transform|pop_snapshot_item_transform)$%%),
+        group_by_regex("Snapshot transform",      mod, %regex~^(push_snapshot_item_transform|pop_snapshot_item_transform|snapshot_item_screen)$%%),
         group_by_regex("Await modifiers",         mod, %regex~^(AwaitModifiers|AwaitArgs|AwaitResult|with_await)$%%),
         group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|state_jv|to_JV|from_JV|JV|serialize).*%%),
         hide_group(group_by_regex("Finalizers",   mod, %regex~^.*_finalize$%%)),

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -626,7 +626,8 @@ struct WidgetEntry {
     //! built lazily at snapshot from those, so per-frame render does zero JSON.
     kind : string                                //! widget kind ("button", "slider_float", ...)
     hex_id : uint                                //! ImGui's GetID() for this widget on this frame
-    bbox : float4                                //! packed [x0, y0, x1, y1]
+    bbox : float4                                //! packed [x0, y0, x1, y1] — ALWAYS screen-space
+    @optional canvas_bbox : float4               //! packed [x0,y0,x1,y1] in a transformed canvas's LOCAL space. Emitted ONLY when the widget was captured under a non-identity snapshot item-transform (e.g. inside a node-editor canvas) — `bbox` is then its screen-space mapping. Absent for the common case where the widget is already screen-space.
     @optional hover : bool                       //! IsItemHovered() this frame
     @optional active : bool                      //! IsItemActive() this frame
     @optional focus : bool                       //! IsItemFocused() this frame
@@ -1048,6 +1049,46 @@ def private check_unique_render(path_key : string; kind : string) {
     g_rendered_this_frame |> insert(path_key)
 }
 
+// ===== Snapshot item-transform (for transformed canvases, e.g. node-editor) =====
+//
+// A custom canvas (imgui-node-editor's ImGuiEx::Canvas) remaps ImGui's coordinate
+// frame to canvas-local while active, so GetItemRectMin/Max — which widget_finalize
+// captures — returns canvas-local coords for any widget rendered inside it. To keep
+// the snapshot uniformly SCREEN-space, such a canvas sets an affine item-transform
+// here for the duration of its block; widget_finalize then maps each captured rect
+// to screen (bbox) and records the original local rect (canvas_bbox). Identity by
+// default, so non-canvas widgets are unaffected.
+var private g_item_xform_active : bool = false
+var private g_item_xform_scale  : float2 = float2(1.0, 1.0)
+var private g_item_xform_offset : float2 = float2(0.0, 0.0)
+
+def public set_snapshot_item_transform(scale : float2; offset : float2) {
+    //! Activate a `screen = local * scale + offset` mapping applied to every widget's
+    //! captured item rect until `clear_snapshot_item_transform()`. A custom canvas
+    //! (e.g. `node_editor`) sets this so interior widgets report screen-space `bbox`
+    //! plus a `canvas_bbox` carrying the original local rect.
+    g_item_xform_active = true
+    g_item_xform_scale = scale
+    g_item_xform_offset = offset
+}
+
+def public clear_snapshot_item_transform() {
+    //! Restore the identity item-transform (the default — widgets captured directly
+    //! in screen space).
+    g_item_xform_active = false
+    g_item_xform_scale = float2(1.0, 1.0)
+    g_item_xform_offset = float2(0.0, 0.0)
+}
+
+def private item_xform_screen(local : float4) : float4 {
+    // Map a captured local item rect to screen via the active affine transform.
+    return float4(
+        local.x * g_item_xform_scale.x + g_item_xform_offset.x,
+        local.y * g_item_xform_scale.y + g_item_xform_offset.y,
+        local.z * g_item_xform_scale.x + g_item_xform_offset.x,
+        local.w * g_item_xform_scale.y + g_item_xform_offset.y)
+}
+
 def public widget_finalize(widget_ident : string;
                            kind : string;
                            var entry : WidgetEntry;
@@ -1061,7 +1102,14 @@ def public widget_finalize(widget_ident : string;
     entry.hex_id = GetID(widget_ident)
     let rmin = GetItemRectMin()
     let rmax = GetItemRectMax()
-    entry.bbox = float4(rmin.x, rmin.y, rmax.x, rmax.y)
+    let local_bbox = float4(rmin.x, rmin.y, rmax.x, rmax.y)
+    if (g_item_xform_active) {
+        // Inside a transformed canvas: keep the local rect, expose screen-space.
+        entry.canvas_bbox = local_bbox
+        entry.bbox = item_xform_screen(local_bbox)
+    } else {
+        entry.bbox = local_bbox
+    }
     entry.hover = IsItemHovered(ImGuiHoveredFlags.None)
     entry.active = IsItemActive()
     entry.focus = IsItemFocused()

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -823,6 +823,12 @@ def begin_frame() {
         g_container_path |> clear()
         g_container_path_str = ""
     }
+    // Defensive: a transformed canvas balances push/pop within a frame, but a missed pop
+    // (e.g. a panic in the block) would otherwise leave the transform active for every
+    // later frame and corrupt unrelated widget bboxes. Reset like the other per-frame state.
+    if (!empty(g_item_xform_stack)) {
+        g_item_xform_stack |> clear()
+    }
 }
 
 var private g_end_of_frame_hooks : table<string; function<() : void>>
@@ -1092,6 +1098,14 @@ def private item_xform_screen(local : float4) : float4 {
         local.y * top.scale.y + top.offset.y,
         local.z * top.scale.x + top.offset.x,
         local.w * top.scale.y + top.offset.y)
+}
+
+def public snapshot_item_screen(local : float4) : float4 {
+    //! Map a captured (canvas-local) item rect to screen via the active item-transform
+    //! stack; identity when no transform is active. Any bbox-capture site that reads
+    //! imgui's current item rect (e.g. container headers) routes through this so the
+    //! snapshot stays uniformly screen-space, consistent with leaf widgets.
+    return empty(g_item_xform_stack) ? local : item_xform_screen(local)
 }
 
 def public widget_finalize(widget_ident : string;

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1104,9 +1104,15 @@ def public widget_finalize(widget_ident : string;
     let rmax = GetItemRectMax()
     let local_bbox = float4(rmin.x, rmin.y, rmax.x, rmax.y)
     if (g_item_xform_active) {
-        // Inside a transformed canvas: keep the local rect, expose screen-space.
-        entry.canvas_bbox = local_bbox
-        entry.bbox = item_xform_screen(local_bbox)
+        // Inside a transformed canvas: expose screen-space, and keep the local rect as
+        // canvas_bbox only when the transform actually moved it — an identity mapping
+        // would make canvas_bbox a redundant copy of bbox.
+        let screen_bbox = item_xform_screen(local_bbox)
+        entry.bbox = screen_bbox
+        if (screen_bbox.x != local_bbox.x || screen_bbox.y != local_bbox.y ||
+            screen_bbox.z != local_bbox.z || screen_bbox.w != local_bbox.w) {
+            entry.canvas_bbox = local_bbox
+        }
     } else {
         entry.bbox = local_bbox
     }

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1100,12 +1100,27 @@ def private item_xform_screen(local : float4) : float4 {
         local.w * top.scale.y + top.offset.y)
 }
 
-def public snapshot_item_screen(local : float4) : float4 {
-    //! Map a captured (canvas-local) item rect to screen via the active item-transform
-    //! stack; identity when no transform is active. Any bbox-capture site that reads
-    //! imgui's current item rect (e.g. container headers) routes through this so the
-    //! snapshot stays uniformly screen-space, consistent with leaf widgets.
-    return empty(g_item_xform_stack) ? local : item_xform_screen(local)
+def public capture_item_bbox(var entry : WidgetEntry; local : float4) {
+    //! Record a captured imgui item rect into `entry`: `bbox` mapped to screen via the
+    //! active snapshot item-transform, plus `canvas_bbox` carrying the original local rect
+    //! when the transform actually moved it. The single capture chokepoint for both leaf
+    //! widgets (`widget_finalize`) and container headers, so every entry stays consistent
+    //! under a transformed canvas. The (0,0,0,0) sentinel (a headerless container) is left
+    //! untouched — never mapped to a phantom rect at the transform offset.
+    if (local.x == 0.0f && local.y == 0.0f && local.z == 0.0f && local.w == 0.0f) {
+        entry.bbox = local
+        return
+    }
+    if (empty(g_item_xform_stack)) {
+        entry.bbox = local
+        return
+    }
+    let screen = item_xform_screen(local)
+    entry.bbox = screen
+    if (screen.x != local.x || screen.y != local.y ||
+        screen.z != local.z || screen.w != local.w) {
+        entry.canvas_bbox = local
+    }
 }
 
 def public widget_finalize(widget_ident : string;
@@ -1121,20 +1136,7 @@ def public widget_finalize(widget_ident : string;
     entry.hex_id = GetID(widget_ident)
     let rmin = GetItemRectMin()
     let rmax = GetItemRectMax()
-    let local_bbox = float4(rmin.x, rmin.y, rmax.x, rmax.y)
-    if (!empty(g_item_xform_stack)) {
-        // Inside a transformed canvas: expose screen-space, and keep the local rect as
-        // canvas_bbox only when the transform actually moved it — an identity mapping
-        // would make canvas_bbox a redundant copy of bbox.
-        let screen_bbox = item_xform_screen(local_bbox)
-        entry.bbox = screen_bbox
-        if (screen_bbox.x != local_bbox.x || screen_bbox.y != local_bbox.y ||
-            screen_bbox.z != local_bbox.z || screen_bbox.w != local_bbox.w) {
-            entry.canvas_bbox = local_bbox
-        }
-    } else {
-        entry.bbox = local_bbox
-    }
+    capture_item_bbox(entry, float4(rmin.x, rmin.y, rmax.x, rmax.y))
     entry.hover = IsItemHovered(ImGuiHoveredFlags.None)
     entry.active = IsItemActive()
     entry.focus = IsItemFocused()

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1049,44 +1049,49 @@ def private check_unique_render(path_key : string; kind : string) {
     g_rendered_this_frame |> insert(path_key)
 }
 
-// ===== Snapshot item-transform (for transformed canvases, e.g. node-editor) =====
+// ===== Snapshot item-transform stack (for transformed canvases, e.g. node-editor) =====
 //
 // A custom canvas (imgui-node-editor's ImGuiEx::Canvas) remaps ImGui's coordinate
 // frame to canvas-local while active, so GetItemRectMin/Max — which widget_finalize
 // captures — returns canvas-local coords for any widget rendered inside it. To keep
-// the snapshot uniformly SCREEN-space, such a canvas sets an affine item-transform
-// here for the duration of its block; widget_finalize then maps each captured rect
-// to screen (bbox) and records the original local rect (canvas_bbox). Identity by
-// default, so non-canvas widgets are unaffected.
-var private g_item_xform_active : bool = false
-var private g_item_xform_scale  : float2 = float2(1.0, 1.0)
-var private g_item_xform_offset : float2 = float2(0.0, 0.0)
+// the snapshot uniformly SCREEN-space, such a canvas pushes an affine item-transform
+// for the duration of its block; widget_finalize maps each captured rect to screen
+// (bbox) and records the original local rect (canvas_bbox). It's a STACK so canvases
+// nest like every other imgui scope (PushID/PushClipRect): each entry is the absolute
+// local→screen affine for that canvas — the editor's CanvasToScreen is already
+// absolute, so a push sets the innermost mapping and a pop restores the enclosing one,
+// no composition needed here. Empty stack = identity, so non-canvas widgets are
+// unaffected.
+struct private ItemXform {
+    scale  : float2
+    offset : float2
+}
+var private g_item_xform_stack : array<ItemXform>
 
-def public set_snapshot_item_transform(scale : float2; offset : float2) {
-    //! Activate a `screen = local * scale + offset` mapping applied to every widget's
-    //! captured item rect until `clear_snapshot_item_transform()`. A custom canvas
-    //! (e.g. `node_editor`) sets this so interior widgets report screen-space `bbox`
-    //! plus a `canvas_bbox` carrying the original local rect.
-    g_item_xform_active = true
-    g_item_xform_scale = scale
-    g_item_xform_offset = offset
+def public push_snapshot_item_transform(scale : float2; offset : float2) {
+    //! Push a `screen = local * scale + offset` mapping applied to every widget's
+    //! captured item rect until the matching `pop_snapshot_item_transform()`. A custom
+    //! canvas (e.g. `node_editor`) pushes this so interior widgets report screen-space
+    //! `bbox` plus a `canvas_bbox` carrying the original local rect. Nestable.
+    g_item_xform_stack |> push(ItemXform(scale = scale, offset = offset))
 }
 
-def public clear_snapshot_item_transform() {
-    //! Restore the identity item-transform (the default — widgets captured directly
-    //! in screen space).
-    g_item_xform_active = false
-    g_item_xform_scale = float2(1.0, 1.0)
-    g_item_xform_offset = float2(0.0, 0.0)
+def public pop_snapshot_item_transform() {
+    //! Pop the innermost item-transform pushed by `push_snapshot_item_transform`,
+    //! restoring the enclosing canvas's mapping (or identity at the outermost level).
+    if (!empty(g_item_xform_stack)) {
+        g_item_xform_stack |> pop()
+    }
 }
 
 def private item_xform_screen(local : float4) : float4 {
-    // Map a captured local item rect to screen via the active affine transform.
+    // Map a captured local item rect to screen via the innermost (top-of-stack) affine.
+    let top = g_item_xform_stack[length(g_item_xform_stack) - 1]
     return float4(
-        local.x * g_item_xform_scale.x + g_item_xform_offset.x,
-        local.y * g_item_xform_scale.y + g_item_xform_offset.y,
-        local.z * g_item_xform_scale.x + g_item_xform_offset.x,
-        local.w * g_item_xform_scale.y + g_item_xform_offset.y)
+        local.x * top.scale.x + top.offset.x,
+        local.y * top.scale.y + top.offset.y,
+        local.z * top.scale.x + top.offset.x,
+        local.w * top.scale.y + top.offset.y)
 }
 
 def public widget_finalize(widget_ident : string;
@@ -1103,7 +1108,7 @@ def public widget_finalize(widget_ident : string;
     let rmin = GetItemRectMin()
     let rmax = GetItemRectMax()
     let local_bbox = float4(rmin.x, rmin.y, rmax.x, rmax.y)
-    if (g_item_xform_active) {
+    if (!empty(g_item_xform_stack)) {
         // Inside a transformed canvas: expose screen-space, and keep the local rect as
         // canvas_bbox only when the transform actually moved it — an identity mapping
         // would make canvas_bbox a redundant copy of bbox.

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -71,10 +71,12 @@ def public stateless_finalize(widget_ident : string; kind : string; var state : 
 def private current_item_bbox() : float4 {
     //! Snapshot ``GetItemRectMin/Max`` for the "last item" — meaningful for
     //! containers whose Begin* call emits a clickable header into the parent
-    //! (``menu`` / ``tab_item``). Returns (0,0,0,0)-shaped float4 directly.
+    //! (``menu`` / ``tab_item``). Mapped to SCREEN via the active snapshot
+    //! item-transform (identity outside a transformed canvas) so a header rendered
+    //! inside a node-editor canvas reports screen-space, consistent with leaf widgets.
     let rmin = GetItemRectMin()
     let rmax = GetItemRectMax()
-    return float4(rmin.x, rmin.y, rmax.x, rmax.y)
+    return snapshot_item_screen(float4(rmin.x, rmin.y, rmax.x, rmax.y))
 }
 
 // ===== Notes on ergonomics =====

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -48,7 +48,7 @@ def private open_close_finalize(widget_ident : string; kind : string; var state 
                                 bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
     //! Container finalize for state with ``pending_open`` / ``pending_close``. Dispatch routes through ``g_dispatchers`` keyed by ``ST``'s ``TypeInfo.hash`` to the ``[widget_dispatch] def _(var state : ST; …)`` body below.
     var entry : WidgetEntry
-    entry.bbox = bbox
+    capture_item_bbox(entry, bbox)
     unsafe {
         container_finalize(widget_ident, kind, entry,
                            addr(state),
@@ -60,7 +60,7 @@ def public stateless_finalize(widget_ident : string; kind : string; var state : 
                               bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
     //! Container finalize for stateless containers (no dispatcher actions). Snapshot rail still reflects state for telemetry; no ``[widget_dispatch]`` is registered for ``ST``, so ``g_dispatchers[(*ti).hash]`` is absent and ``dispatch_or_err`` silently returns ok if a stray action ever targets one (Structure-with-no-dispatcher = display-only).
     var entry : WidgetEntry
-    entry.bbox = bbox
+    capture_item_bbox(entry, bbox)
     unsafe {
         container_finalize(widget_ident, kind, entry,
                            addr(state),
@@ -71,12 +71,12 @@ def public stateless_finalize(widget_ident : string; kind : string; var state : 
 def private current_item_bbox() : float4 {
     //! Snapshot ``GetItemRectMin/Max`` for the "last item" — meaningful for
     //! containers whose Begin* call emits a clickable header into the parent
-    //! (``menu`` / ``tab_item``). Mapped to SCREEN via the active snapshot
-    //! item-transform (identity outside a transformed canvas) so a header rendered
-    //! inside a node-editor canvas reports screen-space, consistent with leaf widgets.
+    //! (``menu`` / ``tab_item``). Returns the captured rect in its native space; the
+    //! finalizers route it through ``capture_item_bbox``, which maps it to screen (and
+    //! records ``canvas_bbox``) when a snapshot item-transform is active.
     let rmin = GetItemRectMin()
     let rmax = GetItemRectMax()
-    return snapshot_item_screen(float4(rmin.x, rmin.y, rmax.x, rmax.y))
+    return float4(rmin.x, rmin.y, rmax.x, rmax.y)
 }
 
 // ===== Notes on ergonomics =====

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -102,7 +102,7 @@ def edit_container_open_close_finalize(widget_ident : string; kind : string;
                                        bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
     //! [edit_container] finalize for bool-typed open/close pointers. Pointer + ti go into g_widgets so the per-kind [widget_dispatch] handles "set"/"open"/"close" by writing through ``*ptr``.
     var entry : WidgetEntry
-    entry.bbox = bbox
+    capture_item_bbox(entry, bbox)
     unsafe {
         container_finalize(widget_ident, kind, entry,
                            reinterpret<void?>(ptr),


### PR DESCRIPTION
## Problem

`widget_finalize` captures `GetItemRectMin/Max` for every widget. Inside a custom canvas — imgui-node-editor's `ImGuiEx::Canvas` remaps ImGui's coordinate frame to canvas-**local** between Begin/End (`EnterLocalSpace`), baking vertices to screen only at `LeaveLocalSpace` — `GetItemRectMin` returns canvas-local coords. So node titles, pin labels, drawlist art, etc. leaked **canvas-local** bboxes into the snapshot, while every widget outside a canvas reports **screen-space**. Inconsistent, and it made canvas-interior widgets un-clickable / un-targetable from outside.

## Fix

An optional affine item-transform (identity by default) that a transformed canvas pushes for the duration of its block:

- `push_snapshot_item_transform(scale, offset)` / `pop_snapshot_item_transform()` — a **stack**, like every other imgui scope (`PushID`, `PushClipRect`, `PushStyleVar`), so transformed canvases nest safely. Each entry is the **absolute** local→screen affine for that canvas; the editor's `CanvasToScreen` is already absolute, so a push sets the innermost mapping and a pop restores the enclosing one — no composition math in this layer.
- When the stack is non-empty, `widget_finalize` stores the screen-space rect (`local*scale + offset`) in `bbox` — uniform with all other widgets — and the original canvas-local rect in a new `@optional canvas_bbox`, **only when the transform actually moved the rect** (an identity mapping leaves `canvas_bbox` unset rather than a redundant copy of `bbox`).
- Empty stack ⇒ identity: non-canvas widgets are byte-identical, no `canvas_bbox`.

It mirrors what `LeaveLocalSpace` already does to vertices (`pos*Scale + ViewTransformPosition`), applied to the captured rect.

## Why here

This is the dasImgui half. The node-editor side (separate PR, gated on this) pushes the transform in `node_editor()` from `CanvasToScreen` and converts its entity payloads — so node/pin/title/drawlist geometry all become screen-space "for free", and pins finally get real geometry (drag targeting).

## Verification

- `compile_check` + `lint` clean.
- `examples/features/snapshot_transform.das` + `tests/integration/test_snapshot_transform.das`: a contract test that wraps one button in a known synthetic affine (scale (2,3), offset (100,50)) with plain buttons before it and after the pop, asserting `bbox = local*scale + offset` + `canvas_bbox = local`, and that the before/after-pop buttons are screen-native with no `canvas_bbox`. Passes locally.
- Docs `Uncategorized-gate`: the new public functions are grouped under "Snapshot transform" in `utils/imgui2rst.das`; regenerated locally, gate clean.
- Identity default ⇒ existing dasImgui recordings/tests unaffected (no canvas → empty stack → no transform).
- End-to-end verified with the node-editor consumer locally (via the junction): interior `text()` and pins report screen-space `bbox` matching the rendered position, with `canvas_bbox` carrying the canvas coords; toolbar buttons (outside the canvas) unchanged with no `canvas_bbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)