### PR TITLE
dasImgui(collapsing_header): real header + close-button driving

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -149,7 +149,7 @@ def document_module_imgui_playwright() {
         group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
         group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|widget_click_point|widget_component_point|get_text)$%%),
         group_by_regex("Actions",           mod, %regex~^(click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
-        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|record_check_value|record_check_changed|record_check_rendered)$%%),
+        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|record_check_value|record_check_changed|record_check_rendered)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|expect_value|expect_render).*%%),
         group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe)$%%),
         group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -633,23 +633,31 @@ def collapsing_header(var state : CollapsingHeaderState; text : string;
     }
     state.flags = flags
     var im_open : bool
+    // The clickable header strip (chevron + label, plus the X-button when
+    // closable) is the IsItem* target right after CollapsingHeader; capture
+    // its rect before the body pushes inner items so a driver can click the
+    // header/arrow like a human (mirrors tree_node). Stays zero while a
+    // closable section is hidden (no header rendered, nothing to click).
+    var header_bbox = float4(0.0f, 0.0f, 0.0f, 0.0f)
     if (closable) {
         if (state.open) {
             unsafe {
                 im_open = CollapsingHeader(text, addr(state.open), flags)
             }
+            header_bbox = current_item_bbox()
         }
         // If state.open is false, the section is hidden — don't issue the
         // ImGui call. CollapsingHeader-with-p_visible only renders while
         // *p_visible is true; we mirror that gate exactly.
     } else {
         im_open = CollapsingHeader(text, flags)
+        header_bbox = current_item_bbox()
     }
     state.opened = im_open
     if (im_open) {
         invoke(blk)
     }
-    open_close_finalize(widget_ident, "collapsing_header", state)
+    open_close_finalize(widget_ident, "collapsing_header", state, header_bbox)
 }
 
 // ===== Choice block-arg family =====

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -1010,6 +1010,7 @@ let TREE_LEAD_MAX_MS : uint  = 3000u   // cap on the pre-click lead (long voice 
 let TREE_ARROW_FRAC  : float = 0.6f    // arrow click x = header.x + header_height * frac (chevron is at the left)
 let TREE_TRAVEL_MS   : int   = 450     // cursor travel onto the header before press
 let TREE_POLL_FRAMES : int   = 120     // poll budget: child rendered-state settles after the toggle
+let CLOSE_BTN_FRAC   : float = 0.5f    // X-button click x = header.z - header_height * frac (X sits at the right edge)
 
 def public toggle_tree_voice(app : ImguiApp; dwell : uint; header_target : string; on_arrow : bool;
                              child_target : string; expect_child_rendered : bool) {
@@ -1040,6 +1041,34 @@ def public toggle_tree_voice(app : ImguiApp; dwell : uint; header_target : strin
     unsafe { delete ev; }
     wait_for_mouse_idle(app)                                            // SYNC: the click fully played
     record_check_rendered(app, child_target, expect_child_rendered, TREE_POLL_FRAMES)   // SYNC: toggle landed
+    let consumed = uint(get_time_usec(started) / 1000)
+    sleep(dwell > consumed ? dwell - consumed : 0u)            // PACING: hold the caption for the rest of the voice
+}
+
+def public close_button_voice(app : ImguiApp; dwell : uint; header_target : string; child_target : string) {
+    //! Click the X-button of a CLOSABLE container header (``collapsing_header`` with ``closable=true``,
+    //! or any closable strip whose header bbox is in telemetry) UNDER an already-posted voice line, then
+    //! assert the whole strip vanished by checking ``child_target`` is no longer rendered — a closable
+    //! header that closes stops drawing its entire body. The X sits a half header-height in from the
+    //! header's right edge (mirrors how ImGui lays the close button out). Self-verifying via
+    //! ``record_check_rendered`` (expect=false): a missed close aborts the recording at teardown. The
+    //! caller should ``move_to`` the header first. Every sleep is PACING; the close is polled, never slept.
+    let started = ref_time_ticks()
+    let lead = clamp(dwell / 3u, TREE_LEAD_MIN_MS, TREE_LEAD_MAX_MS)   // ~1/3 into the line
+    sleep(lead)                                                // PACING: land the click under the voice
+    var snap = snapshot(app)
+    let bb = snap?["globals"]?[header_target]?["bbox"]
+    let by = bb?["y"] ?? 0.0f
+    let bz = bb?["z"] ?? 0.0f
+    let bw = bb?["w"] ?? 0.0f
+    let cy = (by + bw) * 0.5f
+    let click_x = bz - (bw - by) * CLOSE_BTN_FRAC
+    var ev : array<JsonValue?>
+    ev |> click_at(0, (click_x, cy), TREE_TRAVEL_MS, 0)
+    post_command(app, "imgui_mouse_play", JV((events = ev)))
+    unsafe { delete ev; }
+    wait_for_mouse_idle(app)                                            // SYNC: the click fully played
+    record_check_rendered(app, child_target, false, TREE_POLL_FRAMES)  // SYNC: the strip closed
     let consumed = uint(get_time_usec(started) / 1000)
     sleep(dwell > consumed ? dwell - consumed : 0u)            // PACING: hold the caption for the rest of the voice
 }


### PR DESCRIPTION
collapsing_header finalized without a header bbox, so its chevron and X-button were not click targets -- drivers had to fake open/close via imgui_open / imgui_close commands instead of clicking like a human (the same gap tree_node had before it captured its header rect).

This PR makes collapsing_header fully real-drivable:

- **Capture the header bbox** (widgets/imgui_containers_builtin.das): grab current_item_bbox() right after CollapsingHeader (before the body pushes inner items) and pass it to open_close_finalize, mirroring tree_node. The header strip is now a real click target in telemetry; the existing toggle_tree_voice rail already documents collapsing_header support and works against it unchanged.
- **close_button_voice rail** (widgets/imgui_playwright.das): mirrors toggle_tree_voice but clicks the X-button a half header-height in from the right edge and self-verifies the whole strip vanished via record_check_rendered(expect=false). Reusable for any closable strip whose header bbox is in telemetry.
- **Docs gate** (utils/imgui2rst.das): group close_button_voice under "Recording / narration" so the uncategorized-gate stays green.

Verified live against examples/tutorial/collapsing_header.das: BASIC_CH / CLOSABLE_CH / STARTUP_CH now expose real bboxes; a real synthetic header click toggles the body (BASIC_LIVE starts rendering), and a real X-button click closes CLOSABLE_CH (the strip + VOLUME stop rendering). No behavior change to imgui_open / imgui_close, so the existing test_collapsing_header_closable smoke test is unaffected.

Unblocks the collapsing_header tutorial rewrite (all-real, self-verifying) which follows in its own PR.

Generated with [Claude Code](https://claude.com/claude-code)
