### PR TITLE
Fix popup re-open second-pick race (wait_for_visible) + toggleable log-section instrumentation

### DIFF
--- a/tests/integration/test_popup_context_window.das
+++ b/tests/integration/test_popup_context_window.das
@@ -20,13 +20,6 @@ let FEATURE = "modules/dasImgui/examples/features/popup_context_window.das"
 
 [test]
 def test_popup_context_window_smoke(t : T?) {
-    // QUARANTINED pending a follow-up fix. A synth click on a menu item of a context popup that was
-    // just RE-OPENED (right-click → pick → right-click again → pick) no-ops: the cursor lands dead-on
-    // the item but the press doesn't activate it (popup stays open, state unchanged). A first open
-    // works; only the re-open races. Isolated to dispatch-time — a settle BEFORE the dependent click
-    // is dispatched fixes it, but no settle inside the click coroutine does — so the fix is in the
-    // synth-IO dispatch layer (PR #95-era), not this test. Tracked for a follow-up PR.
-    t->skip("popup_context_window re-open second-pick activation race — fix in follow-up PR")
     with_imgui_app(FEATURE) $(d) {
         var snap = wait_for_widget(d, "MAIN_WIN/CTX", 15.0f)
         t |> success(snap != null, "CTX container registers")
@@ -41,10 +34,11 @@ def test_popup_context_window_smoke(t : T?) {
         t |> success(!widget_exists(snap, "MAIN_WIN/CTX/ITEM_NEW"),
                      "ITEM_NEW absent while popup closed")
 
-        // Right-click LEAD to open the context popup.
+        // Right-click LEAD to open the context popup. Gate on wait_for_visible (rendered THIS frame),
+        // not wait_for_widget (exists-only) — see the re-open note below.
         right_click(d, "MAIN_WIN/LEAD")
-        var snap_open = wait_for_widget(d, "MAIN_WIN/CTX/ITEM_NEW", 5.0f)
-        t |> success(snap_open != null, "ITEM_NEW registers after right-click on LEAD")
+        var snap_open = wait_for_visible(d, "MAIN_WIN/CTX/ITEM_NEW", 5.0f)
+        t |> success(snap_open != null, "ITEM_NEW visible after right-click on LEAD")
         if (snap_open == null) return
 
         // Pick "New" — a real synthetic click fires the demo's `if (menu_item(...))` branch.
@@ -53,18 +47,21 @@ def test_popup_context_window_smoke(t : T?) {
                                            "last pick: New", 300),
                      "STATUS reflects 'New' after menu pick")
 
-        // Re-open + pick "Quit" — verifies the popup can be re-opened.
+        // Re-open + pick "Quit" — the case that used to race. ITEM_QUIT's registry entry persists from
+        // the first open, so wait_for_widget (exists-only) returns on the stale entry while the popup
+        // is still closed; the click then dispatches before the re-open paints and is dropped (no bbox
+        // that frame). wait_for_visible gates on rendered-this-frame, so it blocks until the popup is
+        // actually back on screen.
         right_click(d, "MAIN_WIN/LEAD")
-        var snap_open2 = wait_for_widget(d, "MAIN_WIN/CTX/ITEM_QUIT", 5.0f)
-        t |> success(snap_open2 != null, "ITEM_QUIT registers on re-open")
+        var snap_open2 = wait_for_visible(d, "MAIN_WIN/CTX/ITEM_QUIT", 5.0f)
+        t |> success(snap_open2 != null, "ITEM_QUIT visible on re-open")
         if (snap_open2 == null) return
         click(d, "MAIN_WIN/CTX/ITEM_QUIT")
         let got_quit = wait_for_string_value(d, "MAIN_WIN/STATUS", "value",
                                              "last pick: Quit", 300)
         if (!got_quit) {
-            // DIAGNOSTIC (PR #95, macOS-only second-pick regression): on failure surface what the
-            // click actually did — STATUS shows the last pick that registered (still 'New' = the
-            // click never landed; another item = wrong bbox), and whether the popup stayed open.
+            // DIAGNOSTIC: on failure surface what the click did — STATUS shows the last pick that
+            // registered (still 'New' = the click never landed), and whether the items still exist.
             var diag = snapshot(d)
             let stat   = widget_payload_field(diag, "MAIN_WIN/STATUS", "value") ?? "<none>"
             let iq_ex  = widget_exists(diag, "MAIN_WIN/CTX/ITEM_QUIT")

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -48,6 +48,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|force_set|open|close|focus|await|mouse_pos|mouse_click|mouse_scroll|key_press|key_release|key_char)$%%),
         group_by_regex("Synthetic input",         mod, %regex~^(synth_mouse_move|synth_mouse_button|synth_mouse_wheel|synth_key_press|synth_key_release|synth_char|release_held_buttons|release_held_keys|get_synth_cursor|get_synth_keys|imgui_synth_tick|user_control_enabled|set_user_control_enabled|set_user_control|register_real_input_toggle|register_synth_frame_hook|register_synth_stop_hook)$%%),
+        group_by_regex("Debug logging",           mod, %regex~^(log_section|log_section_on|imgui_log_section|imgui_log_drain)$%%),
         group_by_regex("Snapshot transform",      mod, %regex~^(push_snapshot_item_transform|pop_snapshot_item_transform|capture_item_bbox)$%%),
         group_by_regex("Await modifiers",         mod, %regex~^(AwaitModifiers|AwaitArgs|AwaitResult|with_await)$%%),
         group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|state_jv|to_JV|from_JV|JV|serialize).*%%),

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1418,6 +1418,33 @@ var public synth_click_t : float = -1.0
 var private g_click_ticket_next    : int = 0   // next ticket to hand out (bumped at dispatch, just before spawn)
 var private g_click_ticket_serving : int = 0   // ticket currently allowed to drive the button
 
