### PR TITLE
imgui: bind imgui_internal.h ShadeVerts* family (#2)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -66,12 +66,12 @@ fi
 echo "pre-push: using $DASLANG"
 echo "pre-push: daslang source: $DASLANG_SRC"
 
-# Formatter: whole tree, verify-only (CI parity).
-echo "pre-push: formatter --verify ..."
-"$DASLANG" "$DASLANG_SRC/utils/das-fmt/dasfmt.das" -- --path "$ROOT" --verify
-
-# Lint: only .das files changed in the pushed range vs remote tip
-# (mirrors CI's `git diff origin/<base>...HEAD`).
+# Lint + format both run on only the .das files changed in the pushed range vs
+# remote tip (mirrors CI's `git diff origin/<base>...HEAD`). The formatter is
+# scoped to the changed set ON PURPOSE — a whole-tree `--path "$ROOT"` walk
+# follows junctions (e.g. a daspkg-install self-junction under the gitignored
+# modules/) and verifies gitignored build/ artifacts, bricking every push. CI
+# has no whole-tree format gate either; this keeps local in lockstep with it.
 ZERO40="0000000000000000000000000000000000000000"
 ZERO64="0000000000000000000000000000000000000000000000000000000000000000"
 RANGES=()
@@ -100,9 +100,15 @@ while IFS= read -r line; do
 done < <(git diff --name-only --diff-filter=AM "${RANGES[@]}" -- '*.das' | sort -u)
 
 if [ ${#CHANGED[@]} -eq 0 ]; then
-    echo "pre-push: no .das files changed; skipping lint"
+    echo "pre-push: no .das files changed; skipping lint + format"
     exit 0
 fi
+
+# Formatter: verify only the changed .das files (scoped, not whole-tree — see note above).
+echo "pre-push: formatter --verify (${#CHANGED[@]} changed .das) ..."
+FMT_ARGS=()
+for f in "${CHANGED[@]}"; do FMT_ARGS+=(--path "$f"); done
+"$DASLANG" "$DASLANG_SRC/utils/das-fmt/dasfmt.das" -- "${FMT_ARGS[@]}" --verify
 
 echo "pre-push: linting ${#CHANGED[@]} .das file(s)"
 # `-load_module $ROOT` lets the lint resolve `require imgui/*` for dasImgui's

--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -135,12 +135,18 @@ class ImguiGen : CppGenBind {
         // Family 1 — Render* draw helpers from imgui_internal.h. Every argument is
         // an already-bound public type (ImVec2, ImU32, ImDrawList*, ImGuiDir,
         // ImGuiMouseCursor, ImDrawFlags), so no internal struct/enum is pulled in.
+        //
+        // Family 2 — ShadeVerts* vertex-shading helpers. Same discipline: every arg
+        // is already bound (ImDrawList*, int, ImVec2, ImU32, float, bool), so no
+        // internal type is pulled in. They write over already-created draw vertices.
         internal_allow_func <- {
             "ImGui::RenderFrame", "ImGui::RenderFrameBorder",
             "ImGui::RenderText", "ImGui::RenderTextWrapped",
             "ImGui::RenderColorRectWithAlphaCheckerboard", "ImGui::RenderMouseCursor",
             "ImGui::RenderArrow", "ImGui::RenderBullet", "ImGui::RenderCheckMark",
-            "ImGui::RenderArrowPointingAt", "ImGui::RenderArrowDockMenu"
+            "ImGui::RenderArrowPointingAt", "ImGui::RenderArrowDockMenu",
+            "ImGui::ShadeVertsLinearColorGradientKeepAlpha", "ImGui::ShadeVertsLinearUV",
+            "ImGui::ShadeVertsTransformPos"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_render.das
+++ b/examples/features/internal_render.das
@@ -1,0 +1,89 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_render — exercises the imgui_internal.h Render* draw-helper
+//          family (#1, bound via bind_imgui.das internal_allow_func). Every
+//          helper writes straight into an ImDrawList with no ImGui state, so the
+//          example lays them out on the window drawlist and lets you eyeball
+//          that each one actually renders. This is the "binding is usable" gate
+//          for family #1 — it calls the real bound API, not just compiles it.
+// SHOWS:   RenderArrow (all four ImGuiDir), RenderBullet, RenderCheckMark,
+//          RenderArrowPointingAt, RenderColorRectWithAlphaCheckerboard,
+//          RenderFrame + RenderFrameBorder, RenderText.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_render.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_render.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_render.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("internal_render - imgui_internal.h Render* family", 760, 470)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    let white = rgba(235u, 235u, 245u, 255u)
+    let cyan  = rgba(80u, 200u, 230u, 255u)
+    let amber = rgba(240u, 190u, 70u, 255u)
+    let green = rgba(90u, 220u, 120u, 255u)
+
+    SetNextWindowSize(ImVec2(720.0, 430.0), ImGuiCond.Always)
+    window(RENDER_WIN, (text = "internal_render", closable = false,
+                        flags = ImGuiWindowFlags.None)) {
+        text("imgui_internal.h Render* helpers - each writes straight to a drawlist.")
+        separator()
+
+        let o = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            // RenderArrow - one per ImGuiDir, left to right.
+            RenderArrow(dl, ImVec2(o.x + 24.0, o.y + 28.0), white, ImGuiDir.Left, 1.0)
+            RenderArrow(dl, ImVec2(o.x + 64.0, o.y + 28.0), white, ImGuiDir.Right, 1.0)
+            RenderArrow(dl, ImVec2(o.x + 104.0, o.y + 28.0), white, ImGuiDir.Up, 1.0)
+            RenderArrow(dl, ImVec2(o.x + 144.0, o.y + 28.0), white, ImGuiDir.Down, 1.0)
+            // RenderBullet + RenderCheckMark.
+            RenderBullet(dl, ImVec2(o.x + 204.0, o.y + 38.0), cyan)
+            RenderCheckMark(dl, ImVec2(o.x + 232.0, o.y + 28.0), green, 13.0)
+            // RenderArrowPointingAt - arrowhead fitted into a half-size box.
+            RenderArrowPointingAt(dl, ImVec2(o.x + 304.0, o.y + 38.0),
+                                  ImVec2(8.0, 10.0), ImGuiDir.Right, amber)
+            // RenderColorRectWithAlphaCheckerboard - alpha-preview swatch.
+            RenderColorRectWithAlphaCheckerboard(dl,
+                ImVec2(o.x + 24.0, o.y + 70.0), ImVec2(o.x + 168.0, o.y + 150.0),
+                rgba(120u, 80u, 200u, 120u), 8.0, ImVec2(0.0, 0.0), 4.0, ImDrawFlags.None)
+        }
+
+        // RenderFrame / RenderFrameBorder / RenderText draw into the current
+        // window's drawlist implicitly (no ImDrawList argument).
+        RenderFrame(ImVec2(o.x + 200.0, o.y + 70.0), ImVec2(o.x + 380.0, o.y + 150.0),
+                    rgba(45u, 55u, 75u, 255u), true, 4.0)
+        RenderFrameBorder(ImVec2(o.x + 200.0, o.y + 70.0), ImVec2(o.x + 380.0, o.y + 150.0), 4.0)
+        RenderText(ImVec2(o.x + 214.0, o.y + 102.0), "RenderText + RenderFrame")
+
+        dummy(SPACER, ImVec2(700.0, 168.0))
+        separator()
+        text("Every draw above is imgui_internal.h Render* family #1.")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/internal_shade_verts.das
+++ b/examples/features/internal_shade_verts.das
@@ -1,0 +1,97 @@
+options gen2
+
+require imgui/imgui_harness
+require math
+
+// =============================================================================
+// FEATURE: internal_shade_verts — exercises the imgui_internal.h ShadeVerts*
+//          vertex-shading family (#2, bound via bind_imgui.das). Each helper
+//          rewrites vertices that were ALREADY emitted into the drawlist, over a
+//          [start, end) index range. The range comes from length(dl.VtxBuffer)
+//          read before and after the draw (the real VtxBuffer.Size; `length` is
+//          allow-listed in imgui_lint as a host-agnostic ImVector accessor).
+//          This is the "binding is usable" gate for family #2 — it calls the
+//          real bound API at runtime, not just compiles it.
+// SHOWS:   ShadeVertsLinearColorGradientKeepAlpha (recolor a quad to a gradient),
+//          ShadeVertsLinearUV (UV remap — binding exercised; visually a no-op
+//          without a custom texture), ShadeVertsTransformPos (rotate a triangle
+//          in place around its centroid).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_shade_verts.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_shade_verts.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_shade_verts.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("internal_shade_verts - imgui_internal.h ShadeVerts* family", 760, 470)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(720.0, 430.0), ImGuiCond.Always)
+    window(SHADE_WIN, (text = "internal_shade_verts", closable = false,
+                       flags = ImGuiWindowFlags.None)) {
+        text("imgui_internal.h ShadeVerts* helpers - rewrite already-emitted vertices.")
+        separator()
+
+        let o = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            // (1) Linear color gradient: emit a white quad, then recolor its
+            //     vertices left-to-right from blue to magenta.
+            let g0 = ImVec2(o.x + 20.0, o.y + 20.0)
+            let g1 = ImVec2(o.x + 250.0, o.y + 92.0)
+            let v0 = length(dl.VtxBuffer)
+            dl |> add_rect_filled(g0, g1, rgba(255u, 255u, 255u, 255u))
+            let v1 = length(dl.VtxBuffer)
+            ShadeVertsLinearColorGradientKeepAlpha(dl, v0, v1, g0, g1,
+                rgba(60u, 120u, 240u, 255u), rgba(230u, 70u, 200u, 255u))
+
+            // (2) Linear UV remap over a second quad. No custom texture is bound,
+            //     so this is visually a no-op, but it exercises the binding end to
+            //     end (range + four UV corners + clamp flag).
+            let u0 = ImVec2(o.x + 20.0, o.y + 112.0)
+            let u1 = ImVec2(o.x + 250.0, o.y + 184.0)
+            let w0 = length(dl.VtxBuffer)
+            dl |> add_rect_filled(u0, u1, rgba(90u, 200u, 140u, 255u))
+            let w1 = length(dl.VtxBuffer)
+            ShadeVertsLinearUV(dl, w0, w1, u0, u1, ImVec2(0.0, 0.0), ImVec2(1.0, 1.0), true)
+
+            // (3) Position transform: emit a triangle, then rotate its vertices
+            //     ~25 degrees in place around its centroid.
+            let c = ImVec2(o.x + 430.0, o.y + 100.0)
+            let t0 = length(dl.VtxBuffer)
+            dl |> add_triangle_filled(ImVec2(c.x, c.y - 52.0),
+                                      ImVec2(c.x + 48.0, c.y + 32.0),
+                                      ImVec2(c.x - 48.0, c.y + 32.0),
+                                      rgba(240u, 190u, 70u, 255u))
+            let t1 = length(dl.VtxBuffer)
+            let ang = 0.43         // ~25 degrees, in radians
+            ShadeVertsTransformPos(dl, t0, t1, c, cos(ang), sin(ang), c)
+        }
+
+        dummy(SPACER, ImVec2(700.0, 208.0))
+        separator()
+        text("Each shape's vertices were rewritten in place by a ShadeVerts* call.")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -52,6 +52,18 @@ void Module_dasIMGUI::initFunctions_30() {
 	makeExtern< void (*)(ImDrawList *,ImVec2,float,unsigned int) , ImGui::RenderArrowDockMenu , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowDockMenu","ImGui::RenderArrowDockMenu")
 		->args({"draw_list","p_min","sz","col"})
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3807:29
+	makeExtern< void (*)(ImDrawList *,int,int,ImVec2,ImVec2,unsigned int,unsigned int) , ImGui::ShadeVertsLinearColorGradientKeepAlpha , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearColorGradientKeepAlpha","ImGui::ShadeVertsLinearColorGradientKeepAlpha")
+		->args({"draw_list","vert_start_idx","vert_end_idx","gradient_p0","gradient_p1","col0","col1"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3808:29
+	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,const ImVec2 &,const ImVec2 &,const ImVec2 &,bool) , ImGui::ShadeVertsLinearUV , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearUV","ImGui::ShadeVertsLinearUV")
+		->args({"draw_list","vert_start_idx","vert_end_idx","a","b","uv_a","uv_b","clamp"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3809:29
+	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,float,float,const ImVec2 &) , ImGui::ShadeVertsTransformPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsTransformPos","ImGui::ShadeVertsTransformPos")
+		->args({"draw_list","vert_start_idx","vert_end_idx","pivot_in","cos_a","sin_a","pivot_out"})
+		->addToModule(*this, SideEffects::worstDefault);
 }
 }
 

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -62,6 +62,9 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Circle Tessellation preview tooltip to label each sample with its
     // auto-segment count.
     "_CalcCircleAutoSegmentCount",
+    // ImVector size accessor (read-only) — e.g. length(dl.VtxBuffer) gives the
+    // vertex-index range that the ShadeVerts* family (family 2) operates over.
+    "length",
     // Cursor / layout queries (read-only)
     "GetCursorPos", "GetCursorPosX", "GetCursorPosY",
     "GetCursorScreenPos", "GetCursorStartPos",

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -122,7 +122,12 @@ let private ALLOWED_IMGUI : table<string> <- {
     "RenderFrame", "RenderFrameBorder", "RenderText", "RenderTextWrapped",
     "RenderColorRectWithAlphaCheckerboard", "RenderMouseCursor",
     "RenderArrow", "RenderBullet", "RenderCheckMark",
-    "RenderArrowPointingAt", "RenderArrowDockMenu"
+    "RenderArrowPointingAt", "RenderArrowDockMenu",
+    // Vertex-shading draw helpers cherry-picked from imgui_internal.h (family 2).
+    // Write over already-created ImDrawList vertices — host-agnostic, no v2 state.
+    // Bound via bind_imgui.das internal_allow_func.
+    "ShadeVertsLinearColorGradientKeepAlpha", "ShadeVertsLinearUV",
+    "ShadeVertsTransformPos"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
Family 2 of the curated `imgui_internal.h` surface, following family 1 (Render\* draw helpers, #163).

## What

The three `ShadeVerts*` vertex-shading helpers — they write over already-created `ImDrawList` vertices and don't touch any ImGui state:

| Function | Args (all already-bound public types) |
|---|---|
| `ShadeVertsLinearColorGradientKeepAlpha` | `ImDrawList*, int, int, ImVec2, ImVec2, ImU32, ImU32` |
| `ShadeVertsLinearUV` | `ImDrawList*, int, int, ImVec2, ImVec2, ImVec2, ImVec2, bool` |
| `ShadeVertsTransformPos` | `ImDrawList*, int, int, ImVec2, float, float, ImVec2` |

## Discipline

Same rule as family 1: **every argument resolves to an already-bound public type** (`ImDrawList*, int, ImVec2, ImU32, float, bool`), so no internal struct or enum is pulled into the surface. Added to `internal_allow_func` in `bind/bind_imgui.das` and to `ALLOWED_IMGUI` in `widgets/imgui_lint.das`.

## Regen delta

Exactly the three `makeExtern<>` registrations appended to `src/dasIMGUI.func_30.cpp` (+12) — no other generated file changed (the `initFunctions_30` chunk dispatcher already exists from family 1, so registration is inline).

## Verification

- Regen produced the minimal additive delta only (func_30.cpp +12).
- `dasModuleImgui` rebuilt clean.
- The three functions resolve and type-check from `.das` against the rebuilt module (smoke compile-check).
- `bind_imgui.das` + `imgui_lint.das` lint and format clean.

Purely additive — no existing binding touched — so the example/test surface (imgui_demo et al.) is covered by the integration CI here rather than a local full-host-stack compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)