### PR TITLE
synth IO: resolve io.active_widget for input widgets (focus_rect fix)

### DIFF
--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1216,6 +1216,13 @@ def public widget_finalize(widget_ident : string;
     entry.focus = IsItemFocused()
     g_id_to_path[entry.hex_id] = path_key
     g_id_to_bbox[entry.hex_id] = entry.bbox
+    // hex_id is GetID(widget_ident), which differs from ImGui's real active item id for input
+    // widgets - so focus_rect / the snapshot's active_widget couldn't resolve typing focus. When
+    // THIS widget is the active one, also map GetActiveID() (authoritative) -> path. Gated on
+    // entry.active so GetActiveID() is this item; additive (hex_id untouched, no targeting change).
+    if (entry.active) {
+        g_id_to_path[GetActiveID()] = path_key
+    }
     g_registry[path_key] <- entry
     widgets_mark_seen(widget_ident, path_key, kind, state_addr, ti)
     PopID()

--- a/widgets/imgui_visual_aids.das
+++ b/widgets/imgui_visual_aids.das
@@ -735,8 +735,10 @@ def private paint_focus_rect {
 def private paint_all {
     paint_highlights()
     paint_trail()
-    paint_narrates()
+    // focus rect is a widget annotation — paint it before the narrative bar so the
+    // (later-drawn, thus on-top) caption stays readable over the halo, not under it.
     paint_focus_rect()
+    paint_narrates()
     paint_cursor_sprite()
     paint_click_flash()
     paint_key_hud()


### PR DESCRIPTION
Two related focus-rectangle fixes (the second only surfaced because of the first).

## 1. Resolve `io.active_widget` for input widgets

`widget_finalize` indexes `g_id_to_path` by `GetID(widget_ident)`, but ImGui's authoritative active-item id (`GetActiveID()`) **differs** for input widgets that claim ActiveID while being edited. So `active_widget_path()` / the snapshot's `io.active_widget` could never resolve typing focus, and `imgui_focus_rect` drew nothing while a text field was being edited.

When the widget being finalized is the active one, additionally map `GetActiveID() -> path`:

```das
if (entry.active) {
    g_id_to_path[GetActiveID()] = path_key
}
```

**Why this shape (not `entry.hex_id = GetItemID()`):** purely additive and gated on `entry.active`. The existing `g_id_to_path[entry.hex_id]` mapping is untouched, so no targeting/lookup changes for any other widget. Swapping `hex_id` to `GetItemID()` wholesale would change every widget's identity (wrong for containers/compound widgets and a broad test risk); this avoids that.

## 2. Paint the focus rect under the narrative caption

`paint_all` drew `paint_focus_rect()` **after** `paint_narrates()`. ImGui renders later draw calls on top, so the blue halo landed over the yellow caption box wherever they overlapped. The caption is the readable "voice for the eye" overlay and must stay topmost — moved `paint_focus_rect()` ahead of `paint_narrates()`. (Only visible now that fix #1 makes the halo actually draw for input widgets.)

## Verification

**Live** (`examples/tutorial/with_tab_stop.das`): clicked into a text field with `imgui_focus_rect` enabled → the focus rectangle draws around the active field, and the snapshot reports `io.active_widget = "TS_WIN/TS_FIELD_A"` (was empty before); `hex_id` 2550525385 ≠ `active_id` 1715518200 — the exact mismatch this bridges. In the with_tab_stop recording, the caption box now renders cleanly over the halo.

**Tests** (all green against this branch):
- `test_visual_aids_focus_rect` — 2/2
- `test_active_widget` — 1/1 (idle-empty assertion intact; the new map is gated on `entry.active`)
- `test_visual_aids_dashboard` — 1/1
- `test_glfw_synth_keys` — 6/6
- `test_with_tab_stop` — 1/1

Unblocks the `with_tab_stop` tutorial recording, which follows in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)