### PR TITLE
layout helpers: drag-handle bbox + thin-target drag precision + split-overflow fix

### DIFF
--- a/tests/integration/test_layout_helpers.das
+++ b/tests/integration/test_layout_helpers.das
@@ -74,6 +74,16 @@ def test_layout_helpers(t : T?) {
             let lb_y1 = lb?["w"] ?? 0.0f
             t |> success(bb_y0 > lb_y1,
                          "split_v: BOTTOM_BTN.top ({bb_y0}) > LEFT_BTN.bottom ({lb_y1})")
+
+            // Fit (regression guard for the dock_left -> split_v line-height overflow):
+            // the bottom pane must render INSIDE the content region, not pushed below the
+            // fold. dock_left's handle spans the full content height, so its bbox bottom
+            // (bbox.w) is the content-region floor. Before split_v was grouped, the top
+            // pane shared the sidebar's full-height line and the bottom pane dropped past it.
+            let region_floor = find_widget(snap0, "LAYOUT_WIN/SIDEBAR/HANDLE")?["bbox"]?["w"] ?? 0.0f
+            let bb_y1 = bb?["w"] ?? 0.0f
+            t |> success(region_floor > 0.0f && bb_y1 <= region_floor + 1.0f,
+                         "split_v fits: BOTTOM_BTN.bottom ({bb_y1}) within content floor ({region_floor})")
         }
         reset(d)
 

--- a/tests/integration/test_layout_helpers.das
+++ b/tests/integration/test_layout_helpers.das
@@ -107,14 +107,44 @@ def test_layout_helpers(t : T?) {
             t |> success(rb_x0_now > rb_x0_orig + 10.0f,
                          "L3 force_set_value: RIGHT_BTN.left shifted right ({rb_x0_orig} -> {rb_x0_now})")
         }
+        reset(d)
+
+        t |> run("drag") <| @(t : T?) {
+            // The split handle now surfaces its geometry as a child alias
+            // <split>/HANDLE, so a synth-mouse drag targets it directly — the
+            // L1 coverage gap that used to force imgui_force_set.
+            let HANDLE = "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN/HANDLE"
+            var snap0 = wait_for_widget(d, HANDLE, 15.0f)
+            t |> success(snap0 != null, "split_h HANDLE surfaces its bbox")
+            if (snap0 == null) return
+
+            t |> equal(find_widget(snap0, HANDLE)?["kind"] ?? "",
+                       "splitter_handle", "HANDLE registers as 'splitter_handle' kind")
+
+            // Non-degenerate vertical strip between the two panes.
+            let hb = find_widget(snap0, HANDLE)?["bbox"]
+            let hx0 = hb?["x"] ?? 0.0f
+            let hx1 = hb?["z"] ?? 0.0f
+            let hy0 = hb?["y"] ?? 0.0f
+            let hy1 = hb?["w"] ?? 0.0f
+            t |> success(hx1 > hx0 && hy1 > hy0 + 50.0f,
+                         "HANDLE bbox is a tall vertical strip ([{hx0},{hx1}] x [{hy0},{hy1}])")
+
+            let v0 = find_widget(snap0, "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN")?["payload"]?["value"] ?? 0.0f
+            let rb0 = find_widget(snap0, "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN/RIGHT_BTN")?["bbox"]?["x"] ?? 0.0f
+
+            // Real synth drag of the handle to the right. split_h width is
+            // pixel-driven, so the left fraction must rise — no force_set.
+            let resp = drag(d, HANDLE, 80.0f, 0.0f, 8)
+            t |> equal(resp?["ok"] ?? false, true, "drag(HANDLE, +80) hit the handle")
+
+            let moved = wait_until(d, 300) $(snap) => (find_widget(snap, "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN")?["payload"]?["value"] ?? 0.0f) > v0 + 0.02f
+            t |> success(moved != null, "synth drag raised SPLIT_MAIN.value above baseline {v0}")
+
+            var snap1 = snapshot(d)
+            let rb1 = find_widget(snap1, "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN/RIGHT_BTN")?["bbox"]?["x"] ?? 0.0f
+            t |> success(rb1 > rb0 + 5.0f,
+                         "synth drag shifted RIGHT_BTN.left right ({rb0} -> {rb1})")
+        }
     }
 }
