### PR TITLE
imgui: add disable_ini_persistence() helper (opt-in, tutorial-scoped)

### DIFF
--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -383,6 +383,17 @@ namespace das {
         ImGui::SetNextWindowSizeConstraints(size_min, size_max);
     }
 
+    void DisableIniPersistence () {
+        // Null IniFilename so ImGui skips loading/saving window geometry from
+        // imgui.ini. Call after CreateContext and BEFORE the first NewFrame:
+        // ImGui loads the ini on the first NewFrame, so a later call only stops
+        // future saves — it won't undo an already-loaded layout. Tutorial/demo
+        // apps call it in init() to start in their documented layout every run.
+        // The bound IniFilename field is `const char*` (read-only from daslang),
+        // so this C++ helper is the only way to clear it.
+        ImGui::GetIO().IniFilename = nullptr;
+    }
+
     ImGuiSortDirection_ GetColumnSortDirection ( const ImGuiTableColumnSortSpecs * specs ) {
         // Takes pointer (not reference) for daslang interop consistency with `GetSortSpec`.
         // The bitfield-stored `SortDirection` is exposed as this free helper because
@@ -568,6 +579,9 @@ namespace das {
         addExtern<DAS_BIND_FUN(das::SetNextWindowSizeConstraintsNoCallback), SimNode_ExtFuncCall, imguiTempFn>(*this,lib,"SetNextWindowSizeConstraints",
             SideEffects::worstDefault,"das::SetNextWindowSizeConstraintsNoCallback")
                 ->args({"size_min","size_max"});
+        // Disable imgui.ini persistence — tutorial/demo apps start fresh each run.
+        addExtern<DAS_BIND_FUN(das::DisableIniPersistence)>(*this,lib,"DisableIniPersistence",
+            SideEffects::worstDefault,"das::DisableIniPersistence");
         // ImGuiTableColumnSortSpecs / ImGuiTableSortSpecs
         addExtern<DAS_BIND_FUN(das::GetColumnSortDirection)>(*this,lib,"GetColumnSortDirection",
             SideEffects::none,"das::GetColumnSortDirection");

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -37,6 +37,11 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Context / frame lifecycle
     "CreateContext", "DestroyContext", "GetCurrentContext", "SetCurrentContext",
     "NewFrame", "EndFrame", "Render", "GetDrawData",
+    // Settings persistence — nulls IniFilename to disable imgui.ini load/save.
+    // Host-agnostic config call; tutorials opt in (NOT live_imgui_init), calling
+    // it in init() after CreateContext and before the first NewFrame, so the
+    // documented FirstUseEver layout / recording is deterministic every run.
+    "DisableIniPersistence",
     // IO / per-item state queries (post-widget probes — no v2 host needed)
     "GetIO", "GetStyle", "GetVersion",
     "IsItemHovered", "IsItemActive", "IsItemClicked", "IsItemFocused",


### PR DESCRIPTION
Framework primitive surfaced by the tutorial quality sweep (window_size_constraints). The stacked tutorial PR uses it.

## Problem

Window geometry persisted to `imgui.ini` makes tutorial recordings **non-deterministic**: a window's size/pos carries over from a prior run, so the documented `FirstUseEver` layout never applies — windows can even overlap. `window_size_constraints` is the acute case (window size *is* the subject).

## Why a C++ helper

ImGui auto-saves/loads `imgui.ini` whenever `io.IniFilename != NULL` (including on shutdown), and the bound `IniFilename` field is `const char*` — **read-only from daslang** (`error[30952]: can't write to a constant value`). So there's no das-side knob. The fix is a tiny helper that nulls it:

```cpp
void DisableIniPersistence () { ImGui::GetIO().IniFilename = nullptr; }
```

bound as `disable_ini_persistence()`.

## Opt-in, not blanket (addresses the review)

The first cut called this from `live_imgui_init`, which Copilot correctly flagged: `imgui_live` is shared, so that would change behavior for **every** downstream consumer (no saved layout across restarts). Reverted. Now it's **opt-in** — a tutorial/example that needs a deterministic layout calls `disable_ini_persistence()` in its own `init()` (see the stacked window_size_constraints PR). `live_imgui_init` is untouched.

`disable_ini_persistence` is added to `ALLOWED_IMGUI` in `imgui_lint.das` so IMGUI002 permits examples to call this host-agnostic config helper directly (no `[widget]`/`[container]` wrapper needed).

## Verification

Built `dasModuleImgui`; an example calling `disable_ini_persistence()` in `init()` writes **no `imgui.ini`** after a window resize + shutdown (previously it did). Lint clean (including the new allowlist entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)