### PR TITLE
imgui_key_chord: drop ineffective FOCUS_SETTLE_LEAD_FRAMES

### DIFF
--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -427,12 +427,8 @@ def imgui_key_chord(input : JsonValue?) : JsonValue? {
     // input poll falls relative to our per-frame tick, but small enough to stay one
     // discrete tap. synth_key_press auto-pairs the ImGuiMod_* alias so Shortcut() routing
     // sees the chord (mirrors imgui_test_engine).
-    // Lead frames before the chord presses: a chord is usually issued right after a click
-    // that focuses the target window, and ImGui applies that focus the frame AFTER the click
-    // — start a couple frames in so a focus-gated Shortcut (editor IsFocused gate) sees it.
-    let FOCUS_SETTLE_LEAD_FRAMES = 2
     let CHORD_HOLD_FRAMES = 2
-    var t = FOCUS_SETTLE_LEAD_FRAMES
+    var t = 0
     for (m in args.mods) {
         key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.press, key = mod_name_to_key(m)))
     }


### PR DESCRIPTION
## What

Removes `FOCUS_SETTLE_LEAD_FRAMES = 2` from `imgui_key_chord`, restoring the pre-#101 (frame-paced, `t = 0`) behavior. One-line change plus the dead comment block.

## Why — correcting the #101 record

PR #101 added the lead on the theory that a chord issued right after a focusing click must start a couple frames in, so a focus-gated `Shortcut()` (the node-editor's `IsFocused` gate) sees the focus that ImGui applies the frame *after* the click.

That theory was **falsified.** Re-running the failing `dasImguiNodeEditor` clipboard case against dasImgui master at exactly the #101 merge commit (`9c65b18`, lead present) produced **byte-identical counts** to the pre-fix run — the lead does not fix the POSIX chord drop. It was dead code, and #101's claim that it fixed the drop was wrong.

The real cause was a **test-side timing guess**: the chord fired before the click's effect (node selection + canvas focus) had applied on sub-millisecond POSIX-headless frames, so `Ctrl+D` duplicated nothing. The actual fix lives in `dasImguiNodeEditor` (companion PR): a `ne_wait_selected` rail that polls until the node is genuinely selected before issuing the selection-dependent chord — no frame/time guess. With that gate in place the lead is moot.

## Verification (solo, uncontended on port 9090, both platforms)

- `test_imgui_synth_ctrl_shortcuts`: **3/3 PASS on Windows and WSL**, including `test_click_then_ctrl_a_clears_input` — the *exact* click-then-chord scenario the lead claimed to need, passing without it.
- `dasImguiNodeEditor` full integration suite (with the companion node-editor fix): **21/21 PASS on Windows and WSL** (the POSIX repro that originally dropped the chord is now green).

## Merge order

Independent of, but companion to, the `dasImguiNodeEditor` `ne_wait_selected` PR. Recommend merging this first so the node-editor CI (which checks out dasImgui master unpinned) runs against the verified `lead=0` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)