### PR TITLE
dasImgui: recording-pipeline fixes for node-editor support (user-control bleed + prepare asset-root)

### DIFF
--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -1764,6 +1764,19 @@ def public imgui_synth_tick() {
             // with a stuck button.
             var io & = unsafe(GetIO())
             io |> ClearEventsQueue()
+            // Seize the cursor at its current position. ImGui_ImplGlfw_NewFrame keeps
+            // polling glfwGetCursorPos every frame regardless of the detached callbacks,
+            // so unless we own the cursor the gated re-assert below is skipped until the
+            // first synth move and the real position bleeds in (hover/move stay live while
+            // buttons are detached). Owning it here freezes position so synth fully owns IO.
+            if (!synth_cursor_owned) {
+                if (IsMousePosValid(null)) {
+                    let cur = GetMousePos()
+                    mouse_cursor_x = cur.x
+                    mouse_cursor_y = cur.y
+                }
+                synth_cursor_owned = true
+            }
         }
     }
     // Advance the live-side timeline playback (mouse/key), which calls the synth_* primitives above.


### PR DESCRIPTION
Two fixes surfaced while bringing the dasImguiNodeEditor tutorials onto the voiced/self-verifying recording bar via dasImgui's shared pipeline. Both are needed for a node-editor recording to come out correct.

## 1. `set_user_control(false)` leaked the real cursor position

Documented as *"synth fully owns IO"*, but it didn't hold for the cursor **position**. `set_user_control(false)` detaches the GLFW button/key callbacks, but `ImGui_ImplGlfw_NewFrame()` keeps polling `glfwGetCursorPos()` every frame. The synth re-assert in `imgui_synth_tick` that should override that polled position is gated behind `synth_armed` (`synth_cursor_owned || held keys || held buttons`), and `set_user_control_enabled(false)` never set `synth_cursor_owned`. So until the first synth move, the real cursor position bled into `io.MousePos` — hover/move stayed live while buttons were detached. Confusing partial detach: move works, click doesn't.

**Fix:** on the user-control→off transition (render thread, `imgui_synth_tick`), seize the cursor at its current position (`IsMousePosValid`-guarded; else keep the last synth pos) and set `synth_cursor_owned`. The per-frame re-assert then freezes position; real input can't bleed.

**Verified live:** bare probe (`set_user_control(false)`, no synth move) — `io.mouse_pos` was the live OS cursor `(1292,589)` before, frozen synth-owned `(0,0)` after; real mouse no longer drives hover.

## 2. `prepare_recording` wrote the manifest to the wrong asset root

`prepare_recording` hardcoded `dasimgui_module_root()` for the `voiceover/` dir, but `arm_voiceovers` (and `convert_recording`) read it from `dir_name(apng)/voiceover`. For a dasImgui driver those coincide; for a consumer package whose recording app roots the APNG under its own tree (`with_node_editor_recording_app`), the manifest landed where `arm_voiceovers` couldn't find it → the recording ran **silent**.

**Fix:** add `--asset-root` (default: dasImgui's module root). A non-dasImgui driver passes its package root so the manifest + wavs land beside where its APNG will be written.

**Verified:** with `--asset-root <node-editor-root>`, the manifest lands in the node-editor's `voiceover/` dir; the re-record armed all 6 lines (51s voiced, sidecar written) where the first take had been silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)