+// Toggleable per-section debug logging ("ledgeable" sections). A section name maps to enabled;
+// emit via the ambient to_log gated on it, so per-frame instrumentation costs one set-lookup when
+// off. Toggle from a test or via the imgui_log_section live_command. Deliberately a tiny local
+// gate, NOT a daslib/logger require — boost is foundational and we don't pull logger+debugger into
+// every dasImgui app's compile.
+var private g_log_sections : table<string>
+var private g_log_buf : array<string>   // drainable ring of emitted lines (imgui_log_drain returns + clears)
+def log_section(name : string; on : bool) {
+    //! Enable/disable a debug log section. Sections are checked by log_section_on; gated emit sites
+    //! cost one set-lookup when off, so heavy per-frame logging is free until a section is turned on.
+    if (on) { g_log_sections |> insert(name) } else { g_log_sections |> erase(name) }
+}
+def log_section_on(name : string) : bool {
+    //! True if debug log section ``name`` is enabled. Guard heavy per-frame emit: ``if (log_section_on("x")) clk_log(...)``.
+    return key_exists(g_log_sections, name)
+}
+def private clk_log(section, line : string) {
+    // Emit one instrumentation line if its section is on: to the ambient log (stdout/recordings)
+    // AND a drainable buffer (imgui_log_drain → JSON, readable over the transport / MCP, since a
+    // host's stdout is only surfaced to a test on panic). Capped so per-frame sections can't grow it
+    // unbounded.
+    return if (!log_section_on(section))
+    let entry = "[{section}] {line}"
+    to_log(LOG_INFO, "{entry}\n")
+    if (length(g_log_buf) < 8000) { g_log_buf |> push(entry) }
+}
+
 var public synth_held_keys : table<int>        //! currently-held ImGuiKey values (visual_aids keycap HUD)
 var public synth_last_keycode : int = 0        //! last ImGuiKey synth-pressed; 0 = none
 var public synth_last_keycode_t : float = -1.0
