### PR TITLE
dasImgui(playwright): click_render_voice rail for reveal/dismiss gestures

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -149,7 +149,7 @@ def document_module_imgui_playwright() {
         group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
         group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|widget_click_point|widget_component_point|get_text)$%%),
         group_by_regex("Actions",           mod, %regex~^(click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
-        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|record_check_value|record_check_changed|record_check_rendered)$%%),
+        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|record_check_value|record_check_changed|record_check_rendered)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|expect_value|expect_render).*%%),
         group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe)$%%),
         group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -1073,6 +1073,26 @@ def public close_button_voice(app : ImguiApp; dwell : uint; header_target : stri
     sleep(dwell > consumed ? dwell - consumed : 0u)            // PACING: hold the caption for the rest of the voice
 }
 
+def public click_render_voice(app : ImguiApp; dwell : uint; click_target : string;
+                              watch_target : string; expect_rendered : bool) {
+    //! Real-click ``click_target`` UNDER an already-posted voice line, then assert ``watch_target``'s
+    //! rendered state == ``expect_rendered`` — the reveal/dismiss rail. ``expect_rendered=true`` is a
+    //! REVEAL (a button that opens a popup/modal: watch a body widget appear); ``expect_rendered=false``
+    //! is a DISMISS (a Yes/No/Apply/menu-item that closes the popup: watch a body widget — often the
+    //! click target itself — disappear). A button whose own click closes the popup can't be verified by
+    //! its click-count (it's gone next frame); the watch-target's render state is the durable signal.
+    //! Self-verifying via ``record_check_rendered``: a missed reveal/dismiss aborts the recording at
+    //! teardown. The caller should ``move_to`` the click target first. Every sleep is PACING; the
+    //! reveal/dismiss is polled, never slept.
+    let started = ref_time_ticks()
+    let lead = clamp(dwell / 3u, TREE_LEAD_MIN_MS, TREE_LEAD_MAX_MS)   // ~1/3 into the line
+    sleep(lead)                                                // PACING: land the click under the voice
+    click(app, click_target)                                  // real animated click (imgui_click coro)
+    record_check_rendered(app, watch_target, expect_rendered, TREE_POLL_FRAMES)   // SYNC: reveal/dismiss landed
+    let consumed = uint(get_time_usec(started) / 1000)
+    sleep(dwell > consumed ? dwell - consumed : 0u)            // PACING: hold the caption for the rest of the voice
+}
+
 def public wait_for_key_idle(app : ImguiApp; timeout_sec : float = DEFAULT_FRAME_WAIT_SEC) : bool {
     //! Poll ``imgui_key_status`` until ``playing == false`` or timeout; returns true on idle.
     //! Uses one HTTP request per poll (unlike a ``wait_until`` body that pairs a snapshot


### PR DESCRIPTION
A button whose own click opens or closes a popup/modal can't be self-verified by its click-count: on a dismiss it's gone the next frame, and on a reveal the proof is a *different* widget appearing. `hold_through_voice` (which checks the clicked widget's own effect) therefore can't cover popups, modals, or context menus.

Adds **`click_render_voice(app, dwell, click_target, watch_target, expect_rendered)`**: real-click `click_target` under an already-posted voice line, then assert `watch_target`'s rendered state == `expect_rendered` via `record_check_rendered`.

- `expect_rendered=true` is a REVEAL (open button -> body widget appears)
- `expect_rendered=false` is a DISMISS (Yes/No/Apply/menu-item -> body widget, often the click target itself, disappears)

Self-verifying: a missed reveal/dismiss aborts the recording at teardown. Mirrors the `toggle_tree_voice` / `close_button_voice` shape, reuses their lead/poll tunables.

Grouped under "Recording / narration" in imgui2rst.das so the docs uncategorized-gate stays green.

Verified live against examples/tutorial/popup_modal.das: clicking "Delete file..." reveals CONFIRM_YES; clicking "Yes" dismisses it and STATUS_LINE updates to the answer.

Unblocks the popup_modal tutorial rewrite (all-real, self-verifying), which follows in its own PR.

Generated with [Claude Code](https://claude.com/claude-code)
