### PR TITLE
edit_combo: BeginCombo+Selectable so the popup exposes sub_bboxes

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -72,7 +72,7 @@ def document_module_imgui_widgets_builtin() {
         group_by_regex("Focus & scrolling", mod, %regex~^(set_scroll_here_y|set_keyboard_focus_here|set_item_default_focus)$%%),
         group_by_regex("Logging",         mod, %regex~^(log_to_clipboard|log_finish|log_text)$%%),
         group_by_regex("Status queries",  mod, %regex~^is_active$%%),
-        hide_group(group_by_regex("Finalizers", mod, %regex~^.*_finalize$%%)),
+        hide_group(group_by_regex("Finalizers", mod, %regex~^.*_finalize(_vec|_subs)?$%%)),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )
     document("Built-in widgets — inputs, selection, color, plots, output", mod, "imgui_widgets_builtin.rst", groups)
@@ -86,7 +86,7 @@ def document_module_imgui_containers_builtin() {
         group_by_regex("Trees",         mod, %regex~^(tree_node|collapsing_header)$%%),
         group_by_regex("Menus",         mod, %regex~^(menu_bar|menu|menu_item)$%%),
         group_by_regex("Popups",        mod, %regex~^(popup|modal|tooltip|open_popup|open_popup_on_item_click|close_current_popup|is_popup_open)$%%),
-        hide_group(group_by_regex("Finalizers", mod, %regex~^.*_finalize$%%)),
+        hide_group(group_by_regex("Finalizers", mod, %regex~^.*_finalize(_vec|_subs)?$%%)),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )
     document("Built-in containers — windows, child regions, tabs, menus, popups", mod, "imgui_containers_builtin.rst", groups)

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -104,6 +104,25 @@ def edit_finalize(widget_ident : string; kind : string; var ptr : auto(TT)? impl
     register_focusable(widget_ident)
 }
 
+def edit_finalize_subs(widget_ident : string; kind : string; var ptr : auto(TT)? implicit;
+                       var subs : array<float4>) {
+    //! edit_finalize plus a caller-built per-item sub_bboxes array -- for the external-pointer combo,
+    //! whose open-popup item rects are captured one-per-Selectable via capture_current_item_rect (no
+    //! analytic rect). Empty subs (popup closed this frame) leaves sub_bboxes absent, so a driver's
+    //! widget_component_point falls back to the combo box itself. subs is moved out. Same pointer/ti
+    //! routing as edit_finalize (snapshot + dispatch go through *ptr).
+    var entry : WidgetEntry
+    if (!empty(subs)) {
+        entry.sub_bboxes <- subs
+    }
+    unsafe {
+        widget_finalize(widget_ident, kind, entry,
+                        reinterpret<void?>(ptr),
+                        reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<TT>)))
+    }
+    register_focusable(widget_ident)
+}
+
 def edit_container_open_close_finalize(widget_ident : string; kind : string;
                                        var ptr : bool? implicit;
                                        bbox : float4 = float4(0.0f, 0.0f, 0.0f, 0.0f)) {
@@ -2580,11 +2599,32 @@ def edit_color_picker4(var ptr : float4? implicit; text : string = "";
 def edit_combo(var ptr : int? implicit; text : string = "";
                items : array<string>;
                popup_max_height_in_items : int = -1) : bool {
-    //! ``Combo`` against a caller-owned ``int?`` index. ``items`` is passed as an array of C-string pointers (no per-frame zero-separated buffer; daslang ``string`` already carries the trailing null).
+    //! ``BeginCombo`` + a ``Selectable`` loop against a caller-owned ``int?`` index. Built this way
+    //! (not the all-in-one ``Combo()``) so each open-popup item's rect is captured into sub_bboxes,
+    //! letting a driver click item N via widget_component_point -- exactly like the state-managed
+    //! ``combo``. The picked index is written straight through ``*ptr``.
     let lbl = empty(text) ? widget_ident : text
-    let changed = Combo(lbl, ptr, unsafe(addr(items[0])), length(items),
-                        popup_max_height_in_items)
-    edit_finalize(widget_ident, "edit_combo", ptr)
+    let n = length(items)
+    let cur = unsafe(*ptr)
+    let preview = (cur >= 0 && cur < n) ? items[cur] : ""
+    var changed = false
+    var subs : array<float4>
+    constrain_combo_popup(popup_max_height_in_items)
+    if (BeginCombo(lbl, preview, ImGuiComboFlags.None)) {
+        for (i in range(n)) {
+            let is_sel = i == cur
+            if (Selectable(items[i], is_sel)) {
+                unsafe(*ptr) = i
+                changed = true
+            }
+            if (is_sel) {
+                SetItemDefaultFocus()
+            }
+            subs |> push(capture_current_item_rect())
+        }
+        EndCombo()
+    }
+    edit_finalize_subs(widget_ident, "edit_combo", ptr, subs)
     return changed
 }
 


### PR DESCRIPTION
## What

Rewrites `edit_combo` from ImGui's all-in-one `Combo()` to a `BeginCombo` + `Selectable` loop (writing the picked index through `*ptr`), and adds an `edit_finalize_subs` helper (`edit_finalize` + a caller-built `sub_bboxes` array, same pointer/`ti` routing).

## Why

`edit_combo` was the **only** widget still calling the all-in-one `Combo()`, which renders its popup items internally — so no per-item rects ever reached the snapshot (`sub_bboxes`). A playwright/recording driver had nothing to target, so `combo_pick_voice` opened the popup but its item-click landed nowhere and the selection silently no-op'd.

The state-managed `combo` was **already** rebuilt as `BeginCombo` + a `Selectable` loop for exactly this reason (see its comment: "Built as BeginCombo + a Selectable loop … so each open-popup item's rect is captured into sub_bboxes"). This brings `edit_combo` to parity — same telemetry, same drivability.

Surfaced by the `edit_external_tour` recording (a separate PR, based on this one): its self-verification caught the dud combo pick, which is the synthetic-≠-real signal that there was a missing rail.

## Verification

- Pure `.das`, no native rebuild.
- Live: combo opens under a synth click, snapshot shows 4 `sub_bboxes` (Low/Medium/High/Ultra), clicking item 2 commits `value == 2` and writes `g_quality_idx = 2` through the external pointer.
- In the recording: all 7 external-pointer widgets now self-verify (no teardown panic).
- `mcp lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)