### PR TITLE
docs: serve tutorial videos as a real player (start paused, controls, audio)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,13 +205,13 @@ CI workflow: `.github/workflows/tests.yml`. Windows CI excludes 7 high-POST test
 
 Sphinx-based tutorial site. CI gates `-W` (warnings-as-errors) BUT pre-runs `utils/imgui2rst.das --detail_output doc/source/stdlib/generated` to generate per-module stdlib refs. **Locally**, `sphinx-build -W` fails on `stdlib/sec_boost.rst:11: toctree contains reference to nonexisting document 'stdlib/generated/imgui_boost_v2'` unless you run imgui2rst first. Plain `sphinx-build --keep-going` (no `-W`) builds clean.
 
-Tutorial pages live in `doc/source/tutorials/*.rst` and embed MP4 recordings from `doc/source/_static/tutorials/*.mp4` via raw `<video>` HTML. Each tutorial appears in `doc/source/tutorials/index.rst`'s toctree.
+Tutorial pages live in `doc/source/tutorials/*.rst` and embed MP4 recordings from `doc/source/_static/tutorials/*.mp4` via the local `.. video:: name.mp4` directive (registered in `doc/source/tutorial_video.py`). Each tutorial appears in `doc/source/tutorials/index.rst`'s toctree.
 
 ## Tutorial recordings — MP4 in source, APNG ignored
 
 **`doc/source/_static/tutorials/*.mp4` ships in-tree** (~5 MB total for the full set). `*.apng` is gitignored — it's the recorder's raw output; one ffmpeg pass converts to the deliverable MP4.
 
-**Fresh clone before docs build:** nothing to fetch. The `.mp4` files are in the checkout. Sphinx's raw `<video>` blocks reference them.
+**Fresh clone before docs build:** nothing to fetch. The `.mp4` files are in the checkout. The `.. video::` directive references them.
 
 **Re-record workflow:** `daslang.exe -project_root . tests/integration/record_X.das` → eyeball-review the resulting `.apng` locally → `ffmpeg -y -i X.apng -c:v libx264 -crf 23 -pix_fmt yuv420p -movflags +faststart X.mp4` → `git add X.mp4`.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,7 +13,7 @@ import time
 # Make the vendored `daslang` Sphinx domain importable.
 sys.path.insert(0, os.path.abspath('.'))
 
-extensions = ['daslang', 'sphinx.ext.intersphinx']
+extensions = ['daslang', 'tutorial_video', 'sphinx.ext.intersphinx']
 
 # Resolve cross-refs to daslang core (JsonValue, ImGuiCol, etc.) against the
 # published daslang documentation. Sphinx fetches objects.inv at build time.

