### PR TITLE
drag_drop_target: surface accepted-drop count for self-verifiable drops

### DIFF
--- a/tests/integration/test_drag_drop.das
+++ b/tests/integration/test_drag_drop.das
@@ -9,10 +9,11 @@ require daslib/json public
 require daslib/json_boost public
 
 //! Integration smoke for `drag_drop_source` + `drag_drop_target` containers.
-//! Both register in the snapshot (stateless_finalize runs every frame).
-//! Driving an actual drop is L1-fragile (depends on ImGui's drag threshold,
-//! synth-mouse timing, and frame interleaving), so the L1 gate here just
-//! checks `drag_to` returns ok — the visual demo proves the drop semantics.
+//! Both register in the snapshot (stateless_finalize runs every frame). A real
+//! synth drag (drag_to) is driven SOURCE -> TARGET and the drop is asserted via
+//! the `accepted` telemetry rail — `drag_drop_target` counts the drops ImGui
+//! actually delivers (GetDragDropPayload().Delivery), so the test proves the
+//! drop semantics end-to-end, not just that the gesture was dispatched.
 
 let DRAG_DROP_FEATURE = "modules/dasImgui/examples/features/drag_drop.das"
 
@@ -33,11 +34,20 @@ def test_drag_drop_smoke(t : T?) {
         t |> equal(tgt_dd?["kind"] ?? "", "drag_drop_target",
                    "TARGET_DD.kind == 'drag_drop_target'")
 
+        // Baseline: nothing delivered yet.
+        t |> equal(find_widget(snap0, "MAIN_WIN/TARGET_DD")?["payload"]?["accepted"] ?? 0,
+                   0, "TARGET_DD.accepted baseline == 0")
+
         // Drive an L1 drag from SOURCE_BTN's bbox center to TARGET_BTN's
         // bbox center. Server replies ok with the source target name.
         let resp = drag_to(d, "MAIN_WIN/SOURCE_BTN", "MAIN_WIN/TARGET_BTN", 8, 0)
         t |> success(resp != null, "drag_to returned a response")
         t |> equal(resp?["ok"] ?? false, true,
                    "drag_to response.ok == true")
+
+        // The drop must actually LAND: drag_drop_target.accepted ticks 0 -> 1.
+        // This is the real semantic the visual demo used to be the only proof of.
+        let landed = wait_for_payload_value(d, "MAIN_WIN/TARGET_DD", "accepted", 1, 300)
+        t |> success(landed, "drop delivered: TARGET_DD.accepted -> 1 after real synth drag")
     }
 }

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -575,7 +575,7 @@ struct DragDropSourceState {
 struct DragDropTargetState {
     //! Backs `drag_drop_target`. Body runs only when a payload-bearing drag
     //! is hovering this target — caller still calls AcceptDragDropPayload inside.
-    @optional _placeholder : bool             //! unused; keeps the struct non-empty for [container] auto-emit
+    accepted : int                            //! running count of drops ImGui delivered here; telemetry rail to self-verify a real drop landed
 }
 
 struct TreeNodeState {

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -742,10 +742,19 @@ def drag_drop_source(var state : DragDropSourceState; flags : ImGuiDragDropFlags
 def drag_drop_target(var state : DragDropTargetState; blk : block) {
     //! `BeginDragDropTarget()` / `EndDragDropTarget()` — only-on-true.
     //! Body calls `AcceptDragDropPayload(type, flags)` to receive the payload
-    //! when the drag releases over this target.
+    //! when the drag releases over this target. `state.accepted` counts the
+    //! drops ImGui actually delivers here — the body's accept is raw user code,
+    //! invisible to telemetry, so this is the rail a driver/test asserts against.
     let im_open = BeginDragDropTarget()
     if (im_open) {
         invoke(blk)
+        // ImGui flips the active payload's `Delivery` true on the one frame a
+        // drop releases over an accepting target. We only read it inside
+        // `im_open`, so the count is attributed to the hovered target.
+        let pl = GetDragDropPayload()
+        if (pl != null && pl.Delivery) {
+            state.accepted++
+        }
         EndDragDropTarget()
     }
     stateless_finalize(widget_ident, "drag_drop_target", state)


### PR DESCRIPTION
Closes the L1 coverage gap for the drag-drop family — the same class of gap #135 closed for the splitter handle. Surfaced while bringing the `drag_drop` tutorial to the recording bar.

## The gap

`drag_drop_source` / `drag_drop_target` finalize through `stateless_finalize` — they register **kind + bbox only, no payload**. So the effect the tutorial *teaches* — a drop landing, i.e. the example's `DROP_COUNT` / `RECEIVED` globals changing — was invisible to the snapshot rail. An external driver could dispatch the drag but never **assert it landed**, so `test_drag_drop` punted:

> *"driving an actual drop is L1-fragile … the visual demo proves the drop semantics."*

That fails the tutorial bar's "self-verify every interaction" requirement: the recording could do the real drag but couldn't prove the drop.

## The rail

`drag_drop_target` now counts the drops ImGui **actually delivers** into `DragDropTargetState.accepted`:

```das
let im_open = BeginDragDropTarget()
if (im_open) {
    invoke(blk)
    // ImGui flips the active payload's Delivery true on the one frame a
    // drop releases over an accepting target. Read inside im_open, so the
    // count is attributed to the hovered target.
    let pl = GetDragDropPayload()
    if (pl != null && pl.Delivery) {
        state.accepted++
    }
    EndDragDropTarget()
}
```

`container_finalize` already reflects state-struct fields into the snapshot payload, so `accepted` rides telemetry for free — **zero change to the example or to user accept logic**, and every `drag_drop_target` user gets the verifiable signal. The `@optional _placeholder : bool` filler on `DragDropTargetState` is replaced by the real `accepted : int`.

## Verification

`test_drag_drop` now asserts the real end-to-end semantic instead of just that the gesture dispatched:

- baseline `TARGET_DD.accepted == 0`
- drive a real `drag_to(SOURCE_BTN → TARGET_BTN)`
- assert `TARGET_DD.accepted -> 1`

```
=== RUN 'test_drag_drop_smoke'
--- PASS 'test_drag_drop_smoke' (10.98s)
1 tests, 1 passed, 0 failed, 0 errors, 0 skipped
```

Lint clean on all three files. Unblocks the voiced/self-verifying `drag_drop` tutorial recording (follow-up branch), which drives a real source→target drag and asserts `accepted` 0→1 rather than eyeballing the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)