### PR TITLE
recording rails: record_check_unchanged + imgui_key_hud keycap_fade_s

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -149,7 +149,7 @@ def document_module_imgui_playwright() {
         group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
         group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|widget_click_point|widget_component_point|get_text)$%%),
         group_by_regex("Actions",           mod, %regex~^(click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
-        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_rendered|record_check_kind_count)$%%),
+        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_unchanged|record_check_rendered|record_check_kind_count)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|expect_value|expect_render).*%%),
         group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe)$%%),
         group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -667,6 +667,22 @@ def public record_check_changed(app : ImguiApp; target : string; field : string;
     return false
 }
 
+def public record_check_unchanged(app : ImguiApp; target : string; field : string; before : string) : bool {
+    //! Recording-safe "the gesture left it alone" verifier - the mirror of ``record_check_changed``.
+    //! Asserts ``target.payload[field]``'s JSON still EQUALS ``before`` (the value captured before the
+    //! gesture). This is the honest self-test for a NEGATIVE claim - e.g. a node OUTSIDE a group does
+    //! NOT move when the group is dragged. Unlike ``record_check_changed`` there is no event to wait
+    //! for, so the caller must settle the gesture first (``wait_for_mouse_idle``); this then compares
+    //! once. Accumulate-on-miss (surfaced as a teardown panic), mirroring ``record_check_changed``.
+    //! Returns true when the value is still ``before``.
+    var snap = snapshot(app)
+    let v = widget_payload_field(snap, target, field)
+    let now = v != null ? write_json(v) : ""
+    if (now == before) return true
+    g_record_failures |> push("record_check_unchanged({target}.{field}):\n  expected it to stay {before}\n  but the gesture moved it to {now}")
+    return false
+}
+
 def public record_check_rendered(app : ImguiApp; target : string; expected : bool; max_frames : int = 120) : bool {
     //! Recording-safe "did the gesture show/hide it" verifier: assert ``target``'s rendered-this-frame
     //! state (``widget_rendered``) equals ``expected`` within ``max_frames``. The robust signal for a

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -679,7 +679,11 @@ def public record_check_unchanged(app : ImguiApp; target : string; field : strin
     let v = widget_payload_field(snap, target, field)
     let now = v != null ? write_json(v) : ""
     if (now == before) return true
-    g_record_failures |> push("record_check_unchanged({target}.{field}):\n  expected it to stay {before}\n  but the gesture moved it to {now}")
+    // Compare on the raw "" sentinel, but render a missing field as <missing> in the
+    // diagnostic (matching record_check_changed), so an empty value reads unambiguously.
+    let now_disp = empty(now) ? "<missing>" : now
+    let before_disp = empty(before) ? "<missing>" : before
+    g_record_failures |> push("record_check_unchanged({target}.{field}):\n  expected it to stay {before_disp}\n  but the gesture moved it to {now_disp}")
     return false
 }
 

--- a/widgets/imgui_visual_aids.das
+++ b/widgets/imgui_visual_aids.das
@@ -592,6 +592,10 @@ def private glyph_for_imgui_key(kc : int) : string {
     if (kc == int(ImGuiKey.LeftCtrl)  || kc == int(ImGuiKey.RightCtrl)) return "Ctrl"
     if (kc == int(ImGuiKey.LeftAlt)   || kc == int(ImGuiKey.RightAlt)) return "Alt"
     if (kc == int(ImGuiKey.LeftSuper) || kc == int(ImGuiKey.RightSuper)) return "Cmd"
+    // Letter keys arrive as raw keycodes from a chord (no codepoint, unlike typing), so map
+    // them to their glyph here too - otherwise a Ctrl+D pops only the "Ctrl" keycap.
+    if (kc >= int(ImGuiKey.A) && kc <= int(ImGuiKey.Z))
+        return build_string() $(writer) { writer |> write_char('A' + (kc - int(ImGuiKey.A))) }
     return ""    // unknown — caller skips the trace
 }
 

--- a/widgets/imgui_visual_aids.das
+++ b/widgets/imgui_visual_aids.das
@@ -832,17 +832,19 @@ def imgui_cursor_sprite(input : JsonValue?) : JsonValue? {
 }
 
 struct KeyHudArgs {
-    @optional enabled         : bool = true
-    @optional show_modifiers  : bool = true
+    @optional enabled         : bool  = true
+    @optional show_modifiers  : bool  = true
+    @optional keycap_fade_s   : float = 0.7f   // how long each keycap lingers before fading out
 }
 
-[live_command(description="Toggle the keycap + modifier-strip HUD. Pops a keycap at bottom-center for every synth key event and lights up Ctrl/Shift/Alt/Cmd pills while held.")]
+[live_command(description="Toggle the keycap + modifier-strip HUD. Pops a keycap at bottom-center for every synth key event and lights up Ctrl/Shift/Alt/Cmd pills while held. keycap_fade_s sets how long each keycap lingers (default 0.7).")]
 def imgui_key_hud(input : JsonValue?) : JsonValue? {
-    //! ``[live_command]`` toggle for the bottom-center keycap HUD + Ctrl/Shift/Alt/Cmd modifier strip. Args: ``enabled``, ``show_modifiers``.
+    //! ``[live_command]`` toggle for the bottom-center keycap HUD + Ctrl/Shift/Alt/Cmd modifier strip. Args: ``enabled``, ``show_modifiers``, ``keycap_fade_s`` (seconds a keycap lingers - bump it so a chord stays readable while a voice line names it).
     let args = from_JV(input, type<KeyHudArgs>)
     key_hud_enabled = args.enabled
     key_hud_show_modifiers = args.show_modifiers
-    return JV((ok = true, enabled = args.enabled, show_modifiers = args.show_modifiers))
+    key_hud_keycap_fade_s = args.keycap_fade_s
+    return JV((ok = true, enabled = args.enabled, show_modifiers = args.show_modifiers, keycap_fade_s = args.keycap_fade_s))
 }
 
 struct FocusRectArgs {


### PR DESCRIPTION
Two recording-infrastructure additions for the node-editor tutorial sweep.

## 1. `record_check_unchanged` (mirror of `record_check_changed`)

The recording verifiers covered "the gesture changed it" / "showed/hid it" / "became X", but not the **negative** claim "the gesture left it alone". The node-editor `groups` tutorial needs it: a node **outside** a group must **not** move when the group is dragged — the whole point of spatial membership, and exactly the silent dud a self-verifying recording should catch (the legacy groups recording had zero verification and showed a static group).

```das
def public record_check_unchanged(app : ImguiApp; target : string; field : string; before : string) : bool
```

Asserts `target.payload[field]`'s JSON still equals `before` (captured before the gesture). No event to wait for, so the caller settles first (`wait_for_mouse_idle`) and this compares once; a mismatch accumulates into `g_record_failures` → teardown panic, like the other rails.

## 2. `keycap_fade_s` arg on `imgui_key_hud`

The keycap HUD popped for a fixed 0.7 s — too brief to read while a voice line names a chord ("Ctrl+D"). Holding the key isn't an option: imgui-node-editor detects shortcuts with `IsKeyPressed(repeat=true)`, so a held chord re-fires. So expose the linger on the command (the fade var lives in the app's render context, reachable only through the command). A recording bumps `keycap_fade_s` (e.g. 2.5) so `[Ctrl][D]` stays readable through the line. **Backward compatible:** defaults to 0.7 (the prior fixed value); older builds ignore the extra field via `from_JV`.

## Review

- **Copilot R1:** `record_check_unchanged` now renders a missing field as `<missing>` in its diagnostic (matching `record_check_changed`), keeping `""` only as the compare sentinel.
- Both new symbols grouped in `imgui2rst.das` (fixes the uncategorized-gate that failed the first build).

## Consumers

- `record_check_unchanged` → dasImguiNodeEditor #28 (groups).
- `keycap_fade_s` → dasImguiNodeEditor clipboard recording (gracefully degrades if this isn't merged yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)