### PR TITLE
dasImgui(playwright): menu_pick_voice rail for menu-bar navigation

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -149,7 +149,7 @@ def document_module_imgui_playwright() {
         group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
         group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|widget_click_point|widget_component_point|get_text)$%%),
         group_by_regex("Actions",           mod, %regex~^(click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
-        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|record_check_value|record_check_changed|record_check_rendered)$%%),
+        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_rendered)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|expect_value|expect_render).*%%),
         group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe)$%%),
         group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -1093,6 +1093,38 @@ def public click_render_voice(app : ImguiApp; dwell : uint; click_target : strin
     sleep(dwell > consumed ? dwell - consumed : 0u)            // PACING: hold the caption for the rest of the voice
 }
 
+def public menu_pick_voice(app : ImguiApp; dwell : uint; header_target : string; item_target : string) {
+    //! Open a menu-bar menu (``header_target``, e.g. ``MAIN_BAR/FILE_MENU``) and pick an item inside it
+    //! (``item_target``) UNDER an already-posted voice line, navigating the way a human does: click the
+    //! header, then drop STRAIGHT DOWN the menu's column onto the item. A direct click on the item would
+    //! travel diagonally from the header across the menu bar and clip a SIBLING menu header — ImGui
+    //! hover-switches the open menu mid-travel and the click lands in the wrong menu. The vertical drop
+    //! stays inside the open menu's column (menu items span the full menu width, so the header's center-x
+    //! lands on the item) and never crosses a sibling. Self-verifying via ``record_check_rendered``: the
+    //! item must render after the header click (menu opened) and stop rendering after the item click (pick
+    //! landed + menu closed), or the recording aborts at teardown. The caller should ``move_to`` the
+    //! header's column (directly below the header, below the bar) first so the open-click travels vertically.
+    //! Every sleep is PACING; the open/close are polled, never slept.
+    let started = ref_time_ticks()
+    let lead = clamp(dwell / 3u, TREE_LEAD_MIN_MS, TREE_LEAD_MAX_MS)   // ~1/3 into the line
+    sleep(lead)                                                // PACING: land the clicks under the voice
+    click(app, header_target)                                 // open the menu (caller staged below it)
+    record_check_rendered(app, item_target, true, TREE_POLL_FRAMES)   // SYNC: menu opened
+    var snap = snapshot(app)
+    let hb = snap?["globals"]?[header_target]?["bbox"]
+    let hcx = ((hb?["x"] ?? 0.0f) + (hb?["z"] ?? 0.0f)) * 0.5f
+    let ib = snap?["globals"]?[item_target]?["bbox"]
+    let icy = ((ib?["y"] ?? 0.0f) + (ib?["w"] ?? 0.0f)) * 0.5f
+    var ev : array<JsonValue?>
+    ev |> click_at(0, (hcx, icy), TREE_TRAVEL_MS, 0)          // vertical drop down the column, then click
+    post_command(app, "imgui_mouse_play", JV((events = ev)))
+    unsafe { delete ev; }
+    wait_for_mouse_idle(app)                                            // SYNC: the click fully played
+    record_check_rendered(app, item_target, false, TREE_POLL_FRAMES)  // SYNC: pick landed, menu closed
+    let consumed = uint(get_time_usec(started) / 1000)
+    sleep(dwell > consumed ? dwell - consumed : 0u)            // PACING: hold the caption for the rest of the voice
+}
+
 def public wait_for_key_idle(app : ImguiApp; timeout_sec : float = DEFAULT_FRAME_WAIT_SEC) : bool {
     //! Poll ``imgui_key_status`` until ``playing == false`` or timeout; returns true on idle.
     //! Uses one HTTP request per poll (unlike a ``wait_until`` body that pairs a snapshot


### PR DESCRIPTION
A straight-line synth click on a menu item travels diagonally from the menu header across the menu bar; for an item whose center sits off-axis from its header, that path clips a **sibling** menu header, and ImGui hover-switches the open menu mid-travel -- the click lands in the wrong menu. Reproduced cleanly: `File > Dark mode` left DarkMode untoggled and instead incremented `Edit > Undo`. A real user drops straight down the open menu's column and never crosses a sibling.

Adds **`menu_pick_voice(app, dwell, header_target, item_target)`**: click the bar header to open the menu, then drop STRAIGHT DOWN the column (at the header's center-x; menu items span the full menu width, so it lands on the item) and click.

- Self-verifying via `record_check_rendered`: the item must render after the header click (menu opened) and stop rendering after the item click (pick landed + menu closed), or the recording aborts at teardown.
- The caller stages the cursor directly below the header so the open-click travels vertically.

Grouped under "Recording / narration" in imgui2rst.das so the docs uncategorized-gate stays green.

Verified live and via a clean self-verifying recording of examples/tutorial/main_menu_bar.das: File > Dark mode and File > Auto-save each toggle their own value; Edit > Undo counts one click; no wrong-menu hits.

Unblocks the main_menu_bar tutorial rewrite (all-real, self-verifying), which follows in its own PR.

Generated with [Claude Code](https://claude.com/claude-code)