-
-// TODO: synth-mouse drag test for the split handle. The handle is rendered
-// as an InvisibleButton inside split_h's body — not separately registered in
-// the boost snapshot, so its bbox can't be read from the JSON for synth-mouse
-// targeting. Options: (a) register the handle as a child widget so its bbox
-// surfaces; (b) expose handle screen position via a debug field on the state
-// struct; (c) drive drag through a synthetic L1 command that knows the handle
-// path. Pick when the drag test is needed (it's the only L1 coverage gap for
-// §4.6 — L3 force_set_value coverage is in test_layout_set_value above).

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -42,7 +42,7 @@ def document_module_imgui_boost_runtime() {
     var mod = find_module("imgui_boost_runtime")
     var groups <- array<DocGroup>(
         group_by_regex("Widget state types",      mod, %regex~.*State(Float|Int|Float2|Float3|Float4|Int2|Int3|Int4)?$%%),
-        group_by_regex("Per-frame registry",      mod, %regex~^(WidgetEntry|WidgetMeta|begin_frame|end_frame|end_of_frame|register_widget|register_focusable|register_radio_site_alias|register_end_of_frame_hook|register_post_command_hook|lookup_widget|lookup_state_addr|clear_module_widgets|widget_registered|widget_prelude|widget_rect|with_state|id_to_path|id_to_bbox).*%%),
+        group_by_regex("Per-frame registry",      mod, %regex~^(WidgetEntry|WidgetMeta|begin_frame|end_frame|end_of_frame|register_widget|register_focusable|register_radio_site_alias|register_handle_bbox|register_end_of_frame_hook|register_post_command_hook|lookup_widget|lookup_state_addr|clear_module_widgets|widget_registered|widget_prelude|widget_rect|with_state|id_to_path|id_to_bbox).*%%),
         group_by_regex("Path machinery",          mod, %regex~^(container_path_push|container_path_pop|widget_path_key|container_path_key|active_widget_path)$%%),
         group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
         group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1257,6 +1257,7 @@ def public register_handle_bbox(tag : string) {
     //! open-container chain still names this split, and ``GetItemRectMin/Max`` / ``GetID(tag)``
     //! still report the handle. Mirrors ``register_radio_site_alias``.
     let alias = widget_path_key("HANDLE")
+    check_unique_render(alias, "splitter_handle")   // loud on a duplicated container ident, like every finalize
     var entry = WidgetEntry(kind = "splitter_handle", hex_id = GetID(tag))
     let rmin = GetItemRectMin()
     let rmax = GetItemRectMax()

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1247,6 +1247,27 @@ def public register_radio_site_alias(widget_ident : string; v_button : int;
     widgets_mark_seen(alias, alias, "radio_button_int", state_addr, ti)
 }
 
+def public register_handle_bbox(tag : string) {
+    //! Surface a split/dock drag-handle's geometry as a child alias ``<container>/HANDLE``,
+    //! so external drivers and recordings can target a REAL synthetic drag at the handle
+    //! instead of only ``imgui_force_set``-ing the fraction. Geometry-only (no state): written
+    //! straight into ``g_registry``, so it rides the per-frame clear and surfaces via
+    //! ``imgui_snapshot``'s registry-only pass with no freshness bookkeeping. Call from inside
+    //! the ``[container]`` body, right after the handle ``InvisibleButton(tag, …)`` — the
+    //! open-container chain still names this split, and ``GetItemRectMin/Max`` / ``GetID(tag)``
+    //! still report the handle. Mirrors ``register_radio_site_alias``.
+    let alias = widget_path_key("HANDLE")
+    var entry = WidgetEntry(kind = "splitter_handle", hex_id = GetID(tag))
+    let rmin = GetItemRectMin()
+    let rmax = GetItemRectMax()
+    capture_item_bbox(entry, float4(rmin.x, rmin.y, rmax.x, rmax.y))
+    entry.hover = IsItemHovered(ImGuiHoveredFlags.None)
+    entry.active = IsItemActive()
+    g_id_to_path[entry.hex_id] = alias
+    g_id_to_bbox[entry.hex_id] = entry.bbox
+    g_registry[alias] <- entry
+}
+
 def private widgets_mark_seen(bare_ident : string; path_key : string;
                               kind : string; state_addr : void?; ti : TypeInfo const?) {
     // First render: migrate the bare-ident entry to its container-aware path_key. Subsequent renders just bump last_seen_frame.

--- a/widgets/imgui_layout_builtin.das
+++ b/widgets/imgui_layout_builtin.das
@@ -40,6 +40,7 @@ def private draggable_handle_v(var state : SliderStateFloat; px_per_unit : float
                                size : ImVec2; tag : string) : bool {
     let cursor_min = GetCursorScreenPos()
     InvisibleButton(tag, size)
+    register_handle_bbox(tag)   // expose handle geometry as <container>/HANDLE for real synth drags
     let cursor_max = ImVec2(cursor_min.x + size.x, cursor_min.y + size.y)
     let hot = IsItemHovered() || IsItemActive()
     if (hot) {
@@ -68,6 +69,7 @@ def private draggable_handle_h(var state : SliderStateFloat; px_per_unit : float
                                size : ImVec2; tag : string) : bool {
     let cursor_min = GetCursorScreenPos()
     InvisibleButton(tag, size)
+    register_handle_bbox(tag)   // expose handle geometry as <container>/HANDLE for real synth drags
     let cursor_max = ImVec2(cursor_min.x + size.x, cursor_min.y + size.y)
     let hot = IsItemHovered() || IsItemActive()
     if (hot) {

--- a/widgets/imgui_layout_builtin.das
+++ b/widgets/imgui_layout_builtin.das
@@ -117,6 +117,9 @@ def split_h(var state : SliderStateFloat; left_blk : block; right_blk : block) {
     if (right_w < 0.0f) {
         right_w = 0.0f
     }
+    // Group the whole split as ONE layout item (see split_v) so a splitter composed
+    // after a full-height SameLine'd sibling stacks/flows as a unit, not line-by-line.
+    BeginGroup()
     BeginChild("{widget_ident}__L", ImVec2(left_w, total_h),
                ImGuiChildFlags.None, ImGuiWindowFlags.None)
     invoke(left_blk)
@@ -131,6 +134,7 @@ def split_h(var state : SliderStateFloat; left_blk : block; right_blk : block) {
                ImGuiChildFlags.None, ImGuiWindowFlags.None)
     invoke(right_blk)
     EndChild()
+    EndGroup()
     pending_value_container_finalize(widget_ident, "split_h", state)
 }
 
@@ -157,6 +161,12 @@ def split_v(var state : SliderStateFloat; top_blk : block; bottom_blk : block) {
     if (bottom_h < 0.0f) {
         bottom_h = 0.0f
     }
+    // Group the whole vertical split so it is ONE layout item. Without this, when
+    // split_v is composed after dock_left's trailing SameLine, the top child shares
+    // a line with the full-height sidebar; closing it then advances the cursor by the
+    // sidebar's line height (not top_h), dropping the handle + bottom pane below the
+    // fold. The group makes the splitter stack internally regardless of the outer line.
+    BeginGroup()
     BeginChild("{widget_ident}__T", ImVec2(total_w, top_h),
                ImGuiChildFlags.None, ImGuiWindowFlags.None)
     invoke(top_blk)
@@ -169,6 +179,7 @@ def split_v(var state : SliderStateFloat; top_blk : block; bottom_blk : block) {
                ImGuiChildFlags.None, ImGuiWindowFlags.None)
     invoke(bottom_blk)
     EndChild()
+    EndGroup()
     pending_value_container_finalize(widget_ident, "split_v", state)
 }
 

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -131,12 +131,13 @@ def public drag_along(var events : array<JsonValue?>;
     //! ``to_pos``.
     events |> push(JV((t_ms = t_ms,                                kind = "move",   x = last_cursor_x, y = last_cursor_y)))
     events |> push(JV((t_ms = t_ms + approach_ms,                  kind = "move",   x = from_pos._0,   y = from_pos._1)))
-    // Dwell at from_pos so the press fires while the cursor is still exactly there
-    // (zero drift). Without it the press interpolates toward to_pos and slips off a
-    // thin target (an 8px splitter handle). Same timeline length — the press t is unchanged.
+    // Dwell at from_pos, then press 1ms later. Timestamps STAY strictly increasing —
+    // the host sorts the timeline by t_ms with no tie-break, so a press sharing the
+    // dwell's t_ms could sort first and slip the press off a thin (8px) handle. The
+    // 1ms offset into a drag_ms-long segment is sub-pixel, so the press still lands on target.
     events |> push(JV((t_ms = t_ms + approach_ms + 100,            kind = "move",   x = from_pos._0,   y = from_pos._1)))
-    events |> push(JV((t_ms = t_ms + approach_ms + 100,            kind = "button", button = button,   action = "press")))
-    events |> push(JV((t_ms = t_ms + approach_ms + 100 + drag_ms,  kind = "move",   x = to_pos._0,     y = to_pos._1)))
+    events |> push(JV((t_ms = t_ms + approach_ms + 101,            kind = "button", button = button,   action = "press")))
+    events |> push(JV((t_ms = t_ms + approach_ms + 101 + drag_ms,  kind = "move",   x = to_pos._0,     y = to_pos._1)))
     events |> push(JV((t_ms = t_ms + approach_ms + 200 + drag_ms,  kind = "button", button = button,   action = "release")))
     events |> push(JV((t_ms = t_ms + approach_ms + 300 + drag_ms,  kind = "move",   x = to_pos._0,     y = to_pos._1)))
     last_cursor_x = to_pos._0
@@ -513,17 +514,19 @@ def public drag(app : ImguiApp; target : string;
     let ex = cx + dx
     let ey = cy + dy
     let drag_ms = (steps > 0 ? steps : 1) * 32
-    // Dwell at center BEFORE pressing: the press timestamp coincides with a
-    // move waypoint that still sits at (cx,cy), so the press lands dead-center
-    // with zero interpolation drift. Without the dwell the press fires mid-travel
-    // and a thin target (an 8px splitter handle) is missed entirely.
+    // Dwell at center BEFORE pressing: a move waypoint pins (cx,cy) at t=80, then
+    // the press fires 1ms later. Timestamps are STRICTLY increasing (the host sorts
+    // the timeline by t_ms with no tie-break, so a press sharing the dwell's t_ms
+    // could sort first and defeat it). The 1ms-into-a-drag_ms-long segment leaves the
+    // press essentially dead-center (sub-pixel drift), so it still lands on an 8px
+    // handle — without the dwell the press fires mid-travel and misses entirely.
     var events <- [
         JV((t_ms = 0,             kind = "move",   x = cx, y = cy)),
         JV((t_ms = 80,            kind = "move",   x = cx, y = cy)),
-        JV((t_ms = 80,            kind = "button", button = button, action = "press")),
-        JV((t_ms = 80 + drag_ms,  kind = "move",   x = ex, y = ey)),
-        JV((t_ms = 180 + drag_ms, kind = "button", button = button, action = "release")),
-        JV((t_ms = 280 + drag_ms, kind = "move",   x = ex, y = ey))
+        JV((t_ms = 81,            kind = "button", button = button, action = "press")),
+        JV((t_ms = 81 + drag_ms,  kind = "move",   x = ex, y = ey)),
+        JV((t_ms = 181 + drag_ms, kind = "button", button = button, action = "release")),
+        JV((t_ms = 281 + drag_ms, kind = "move",   x = ex, y = ey))
     ]
     let resp = post_command(app, "imgui_mouse_play", JV((events = events)))
     unsafe { delete events; }

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -131,6 +131,10 @@ def public drag_along(var events : array<JsonValue?>;
     //! ``to_pos``.
     events |> push(JV((t_ms = t_ms,                                kind = "move",   x = last_cursor_x, y = last_cursor_y)))
     events |> push(JV((t_ms = t_ms + approach_ms,                  kind = "move",   x = from_pos._0,   y = from_pos._1)))
+    // Dwell at from_pos so the press fires while the cursor is still exactly there
+    // (zero drift). Without it the press interpolates toward to_pos and slips off a
+    // thin target (an 8px splitter handle). Same timeline length — the press t is unchanged.
+    events |> push(JV((t_ms = t_ms + approach_ms + 100,            kind = "move",   x = from_pos._0,   y = from_pos._1)))
     events |> push(JV((t_ms = t_ms + approach_ms + 100,            kind = "button", button = button,   action = "press")))
     events |> push(JV((t_ms = t_ms + approach_ms + 100 + drag_ms,  kind = "move",   x = to_pos._0,     y = to_pos._1)))
     events |> push(JV((t_ms = t_ms + approach_ms + 200 + drag_ms,  kind = "button", button = button,   action = "release")))
@@ -509,8 +513,13 @@ def public drag(app : ImguiApp; target : string;
     let ex = cx + dx
     let ey = cy + dy
     let drag_ms = (steps > 0 ? steps : 1) * 32
+    // Dwell at center BEFORE pressing: the press timestamp coincides with a
+    // move waypoint that still sits at (cx,cy), so the press lands dead-center
+    // with zero interpolation drift. Without the dwell the press fires mid-travel
+    // and a thin target (an 8px splitter handle) is missed entirely.
     var events <- [
         JV((t_ms = 0,             kind = "move",   x = cx, y = cy)),
+        JV((t_ms = 80,            kind = "move",   x = cx, y = cy)),
         JV((t_ms = 80,            kind = "button", button = button, action = "press")),
         JV((t_ms = 80 + drag_ms,  kind = "move",   x = ex, y = ey)),
         JV((t_ms = 180 + drag_ms, kind = "button", button = button, action = "release")),


### PR DESCRIPTION
Makes the `split_h` / `split_v` / `dock_left` helpers fully drivable for real synthetic drags (recordings + tests), and fixes two latent bugs the work surfaced.

## 1. Expose the drag handle's geometry

The splitter handles are `InvisibleButton`s rendered *inside* the `[container]` body — never registered in telemetry, so `imgui_snapshot` reported `bbox=(0,0,0,0)` for the split/dock and an external driver could only `imgui_force_set` the fraction, never perform a **real** drag. That's the documented L1 coverage gap for §4.6.

- **`register_handle_bbox(tag)`** (`imgui_boost_runtime.das`) — mirrors `register_radio_site_alias`: captures the handle's `GetItemRectMin/Max` + `GetID` right after the `InvisibleButton` and surfaces it as a geometry-only child alias **`<container>/HANDLE`**, written straight into `g_registry` (rides the per-frame clear, no freshness bookkeeping). Now guards with `check_unique_render` so a duplicated container ident fails loudly.
- `draggable_handle_v` / `_h` call it, so `split_h` / `split_v` / `dock_left` all expose `.../HANDLE` automatically.

## 2. Thin-target drag precision (`drag` / `drag_along`)

The `drag` helpers fired their press mid-interpolation, which is fine for a wide slider but slips off an **8px** splitter handle. Both now **dwell at the target center, then press 1ms later** — strictly-increasing timestamps (the host sorts the timeline by `t_ms` with no tie-break), landing dead-center but deterministically.

## 3. split_v / split_h overflow when composed after dock_left

`dock_left` ends with a trailing `SameLine` after a **full-height** sidebar child. A `split_v` placed after it had its top pane share that tall line; closing the pane advanced the cursor by the *line height* (the sidebar's full height), not the pane height — so the handle and **bottom pane dropped below the fold** (Output pane off-screen, handle ungrabbable). Both splitters now wrap their panes in **`BeginGroup`/`EndGroup`**, making each splitter one layout unit that stacks internally regardless of the outer line. On the layout example: scroll overflow **208px → 9px**, split_v handle **y657 → y458** (mid-window), Output pane now visible, and a real synth drag moves it.

## Verification

- `test_layout_helpers` — 5/5, incl. a new `drag` sub-test (HANDLE bbox + real synth drag raises the value + panes reflow) and a **fit assertion** (bottom pane within the content region — regression guard for the overflow).
- `test_io_synth_drag` — 1/1 (the primary `drag` consumer; confirms the timing change is a no-regression).
- Doc Uncategorized-gate: `register_handle_bbox` filed under "Per-frame registry" in `imgui2rst.das` (regen verified clean locally).
- Live-probed on `examples/tutorial/layout.das`: real synth drags move `SIDEBAR` 200→248px and `SPLIT_MAIN` 0.40→0.46 / `SPLIT_VERT` 0.65→0.74.

Unblocks the voiced/self-verifying `layout` tutorial recording (follow-up branch), which drives every split with a real handle drag instead of `imgui_force_set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)