### PR TITLE
synth IO: frame-paced discrete key tap (repeat-proof Tab/Enter/arrows)

### DIFF
--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -456,6 +456,14 @@ struct KeyEventWire {
 
 struct KeyPlayArgs {
     events : array<KeyEventWire>
+    // When true, t_ms is read as a FRAME index (one event-group per frame) instead of
+    // wall-clock ms - the same pacing imgui_key_chord uses so a discrete tap is held for a
+    // fixed FRAME count and fires its shortcut exactly once regardless of frame rate. A
+    // wall-clock hold spans a variable number of frames, so on a slow frame (e.g. the
+    // recorder's synchronous-APNG capture) it crosses ImGui's key-repeat threshold and
+    // over-fires - one Tab cycling several fields. Use for non-ASCII discrete taps
+    // (Tab/Enter/arrows) that imgui_key_chord (ASCII-only) can't express.
+    @optional frame_paced : bool = false
 }
 
 def public sort_key_play_events(var events : array<KeyEventWire>) {
@@ -465,12 +473,13 @@ def public sort_key_play_events(var events : array<KeyEventWire>) {
     }
 }
 
-[live_command(description="Play a scripted key/char timeline via ImGui bypass. Args: events array of (t_ms, kind, key, codepoint)")]
+[live_command(description="Play a scripted key/char timeline via ImGui bypass. Args: events array of (t_ms, kind, key, codepoint); optional frame_paced (t_ms as frame index for repeat-proof discrete taps)")]
 def imgui_key_play(input : JsonValue?) : JsonValue? {
     var args = from_JV(input, type<KeyPlayArgs>)
     return JV((error = "no events")) if (empty(args.events))
     sort_key_play_events(args.events)
     reset_key_timeline()
+    key_frame_paced = args.frame_paced   // after reset (which clears it); frame-index pacing for discrete taps
     key_timeline |> reserve(length(args.events))
     for (w in args.events) {
         var ev = KeyEvent(t_ms = w.t_ms, key = w.key, codepoint = w.codepoint)

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -542,14 +542,19 @@ def public focus(app : ImguiApp; target : string) : JsonValue? {
     return send_imgui_command(app.transport, "imgui_focus", JV((target = target)))
 }
 
-def public key_tap(app : ImguiApp; key : int) {
-    //! Synthesize a complete press+release of an ImGuiKey by integer code.
-    //! Pairs ``imgui_key_press`` + ``imgui_key_release`` — neither verb alone
-    //! does both, so calling only press leaves the key stuck (visible in the
-    //! key_hud overlay and as repeating-input bugs in driven widgets).
-    //! Use ``int(ImGuiKey.Tab)`` / ``int(ImGuiKey.Escape)`` / etc. at the call site.
-    post_command(app, "imgui_key_press",   JV((key = key)))
-    post_command(app, "imgui_key_release", JV((key = key)))
+def public key_tap(app : ImguiApp; key : int; hold_frames : int = 2) {
+    //! Synthesize a discrete press+release of an ImGuiKey by integer code, FRAME-PACED: the key
+    //! is held for ``hold_frames`` frames then released via ``imgui_key_play``'s frame-index
+    //! pacing, so it fires its shortcut/navigation exactly once regardless of frame rate. The
+    //! old wall-clock press+release pair spanned a variable number of frames, so on a slow frame
+    //! (e.g. the recorder's synchronous-APNG capture) the hold crossed ImGui's key-repeat
+    //! threshold and over-fired — one Tab cycling several fields, one Enter committing twice.
+    //! Mirrors ``imgui_key_chord``'s frame-pacing but for any key (no ASCII / modifier restriction).
+    //! Use ``int(ImGuiKey.Tab)`` / ``int(ImGuiKey.Enter)`` / etc. at the call site.
+    post_command(app, "imgui_key_play", JV((frame_paced = true, events = [
+        JV((t_ms = 0,           kind = "press",   key = key)),
+        JV((t_ms = hold_frames, kind = "release", key = key))
+    ])))
 }
 
 // ===== Voiceover sync (record-time, opt-in via a prepared manifest) =====


### PR DESCRIPTION
## Problem
A discrete synthetic key tap (Tab to move focus, Enter to commit) was driven by a **wall-clock** press+release pair (`key_tap` → `imgui_key_press`/`imgui_key_release`). A wall-clock hold spans a variable number of frames, so on a slow frame — notably the recorder's **synchronous-APNG capture** (blocks the GL thread during zlib) — the hold crosses ImGui's **key-repeat** threshold and the key fires several times: one Tab cycles past several fields, one Enter commits twice.

Found while building the `with_tab_stop` tutorial: clicking field A then one `key_tap(Tab)` jumped focus to field **D** (three repeats), not B.

`imgui_key_chord` already dodges this with **frame-pacing** (hold a fixed *frame* count), but it's ASCII-char-only and can't express Tab/Enter/arrows.

## Fix
Generalize the chord's frame-pacing to the timeline player:
- `imgui_key_play` gains an optional **`frame_paced`** flag; when set, `t_ms` is read as a frame index (one event-group per frame), reusing the existing `key_frame_paced` drain path.
- playwright **`key_tap`** now posts a frame-paced `imgui_key_play` (press frame 0, release frame `hold_frames`, default 2) instead of a wall-clock press+release pair → fires exactly once regardless of frame rate. This also hardens **`type_into_voice`** (taps Tab between cells, Enter to commit), which is the basis for the upcoming keyboard tutorials.

## Verified (live, with_tab_stop)
Click field A → one frame-paced Tab focuses field **B** (was: focus jumped to D). Confirmed the full chain A→B→C→D with the wrapped field skipped, each hop a clean single tap.

Foundation for the keyboard tutorials (`with_tab_stop`, `input_text`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)