### PR TITLE
dasImgui(synth): imgui_key_type emits control chars as keys only (fixes doubled newline)

### DIFF
--- a/examples/features/io_synth_text.das
+++ b/examples/features/io_synth_text.das
@@ -42,6 +42,8 @@ def update() {
         }
         input_text(DEMO_INPUT, (text = "Type here"))
         text("buffer = {DEMO_INPUT.value}")
+        input_text_multiline(DEMO_MULTI, (text = "Multi", size = float2(0.0f, 70.0f)))
+        text("multi = {DEMO_MULTI.value}")
     }
 
     harness_end_frame()

--- a/tests/integration/test_io_synth_text.das
+++ b/tests/integration/test_io_synth_text.das
@@ -49,5 +49,13 @@ def test_imgui_type_text_buffer_fills(t : T?) {
         // per frame means 5 chars take ~5 frames; allow 5s for poll cadence.
         let done = wait_for_string_value(d, "MAIN_WIN/DEMO_INPUT", "value", "hello", 300)
         t |> success(done, "DEMO_INPUT.value reaches 'hello' after L1 keyboard stream")
+
+        // Gate 5: a '\n' in the stream inserts exactly ONE newline in a multiline
+        // buffer. imgui_key_type sends '\n' as the Enter key alone (no 0x0A char),
+        // matching a real backend; emitting the char too would double-insert.
+        let multi = type_text(d, "MAIN_WIN/DEMO_MULTI", "a\nb")
+        t |> equal(multi?["ok"] ?? false, true, "type_text into multiline returned ok")
+        let multi_done = wait_for_string_value(d, "MAIN_WIN/DEMO_MULTI", "value", "a\nb", 300)
+        t |> success(multi_done, "DEMO_MULTI.value == 'a\\nb' (single newline, not doubled)")
     }
 }

--- a/widgets/imgui_live_core.das
+++ b/widgets/imgui_live_core.das
@@ -379,7 +379,13 @@ def imgui_key_type(input : JsonValue?) : JsonValue? {
             if (k != 0) {
                 key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.press, key = k))
             }
-            key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.char_, codepoint = cp))
+            // Real backends emit a Char event only for printable codepoints; control
+            // chars arrive as a key alone (Enter -> '\n', Tab -> focus). Emitting the
+            // char too double-inserts in InputTextMultiline (the Enter key AND the 0x0A
+            // char each add a newline).
+            if (cp >= 0x20u) {
+                key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.char_, codepoint = cp))
+            }
             if (k != 0) {
                 key_timeline |> push(KeyEvent(t_ms = t, kind = KEKind.release, key = k))
             }


### PR DESCRIPTION
## Bug

`imgui_key_type` streamed every codepoint as a key event **and** a Char event. For `\n` that means `press(Enter) + char(0x0A) + release(Enter)`; in `InputTextMultiline` the Enter key inserts a newline **and** the `0x0A` char inserts another -> **every typed newline doubled**. A real backend emits a Char only for printable codepoints; control chars (Enter, Tab) arrive as a key alone.

Found while bringing the `input_text` tutorial onto the self-verifying recording bar: typing `"a\nb"` into the multiline field landed as `"a\n\nb"`.

## Fix

[imgui_live_core.das](widgets/imgui_live_core.das) — guard the Char push to printable codepoints (`cp >= 0x20`). Newline/tab now type the way a real keyboard does. Single-line behavior is unchanged: the `0x0A` / `0x09` chars were already filtered by ImGui's single-line `InputText`, so only the Enter-commit / Tab-navigate from the key event ever took effect.

## Regression test (CI, headless)

- Adds a multiline target (`DEMO_MULTI`) to the `io_synth_text` feature.
- Adds **Gate 5** to `test_io_synth_text`: type `"a\nb"` into the multiline buffer, assert `value == "a\nb"` (exactly one newline). Without the fix the buffer is `"a\n\nb"`.

Local: `test_io_synth_text` passes (5 gates, ~11s).

## Files
- `widgets/imgui_live_core.das` - the guard
- `examples/features/io_synth_text.das` - multiline target
- `tests/integration/test_io_synth_text.das` - Gate 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)