@@ -1712,6 +1739,7 @@ def private click_at_coro(center : float2; scrolled : bool; button : int; ticket
     while (g_click_ticket_serving != ticket) {
         await_next_frame()
     }
+    if (log_section_on("synth.click")) clk_log("synth.click", "SERVE ticket={ticket} frame={GetFrameCount()} from=({mouse_cursor_x},{mouse_cursor_y}) to=({center.x},{center.y}) scrolled={scrolled} active={GetActiveID()} hover={IsAnyItemHovered()}")
     if (scrolled) await_next_frame()
     // Animate the approach from the current cursor to the target instead of warping — a real
     // mouse never teleports, and the move_to that precedes a click may land elsewhere (e.g. the
@@ -1730,6 +1758,7 @@ def private click_at_coro(center : float2; scrolled : bool; button : int; ticket
         let f = float(i) / float(steps)
         synth_mouse_move(sx + dx * f, sy + dy * f)
         await_next_frame()
+        if (log_section_on("synth.click.move")) clk_log("synth.click.move", "ticket={ticket} step={i}/{steps} frame={GetFrameCount()} pos=({sx + dx * f},{sy + dy * f}) active={GetActiveID()} hover={IsAnyItemHovered()}")
     }
     unsafe {
         var io & = GetIO()
@@ -1737,8 +1766,10 @@ def private click_at_coro(center : float2; scrolled : bool; button : int; ticket
     }
     synth_mouse_button(button, 1)
     await_next_frame()
+    if (log_section_on("synth.click")) clk_log("synth.click", "PRESS-HOLD ticket={ticket} button={button} frame={GetFrameCount()} pos=({center.x},{center.y}) active={GetActiveID()} hover={IsAnyItemHovered()}")
     synth_mouse_button(button, 0)
     g_click_ticket_serving++
+    if (log_section_on("synth.click")) clk_log("synth.click", "RELEASE ticket={ticket} frame={GetFrameCount()} active={GetActiveID()} hover={IsAnyItemHovered()}")
 }
 
 // --- immediate synth live_commands (transport calls these; live adds the animated forms) ---
@@ -1840,6 +1871,7 @@ def set_user_control(input : JsonValue?) : JsonValue? {
 def private dispatch_or_err(action : string; input : JsonValue?) : Result<string, string> {
     let target = extract_string_field(input, "target")
     let (level, resolved) = classify_target(target)
+    if (log_section_on("synth.click")) clk_log("synth.click", "ATTEMPT action='{action}' target='{target}' level={level} resolved='{resolved}' frame={GetFrameCount()}")
     if (level == 0) return err("unresolvable target: {target}", type<string>)
     // A click is a real synthetic mouse click: warp to the widget center, press and
     // release across one frame (click_at_coro), driving ImGui's own input path. Every
@@ -1850,6 +1882,7 @@ def private dispatch_or_err(action : string; input : JsonValue?) : Result<string
     if (action == "click") {
         let button = input?["button"] ?? 0
         let (got, center) = resolve_target_bbox(resolved)
+        if (log_section_on("synth.click")) clk_log("synth.click", "BBOX resolved='{resolved}' got={got} center=({center.x},{center.y}) frame={GetFrameCount()}")
         if (!got) return err("target {resolved} has no bbox this frame (not rendered)", type<string>)
         // Scroll a below-the-fold target into view first. Scroll is a pure vertical content
         // translation, so the post-scroll center is the current center shifted up by the applied
@@ -1861,6 +1894,7 @@ def private dispatch_or_err(action : string; input : JsonValue?) : Result<string
         // no coroutine to serve it would stall g_click_ticket_serving and hang all later clicks.
         let my_ticket = g_click_ticket_next
         g_click_ticket_next++
+        if (log_section_on("synth.click")) clk_log("synth.click", "DISPATCH target='{target}' resolved='{resolved}' level={level} center=({center.x},{center.y}) scroll_dy={scroll_dy} target_center=({target_center.x},{target_center.y}) ticket={my_ticket} serving={g_click_ticket_serving} frame={GetFrameCount()} active={GetActiveID()} hover={IsAnyItemHovered()}")
         spawn_coroutine(click_at_coro(target_center, scroll_dy != 0.0f, button, my_ticket))
         // Return the clean resolved target (path or hex_id), not a synthetic tag:
         // the post-command auto-highlight hook resolves it via widget_rect, and
@@ -1931,6 +1965,28 @@ def imgui_force_set(input : JsonValue?) : JsonValue? {
     let r = dispatch_or_err("set", input)
     if (r._is_ok) dispatch_post_command_hooks("set", r._value)
     return with_await(input, r)
+}
+
+[live_command(description = "Toggle a debug log section in the host ('name' + bool 'on') for ledgeable per-frame instrumentation")]
+def imgui_log_section(input : JsonValue?) : JsonValue? {
+    //! Live-command: enable/disable host-side debug log section ``input["name"]`` per ``input["on"]``.
+    //! Gated emit sites (e.g. "synth.click") cost one set-lookup when off, so heavy per-frame
+    //! logging is free until a section is turned on. Runs in the host context, so it reaches the
+    //! dispatch/coroutine instrumentation a test's own context can't.
+    let name = extract_string_field(input, "name")
+    let on = input?["on"] ?? false
+    log_section(name, on)
+    return JV((ok = true, name = name, on = on))
+}
+
+[live_command(description = "Return + clear the host's buffered debug-log lines (from enabled log sections)")]
+def imgui_log_drain(_input : JsonValue?) : JsonValue? {
+    //! Live-command: return the host-side instrumentation lines accumulated since the last drain
+    //! (a JSON array of strings) and clear the buffer. The transport-readable companion to the
+    //! stdout emit — a test or MCP client reads the dispatch/coroutine trace from the response.
+    var result = JV(g_log_buf)
+    g_log_buf |> clear()
+    return result
 }
 
 [live_command(description = "Queue an open command on a container widget ('target' name)")]

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -257,9 +257,11 @@ def public widget_click_point(var snap : JsonValue?; ident : string) : tuple<flo
 }
 
 def public widget_rendered(var snap : JsonValue?; ident : string) : bool {
-    //! True iff ``globals[ident]`` is for a widget that painted this frame.
-    //! Registered-but-not-yet-painted entries carry ``"rendered": false``; rendered widgets omit the field (``?? true`` covers absent).
-    return snap?["globals"]?[ident]?["rendered"] ?? true
+    //! True iff ``globals[ident]`` EXISTS and painted this frame. Registered-but-unpainted entries
+    //! carry ``"rendered": false``; painted widgets omit the field (``?? true``). The leading
+    //! existence check is load-bearing: an absent (or misspelled) path yields ``null ?? true`` — a
+    //! false pass — so a never-registered ident must report not-rendered, not silently "rendered".
+    return widget_exists(snap, ident) && (snap?["globals"]?[ident]?["rendered"] ?? true)
 }
 
 // ===== Poll-until family =====
@@ -311,10 +313,14 @@ def public wait_for_widget(app : ImguiApp; widget_ident : string;
     return null
 }
 
-def public wait_for_render(app : ImguiApp; widget_ident : string;
-                           timeout_sec : float = DEFAULT_FRAME_WAIT_SEC) : JsonValue? {
-    //! Poll snapshot until ``globals[widget_ident]`` reports ``rendered:true`` (the widget painted this frame).
-    //! Use when you specifically need first-paint semantics — registered-but-not-rendered widgets pass ``wait_for_widget`` immediately.
+def public wait_for_visible(app : ImguiApp; widget_ident : string;
+                            timeout_sec : float = DEFAULT_FRAME_WAIT_SEC) : JsonValue? {
+    //! Poll snapshot until ``widget_ident`` is registered AND painted this frame (``widget_rendered``).
+    //! The robust gate for a widget that can hide and re-show: ``wait_for_widget`` returns on a stale
+    //! registry entry left from a prior appearance (e.g. a re-opened popup / menu) while the widget
+    //! is currently off-screen, so a click fired right after can dispatch before the widget
+    //! re-renders and be silently dropped (no bbox this frame). Use this whenever the click target
+    //! may have been shown before.
     let start = ref_time_ticks()
     let timeout_usec = int(timeout_sec * 1000000.0f)
     while (get_time_usec(start) < timeout_usec) {
@@ -323,6 +329,14 @@ def public wait_for_render(app : ImguiApp; widget_ident : string;
         sleep(FRAME_POLL_INTERVAL_MS)
     }
     return null
+}
+
+def public wait_for_render(app : ImguiApp; widget_ident : string;
+                           timeout_sec : float = DEFAULT_FRAME_WAIT_SEC) : JsonValue? {
+    //! First-paint gate — alias of :func:`wait_for_visible`. ``widget_rendered`` now requires
+    //! existence, so this no longer false-passes for an absent path. Prefer ``wait_for_visible``
+    //! at call sites that target a widget which can hide and re-show.
+    return wait_for_visible(app, widget_ident, timeout_sec)
 }
 
 def public wait_for_int_value(app : ImguiApp;


### PR DESCRIPTION
Follow-up to #96, which quarantined `test_popup_context_window_smoke` (a synth click on a just-re-opened context-popup item was silently dropped). This PR root-causes and fixes it, and un-quarantines the test.

## Root cause (revises the prior hypothesis)

It is **not** synth-IO press timing — it is the **wait/observation layer**, and it is **time-sensitive**: it only reproduces at realistic frame rates (~60fps windowed, or slow CI runners), not at fast local headless (~14000fps, `DeltaTime` ~0.07ms vs ~16ms), which is why it eluded isolation.

Mechanism, from instrumented traces on a failing run:
- The menu item's entry persists in the **long-lived** registry (`g_widgets`) from the first open. Picking "New" auto-closes the popup, but the entry stays.
- On re-open, `right_click(LEAD)` is *queued* (its coroutine presses — and thereby reopens the popup — a frame later). `wait_for_widget(ITEM_QUIT)` gates on **exists-in-registry**, so it returns **immediately** on the stale entry while the popup is still closed.
- `click(ITEM_QUIT)` then dispatches *before* the popup repaints. `resolve_target_bbox` reads the **per-frame** registry, finds no bbox (`got=false`), and the click is **dropped** (err, no coroutine). STATUS never updates.

```
ATTEMPT click target='MAIN_WIN/CTX/ITEM_QUIT' level=2 resolved='...ITEM_QUIT' frame=772
BBOX   resolved='...ITEM_QUIT' got=false center=(0,0) frame=772      ← no bbox
... the reopen right-click does not PRESS until frame 773 (one frame later)
```

## Fix

- **`widget_rendered` now requires existence** (`widget_exists && (rendered ?? true)`). An absent/misspelled path previously yielded `null ?? true` — a false pass — and now correctly reports not-rendered.
- **New `wait_for_visible`** — registered **and** painted this frame — the robust gate for any widget that can hide and re-show (re-opened popups/menus). `wait_for_render` becomes a delegating alias.
- **`test_popup_context_window`**: un-quarantined; the popup-item waits use `wait_for_visible`.

## Instrumentation (the tooling that found it)

A small **dasImgui-local** log-section gate — `log_section` / `log_section_on` + a `clk_log` helper, plus `imgui_log_section` (toggle a section in the host) and `imgui_log_drain` (read+clear a buffered trace over the transport). Gated emit sites on the synth-click dispatch + coroutine path cost one set-lookup when off, so heavy per-frame logging is free until a section is turned on. Deliberately **not** a `daslib/logger` require — `imgui_boost_runtime` is foundational and we don't want to pull `logger`+`debugger`+`jsonrpc` into every dasImgui app's compile.

## Verification

- **Windowed** (actual repro condition): the un-quarantined test passes **5/5**; a fix probe passes **8/8** (was ~2-3/5 failing).
- **Full headless integration suite** (CI config): **149 tests, 149 passed, 0 failed, 0 skipped** — the `widget_rendered` change regresses none of the 40+ `wait_for_render` callers.
- lint clean, formatted, docs gate (`imgui2rst` "Debug logging" group; `wait_for_visible` covered by the existing `wait_for_*` group; no Uncategorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)