--- a/doc/source/tutorial_video.py
+++ b/doc/source/tutorial_video.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Local Sphinx directive: ``.. video:: scene_name.mp4`` embeds a tutorial
+# recording from ``_static/tutorials/`` in a native HTML5 player.
+#
+# Centralizes the player markup so the chrome (controls, preload, sizing) is
+# tuned in one place instead of being duplicated across every tutorial page.
+# The player starts PAUSED with native controls (play/pause, scrubber, volume,
+# fullscreen); audio is on; no autoplay, no loop — it behaves like a normal
+# embedded video.
+#
+# Kept out of the vendored ``daslang.py`` domain (which stays byte-compatible
+# with daslang upstream) — this is presentation local to the imgui docs.
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+
+# Tutorial RSTs live at ``tutorials/<name>.rst`` and render to
+# ``tutorials/<name>.html``; ``../_static/tutorials/`` resolves to the built
+# ``_static/tutorials/`` for all of them (matches the prior raw-HTML blocks).
+_VIDEO_HTML = (
+    '<video controls preload="metadata" playsinline width="100%">\n'
+    '  <source src="../_static/tutorials/{name}" type="video/mp4">\n'
+    "  Your browser doesn't support HTML5 video. "
+    '<a href="../_static/tutorials/{name}">Download the recording</a>.\n'
+    '</video>'
+)
+
+
+class VideoDirective(Directive):
+    """``.. video:: scene_name.mp4`` — embed a tutorial recording.
+
+    One argument: the mp4 filename under ``doc/source/_static/tutorials/``.
+    """
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    has_content = False
+
+    def run(self):
+        name = self.arguments[0].strip()
+        return [nodes.raw('', _VIDEO_HTML.format(name=name), format='html')]
+
+
+def setup(app):
+    app.add_directive('video', VideoDirective)
+    return {
+        'version': '1.0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/doc/source/tutorials/boost_basics.rst
+++ b/doc/source/tutorials/boost_basics.rst
@@ -15,12 +15,7 @@ Source: ``examples/tutorial/boost_basics.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/boost_basics.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/boost_basics.mp4">Download the recording</a>.
-   </video>
+.. video:: boost_basics.mp4
 
 .. literalinclude:: ../../../examples/tutorial/boost_basics.das
    :language: das

--- a/doc/source/tutorials/buttons.rst
+++ b/doc/source/tutorials/buttons.rst
@@ -26,12 +26,7 @@ Source: ``examples/tutorial/buttons.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/buttons.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/buttons.mp4">Download the recording</a>.
-   </video>
+.. video:: buttons.mp4
 
 .. literalinclude:: ../../../examples/tutorial/buttons.das
    :language: das

--- a/doc/source/tutorials/child.rst
+++ b/doc/source/tutorials/child.rst
@@ -27,12 +27,7 @@ Source: ``examples/tutorial/child.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/child.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/child.mp4">Download the recording</a>.
-   </video>
+.. video:: child.mp4
 
 .. literalinclude:: ../../../examples/tutorial/child.das
    :language: das

--- a/doc/source/tutorials/collapsing_header.rst
+++ b/doc/source/tutorials/collapsing_header.rst
@@ -28,12 +28,7 @@ Source: ``examples/tutorial/collapsing_header.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/collapsing_header.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/collapsing_header.mp4">Download the recording</a>.
-   </video>
+.. video:: collapsing_header.mp4
 
 .. literalinclude:: ../../../examples/tutorial/collapsing_header.das
    :language: das

--- a/doc/source/tutorials/color.rst
+++ b/doc/source/tutorials/color.rst
@@ -31,12 +31,7 @@ Source: ``examples/tutorial/color.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/color.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/color.mp4">Download the recording</a>.
-   </video>
+.. video:: color.mp4
 
 .. literalinclude:: ../../../examples/tutorial/color.das
    :language: das

--- a/doc/source/tutorials/color_button_hover.rst
+++ b/doc/source/tutorials/color_button_hover.rst
@@ -27,12 +27,7 @@ Source: ``examples/tutorial/color_button_hover.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/color_button_hover.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/color_button_hover.mp4">Download the recording</a>.
-   </video>
+.. video:: color_button_hover.mp4
 
 .. literalinclude:: ../../../examples/tutorial/color_button_hover.das
    :language: das

--- a/doc/source/tutorials/containers.rst
+++ b/doc/source/tutorials/containers.rst
@@ -32,12 +32,7 @@ Source: ``examples/tutorial/containers.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/containers.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/containers.mp4">Download the recording</a>.
-   </video>
+.. video:: containers.mp4
 
 .. literalinclude:: ../../../examples/tutorial/containers.das
    :language: das

--- a/doc/source/tutorials/custom_widgets.rst
+++ b/doc/source/tutorials/custom_widgets.rst
@@ -16,12 +16,7 @@ Source: ``examples/tutorial/custom_widgets.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/custom_widgets.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/custom_widgets.mp4">Download the recording</a>.
-   </video>
+.. video:: custom_widgets.mp4
 
 .. literalinclude:: ../../../examples/tutorial/custom_widgets.das
    :language: das

--- a/doc/source/tutorials/data_table.rst
+++ b/doc/source/tutorials/data_table.rst
@@ -26,12 +26,7 @@ Source: ``examples/tutorial/data_table.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/data_table.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/data_table.mp4">Download the recording</a>.
-   </video>
+.. video:: data_table.mp4
 
 .. literalinclude:: ../../../examples/tutorial/data_table.das
    :language: das

--- a/doc/source/tutorials/display_widgets.rst
+++ b/doc/source/tutorials/display_widgets.rst
@@ -34,12 +34,7 @@ Source: ``examples/tutorial/display_widgets.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/display_widgets.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/display_widgets.mp4">Download the recording</a>.
-   </video>
+.. video:: display_widgets.mp4
 
 .. literalinclude:: ../../../examples/tutorial/display_widgets.das
    :language: das

--- a/doc/source/tutorials/docking.rst
+++ b/doc/source/tutorials/docking.rst
@@ -20,12 +20,7 @@ Source: ``examples/tutorial/docking.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/docking.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/docking.mp4">Download the recording</a>.
-   </video>
+.. video:: docking.mp4
 
 .. literalinclude:: ../../../examples/tutorial/docking.das
    :language: das

--- a/doc/source/tutorials/drag.rst
+++ b/doc/source/tutorials/drag.rst
@@ -28,12 +28,7 @@ Source: ``examples/tutorial/drag.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/drag.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/drag.mp4">Download the recording</a>.
-   </video>
+.. video:: drag.mp4
 
 .. literalinclude:: ../../../examples/tutorial/drag.das
    :language: das

--- a/doc/source/tutorials/drag_drop.rst
+++ b/doc/source/tutorials/drag_drop.rst
@@ -22,12 +22,7 @@ Source: ``examples/features/drag_drop.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/drag_drop.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/drag_drop.mp4">Download the recording</a>.
-   </video>
+.. video:: drag_drop.mp4
 
 .. literalinclude:: ../../../examples/features/drag_drop.das
    :language: das

--- a/doc/source/tutorials/drawlist.rst
+++ b/doc/source/tutorials/drawlist.rst
@@ -34,12 +34,7 @@ Source: ``examples/tutorial/drawlist.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/drawlist.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/drawlist.mp4">Download the recording</a>.
-   </video>
+.. video:: drawlist.mp4
 
 .. literalinclude:: ../../../examples/tutorial/drawlist.das
    :language: das

--- a/doc/source/tutorials/driving_outside.rst
+++ b/doc/source/tutorials/driving_outside.rst
@@ -30,12 +30,7 @@ commands**: value writes and container toggles mutate state directly
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/driving_outside.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/driving_outside.mp4">Download the recording</a>.
-   </video>
+.. video:: driving_outside.mp4
 
 .. literalinclude:: ../../../examples/tutorial/driving_outside.das
    :language: das

--- a/doc/source/tutorials/dropdown_select.rst
+++ b/doc/source/tutorials/dropdown_select.rst
@@ -24,12 +24,7 @@ Source: ``examples/tutorial/dropdown_select.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/dropdown_select.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/dropdown_select.mp4">Download the recording</a>.
-   </video>
+.. video:: dropdown_select.mp4
 
 .. literalinclude:: ../../../examples/tutorial/dropdown_select.das
    :language: das

--- a/doc/source/tutorials/edit_external_tour.rst
+++ b/doc/source/tutorials/edit_external_tour.rst
@@ -16,12 +16,7 @@ keeps the snapshot stable across frames.
 
 Source: ``examples/tutorial/editing_external.das``.
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/edit_external_tour.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/edit_external_tour.mp4">Download the recording</a>.
-   </video>
+.. video:: edit_external_tour.mp4
 
 What the tour shows
 ===================

--- a/doc/source/tutorials/edit_tab_item.rst
+++ b/doc/source/tutorials/edit_tab_item.rst
@@ -31,12 +31,7 @@ Source: ``examples/tutorial/edit_tab_item.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/edit_tab_item.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/edit_tab_item.mp4">Download the recording</a>.
-   </video>
+.. video:: edit_tab_item.mp4
 
 .. literalinclude:: ../../../examples/tutorial/edit_tab_item.das
    :language: das

--- a/doc/source/tutorials/flat_tooltips.rst
+++ b/doc/source/tutorials/flat_tooltips.rst
@@ -30,12 +30,7 @@ Source: ``examples/tutorial/flat_tooltips.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/flat_tooltips.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/flat_tooltips.mp4">Download the recording</a>.
-   </video>
+.. video:: flat_tooltips.mp4
 
 .. literalinclude:: ../../../examples/tutorial/flat_tooltips.das
    :language: das

--- a/doc/source/tutorials/group.rst
+++ b/doc/source/tutorials/group.rst
@@ -25,12 +25,7 @@ Source: ``examples/tutorial/group.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/group.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/group.mp4">Download the recording</a>.
-   </video>
+.. video:: group.mp4
 
 .. literalinclude:: ../../../examples/tutorial/group.das
    :language: das

--- a/doc/source/tutorials/input_numeric.rst
+++ b/doc/source/tutorials/input_numeric.rst
@@ -29,12 +29,7 @@ Source: ``examples/tutorial/input_numeric.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/input_numeric.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/input_numeric.mp4">Download the recording</a>.
-   </video>
+.. video:: input_numeric.mp4
 
 .. literalinclude:: ../../../examples/tutorial/input_numeric.das
    :language: das

--- a/doc/source/tutorials/input_text.rst
+++ b/doc/source/tutorials/input_text.rst
@@ -29,12 +29,7 @@ Source: ``examples/tutorial/input_text.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/input_text.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/input_text.mp4">Download the recording</a>.
-   </video>
+.. video:: input_text.mp4
 
 .. literalinclude:: ../../../examples/tutorial/input_text.das
    :language: das

--- a/doc/source/tutorials/layout.rst
+++ b/doc/source/tutorials/layout.rst
@@ -15,12 +15,7 @@ Source: ``examples/tutorial/layout.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/layout.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/layout.mp4">Download the recording</a>.
-   </video>
+.. video:: layout.mp4
 
 .. literalinclude:: ../../../examples/tutorial/layout.das
    :language: das

--- a/doc/source/tutorials/layout_primitives.rst
+++ b/doc/source/tutorials/layout_primitives.rst
@@ -42,12 +42,7 @@ Source: ``examples/tutorial/layout_primitives.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/layout_primitives.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/layout_primitives.mp4">Download the recording</a>.
-   </video>
+.. video:: layout_primitives.mp4
 
 .. literalinclude:: ../../../examples/tutorial/layout_primitives.das
    :language: das

--- a/doc/source/tutorials/live_reload.rst
+++ b/doc/source/tutorials/live_reload.rst
@@ -39,12 +39,7 @@ Source: ``examples/tutorial/live_reload.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/live_reload.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/live_reload.mp4">Download the recording</a>.
-   </video>
+.. video:: live_reload.mp4
 
 .. literalinclude:: ../../../examples/tutorial/live_reload.das
    :language: das

--- a/doc/source/tutorials/main_menu_bar.rst
+++ b/doc/source/tutorials/main_menu_bar.rst
@@ -43,12 +43,7 @@ Source: ``examples/tutorial/main_menu_bar.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/main_menu_bar.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/main_menu_bar.mp4">Download the recording</a>.
-   </video>
+.. video:: main_menu_bar.mp4
 
 .. literalinclude:: ../../../examples/tutorial/main_menu_bar.das
    :language: das

--- a/doc/source/tutorials/narrative_layout_tour.rst
+++ b/doc/source/tutorials/narrative_layout_tour.rst
@@ -12,12 +12,7 @@ explaining what each one does.
 
 Source: ``examples/tutorial/narrative_layout_tour.das``.
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/narrative_layout_tour.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/narrative_layout_tour.mp4">Download the recording</a>.
-   </video>
+.. video:: narrative_layout_tour.mp4
 
 What the tour shows
 ===================

--- a/doc/source/tutorials/narrative_widgets.rst
+++ b/doc/source/tutorials/narrative_widgets.rst
@@ -33,12 +33,7 @@ Source: ``examples/tutorial/narrative_widgets.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/narrative_widgets.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/narrative_widgets.mp4">Download the recording</a>.
-   </video>
+.. video:: narrative_widgets.mp4
 
 .. literalinclude:: ../../../examples/tutorial/narrative_widgets.das
    :language: das

--- a/doc/source/tutorials/plot.rst
+++ b/doc/source/tutorials/plot.rst
@@ -29,12 +29,7 @@ Source: ``examples/tutorial/plot.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/plot.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/plot.mp4">Download the recording</a>.
-   </video>
+.. video:: plot.mp4
 
 .. literalinclude:: ../../../examples/tutorial/plot.das
    :language: das

--- a/doc/source/tutorials/popup_modal.rst
+++ b/doc/source/tutorials/popup_modal.rst
@@ -32,12 +32,7 @@ Source: ``examples/tutorial/popup_modal.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/popup_modal.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/popup_modal.mp4">Download the recording</a>.
-   </video>
+.. video:: popup_modal.mp4
 
 .. literalinclude:: ../../../examples/tutorial/popup_modal.das
    :language: das

--- a/doc/source/tutorials/popup_window.rst
+++ b/doc/source/tutorials/popup_window.rst
@@ -27,12 +27,7 @@ Source: ``examples/tutorial/popup_window.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/popup_window.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/popup_window.mp4">Download the recording</a>.
-   </video>
+.. video:: popup_window.mp4
 
 .. literalinclude:: ../../../examples/tutorial/popup_window.das
    :language: das

--- a/doc/source/tutorials/popups.rst
+++ b/doc/source/tutorials/popups.rst
@@ -28,12 +28,7 @@ Source: ``examples/tutorial/popups.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/popups.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/popups.mp4">Download the recording</a>.
-   </video>
+.. video:: popups.mp4
 
 The recording narrates the widget code with the target visible — the
 popups themselves are right-click-triggered by ImGui's internal

--- a/doc/source/tutorials/recording.rst
+++ b/doc/source/tutorials/recording.rst
@@ -43,12 +43,7 @@ all; it operates entirely through the live-command HTTP surface.
 The driver
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/recording.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/recording.mp4">Download the recording</a>.
-   </video>
+.. video:: recording.mp4
 
 .. literalinclude:: ../../../tests/integration/record_recording.das
    :language: das

--- a/doc/source/tutorials/selectable_hover.rst
+++ b/doc/source/tutorials/selectable_hover.rst
@@ -28,12 +28,7 @@ Source: ``examples/tutorial/selectable_hover.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/selectable_hover.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/selectable_hover.mp4">Download the recording</a>.
-   </video>
+.. video:: selectable_hover.mp4
 
 .. literalinclude:: ../../../examples/tutorial/selectable_hover.das
    :language: das

--- a/doc/source/tutorials/slider.rst
+++ b/doc/source/tutorials/slider.rst
@@ -29,12 +29,7 @@ Source: ``examples/tutorial/slider.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/slider.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/slider.mp4">Download the recording</a>.
-   </video>
+.. video:: slider.mp4
 
 .. literalinclude:: ../../../examples/tutorial/slider.das
    :language: das

--- a/doc/source/tutorials/state_telemetry.rst
+++ b/doc/source/tutorials/state_telemetry.rst
@@ -29,12 +29,7 @@ Source: ``examples/tutorial/state_telemetry.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/state_telemetry.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/state_telemetry.mp4">Download the recording</a>.
-   </video>
+.. video:: state_telemetry.mp4
 
 .. literalinclude:: ../../../examples/tutorial/state_telemetry.das
    :language: das

--- a/doc/source/tutorials/tab_bar.rst
+++ b/doc/source/tutorials/tab_bar.rst
@@ -26,12 +26,7 @@ Source: ``examples/tutorial/tab_bar.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/tab_bar.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/tab_bar.mp4">Download the recording</a>.
-   </video>
+.. video:: tab_bar.mp4
 
 .. literalinclude:: ../../../examples/tutorial/tab_bar.das
    :language: das

--- a/doc/source/tutorials/toggles.rst
+++ b/doc/source/tutorials/toggles.rst
@@ -22,12 +22,7 @@ Source: ``examples/tutorial/toggles.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/toggles.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/toggles.mp4">Download the recording</a>.
-   </video>
+.. video:: toggles.mp4
 
 .. literalinclude:: ../../../examples/tutorial/toggles.das
    :language: das

--- a/doc/source/tutorials/tree_image_misc.rst
+++ b/doc/source/tutorials/tree_image_misc.rst
@@ -22,12 +22,7 @@ Source: ``examples/tutorial/tree_image_misc.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/tree_image_misc.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/tree_image_misc.mp4">Download the recording</a>.
-   </video>
+.. video:: tree_image_misc.mp4
 
 .. literalinclude:: ../../../examples/tutorial/tree_image_misc.das
    :language: das

--- a/doc/source/tutorials/tree_node.rst
+++ b/doc/source/tutorials/tree_node.rst
@@ -27,12 +27,7 @@ Source: ``examples/tutorial/tree_node.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/tree_node.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/tree_node.mp4">Download the recording</a>.
-   </video>
+.. video:: tree_node.mp4
 
 .. literalinclude:: ../../../examples/tutorial/tree_node.das
    :language: das

--- a/doc/source/tutorials/visual_aids_tour.rst
+++ b/doc/source/tutorials/visual_aids_tour.rst
@@ -41,12 +41,7 @@ Source: ``examples/tutorial/visual_aids_tour.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/visual_aids_tour.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/visual_aids_tour.mp4">Download the recording</a>.
-   </video>
+.. video:: visual_aids_tour.mp4
 
 .. literalinclude:: ../../../examples/tutorial/visual_aids_tour.das
    :language: das

--- a/doc/source/tutorials/widgets_tour.rst
+++ b/doc/source/tutorials/widgets_tour.rst
@@ -15,12 +15,7 @@ Source: ``examples/tutorial/widgets_tour.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/widgets_tour.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/widgets_tour.mp4">Download the recording</a>.
-   </video>
+.. video:: widgets_tour.mp4
 
 .. literalinclude:: ../../../examples/tutorial/widgets_tour.das
    :language: das

--- a/doc/source/tutorials/window_size_constraints.rst
+++ b/doc/source/tutorials/window_size_constraints.rst
@@ -34,12 +34,7 @@ Source: ``examples/tutorial/window_size_constraints.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/window_size_constraints.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/window_size_constraints.mp4">Download the recording</a>.
-   </video>
+.. video:: window_size_constraints.mp4
 
 .. literalinclude:: ../../../examples/tutorial/window_size_constraints.das
    :language: das

--- a/doc/source/tutorials/with_disabled.rst
+++ b/doc/source/tutorials/with_disabled.rst
@@ -37,12 +37,7 @@ Source: ``examples/tutorial/with_disabled.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/with_disabled.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/with_disabled.mp4">Download the recording</a>.
-   </video>
+.. video:: with_disabled.mp4
 
 .. literalinclude:: ../../../examples/tutorial/with_disabled.das
    :language: das

--- a/doc/source/tutorials/with_id.rst
+++ b/doc/source/tutorials/with_id.rst
@@ -27,12 +27,7 @@ Source: ``examples/tutorial/with_id.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/with_id.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/with_id.mp4">Download the recording</a>.
-   </video>
+.. video:: with_id.mp4
 
 .. literalinclude:: ../../../examples/tutorial/with_id.das
    :language: das

--- a/doc/source/tutorials/with_style.rst
+++ b/doc/source/tutorials/with_style.rst
@@ -20,12 +20,7 @@ Source: ``examples/tutorial/with_style.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/with_style.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/with_style.mp4">Download the recording</a>.
-   </video>
+.. video:: with_style.mp4
 
 .. literalinclude:: ../../../examples/tutorial/with_style.das
    :language: das

--- a/doc/source/tutorials/with_tab_stop.rst
+++ b/doc/source/tutorials/with_tab_stop.rst
@@ -25,12 +25,7 @@ Source: ``examples/tutorial/with_tab_stop.das``.
 Walkthrough
 ************
 
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/with_tab_stop.mp4" type="video/mp4">
-     Your browser doesn't support HTML5 video. <a href="../_static/tutorials/with_tab_stop.mp4">Download the recording</a>.
-   </video>
+.. video:: with_tab_stop.mp4
 
 .. literalinclude:: ../../../examples/tutorial/with_tab_stop.das
    :language: das

--- a/skills/recording.md
+++ b/skills/recording.md
@@ -217,15 +217,13 @@ The recorder produces `.apng` (intermediate). The deliverable is `.mp4` produced
 
 When dasImgui is daspkg-installed under `daScript/modules/dasImgui/`, the APNG lands in that install copy. For source-repo workflows (preferred), launch the driver with `-project_root <dasimgui-source>` so the loaded copy IS the source repo. The helper forwards `-project_root` from the driver's own argv to the spawned daslang-live.
 
-Each tutorial RST under `doc/source/tutorials/*.rst` cites its video via raw HTML:
+Each tutorial RST under `doc/source/tutorials/*.rst` cites its video via the local `video` directive (registered by `doc/source/tutorial_video.py`, listed in `conf.py`'s `extensions`):
 
 ```rst
-.. raw:: html
-
-   <video autoplay loop muted playsinline width="100%">
-     <source src="../_static/tutorials/scene_name.mp4" type="video/mp4">
-   </video>
+.. video:: scene_name.mp4
 ```
+
+The directive emits a native HTML5 `<video controls preload="metadata" playsinline>` player: it starts **paused** with play/pause, scrubber, volume, and fullscreen controls; audio is on; no autoplay, no loop. Change player chrome once in `tutorial_video.py` rather than across every page. The argument is just the mp4 filename under `doc/source/_static/tutorials/`.
 
 CI's sphinx step uses `-W` (warnings-as-errors), so an RST referencing a missing `.mp4` fails the build. Commit the `.mp4` ahead of the RST cite to keep the intermediate state passing.
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -129,7 +129,7 @@ git push -u origin <branch>
 
 `.github/workflows/docs.yml` checks out the source — `.mp4` files are
 already in the tree, no fetch step. CI uses `-W` (warnings-as-errors)
-on sphinx, so an RST `<video>` block referencing a missing `.mp4` fails
+on sphinx, so an RST `.. video::` cite referencing a missing `.mp4` fails
 the build. Implication for a new tutorial PR: commit the `.mp4`
 ahead of the RST cite to keep CI passing.
 


### PR DESCRIPTION
## Why

Tutorial recordings now carry a music bed + per-`say()` voiceover. The old embed — `<video autoplay loop muted playsinline>` — was wrong for that: it started **muted**, **looped** (talking over itself), and offered **no controls** to pause or adjust volume. This makes the embedded videos behave like a normal video: **start paused**, native controls, audio on.

## What

- **New local Sphinx directive** `doc/source/tutorial_video.py` (registered in `conf.py`'s `extensions`). One argument, the mp4 filename:

  ```rst
  .. video:: scene_name.mp4
  ```

  emits `<video controls preload="metadata" playsinline width="100%">` with a `<source>` + download fallback — **play/pause, scrubber, volume, fullscreen; audio on; no autoplay, no loop**.

- **Centralized**: player chrome lives in one place. Future tweaks (sizing, `preload`, a first-frame poster) are a one-line edit in the directive instead of a 47-file sweep — which is exactly why this change touches 47 files once.

- **All 47 tutorial RSTs** rewritten from the 5-line raw-HTML block to the one-line directive (−6/+1 each).

- **Canonical template updated** in `CLAUDE.md`, `skills/recording.md`, `tests/integration/README.md`.

- The vendored `daslang.py` domain is **untouched** — it stays byte-compatible with daslang upstream; this directive is dasImgui-local presentation.

## Verification

`sphinx-build -b html --keep-going doc/source <out>` → exit 0, directive resolves with no "unknown directive" warning. All 47 generated tutorial pages emit `<video controls preload="metadata" playsinline width="100%">`, and **no `<video>` tag anywhere carries `autoplay`/`muted`/`loop`**.

A paused video shows its first frame on desktop Chrome/Firefox/Edge. If any browser renders a black poster instead, appending `#t=0.001` to the `src` in `tutorial_video.py` is the one-line follow-up (the payoff of centralizing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)