### PR TITLE
imgui: bind PushItemFlag/PopItemFlag (family #3) + with_item_flag guard

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -139,6 +139,11 @@ class ImguiGen : CppGenBind {
         // Family 2 — ShadeVerts* vertex-shading helpers. Same discipline: every arg
         // is already bound (ImDrawList*, int, ImVec2, ImU32, float, bool), so no
         // internal type is pulled in. They write over already-created draw vertices.
+        //
+        // Family 3 — PushItemFlag/PopItemFlag item-flag stack. First family pulling
+        // an internal enum (ImGuiItemFlags_) into internal_allow_enum; v2 surface is
+        // the with_item_flag scope guard (imgui_scope_builtin.das), mirroring
+        // with_disabled — a push/pop pair, not a raw allow-list call.
         internal_allow_func <- {
             "ImGui::RenderFrame", "ImGui::RenderFrameBorder",
             "ImGui::RenderText", "ImGui::RenderTextWrapped",
@@ -146,7 +151,11 @@ class ImguiGen : CppGenBind {
             "ImGui::RenderArrow", "ImGui::RenderBullet", "ImGui::RenderCheckMark",
             "ImGui::RenderArrowPointingAt", "ImGui::RenderArrowDockMenu",
             "ImGui::ShadeVertsLinearColorGradientKeepAlpha", "ImGui::ShadeVertsLinearUV",
-            "ImGui::ShadeVertsTransformPos"
+            "ImGui::ShadeVertsTransformPos",
+            "ImGui::PushItemFlag", "ImGui::PopItemFlag"
+        }
+        internal_allow_enum <- {
+            "ImGuiItemFlags_"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_item_flag.das
+++ b/examples/features/internal_item_flag.das
@@ -1,0 +1,85 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_item_flag — exercises the imgui_internal.h item-flag stack
+//          (PushItemFlag/PopItemFlag, family #3) through the with_item_flag scope
+//          guard. ImGuiItemFlags is the FIRST internal enum pulled into the v2
+//          binding (bind_imgui.das internal_allow_enum). with_item_flag covers the
+//          flags WITHOUT a dedicated public guard — Disabled / ButtonRepeat /
+//          NoTabStop already have with_disabled / with_button_repeat / with_tab_stop.
+//          This is the "binding is usable" gate for family #3 — it calls the real
+//          bound API at runtime, not just compiles it.
+// SHOWS:   MixedValue (checkbox drawn as an indeterminate dash), ReadOnly (slider
+//          highlights but ignores drags), AllowOverlap (a wide button yields hover
+//          to a small button placed on top of it).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_item_flag.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_item_flag.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_item_flag.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("internal_item_flag - imgui_internal.h PushItemFlag/PopItemFlag family", 720, 460)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(680.0, 420.0), ImGuiCond.Always)
+    window(ITEM_FLAG_WIN, (text = "internal_item_flag", closable = false,
+                           flags = ImGuiWindowFlags.None)) {
+        text("with_item_flag wraps PushItemFlag/PopItemFlag for internal item flags")
+        text("that have no dedicated public guard.")
+        separator()
+
+        // MixedValue — the checkbox draws as an indeterminate dash regardless of
+        // its real checked state (the classic tri-state look).
+        text("MixedValue:")
+        checkbox(CB_NORMAL, (text = "plain checkbox"))
+        with_item_flag(ImGuiItemFlags.MixedValue, true) {
+            checkbox(CB_MIXED, (text = "same checkbox, drawn as a dash"))
+        }
+        separator()
+
+        // ReadOnly — the slider still hovers/highlights, but its value never moves
+        // when dragged.
+        text("ReadOnly:")
+        slider_float(SL_RW, (text = "editable"))
+        with_item_flag(ImGuiItemFlags.ReadOnly, true) {
+            slider_float(SL_RO, (text = "read-only (drag does nothing)"))
+        }
+        separator()
+
+        // AllowOverlap — the wide button yields hover to a later widget drawn over
+        // it; without the flag the wide button would swallow the overlap.
+        text("AllowOverlap: the small button sits on top of the wide one.")
+        let p = GetCursorScreenPos()
+        with_item_flag(ImGuiItemFlags.AllowOverlap, true) {
+            button(OVL_UNDER, (text = "wide button underneath", size = float2(300.0, 36.0)))
+        }
+        SetCursorScreenPos(p)
+        small_button(OVL_OVER, (text = "on top"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -37,6 +37,7 @@ addEnumeration(new Enumeration_ImDrawFlags_());
 addEnumeration(new Enumeration_ImDrawListFlags_());
 addEnumeration(new Enumeration_ImFontAtlasFlags_());
 addEnumeration(new Enumeration_ImGuiViewportFlags_());
+addEnumeration(new Enumeration_ImGuiItemFlags_());
 addEnumFlagOps<ImGuiWindowFlags_>(*this,lib,"ImGuiWindowFlags_");
 addEnumFlagOps<ImGuiChildFlags_>(*this,lib,"ImGuiChildFlags_");
 addEnumFlagOps<ImGuiInputTextFlags_>(*this,lib,"ImGuiInputTextFlags_");

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1010,3 +1010,26 @@ public:
 	}
 };
 
+// from imgui_internal.h:823:6
+class Enumeration_ImGuiItemFlags_ : public das::Enumeration {
+public:
+	Enumeration_ImGuiItemFlags_() : das::Enumeration("ImGuiItemFlags") {
+		external = true;
+		cppName = "ImGuiItemFlags_";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("None", "ImGuiItemFlags_None", int64_t(ImGuiItemFlags_::ImGuiItemFlags_None), das::LineInfo());
+		addIEx("NoTabStop", "ImGuiItemFlags_NoTabStop", int64_t(ImGuiItemFlags_::ImGuiItemFlags_NoTabStop), das::LineInfo());
+		addIEx("ButtonRepeat", "ImGuiItemFlags_ButtonRepeat", int64_t(ImGuiItemFlags_::ImGuiItemFlags_ButtonRepeat), das::LineInfo());
+		addIEx("Disabled", "ImGuiItemFlags_Disabled", int64_t(ImGuiItemFlags_::ImGuiItemFlags_Disabled), das::LineInfo());
+		addIEx("NoNav", "ImGuiItemFlags_NoNav", int64_t(ImGuiItemFlags_::ImGuiItemFlags_NoNav), das::LineInfo());
+		addIEx("NoNavDefaultFocus", "ImGuiItemFlags_NoNavDefaultFocus", int64_t(ImGuiItemFlags_::ImGuiItemFlags_NoNavDefaultFocus), das::LineInfo());
+		addIEx("SelectableDontClosePopup", "ImGuiItemFlags_SelectableDontClosePopup", int64_t(ImGuiItemFlags_::ImGuiItemFlags_SelectableDontClosePopup), das::LineInfo());
+		addIEx("MixedValue", "ImGuiItemFlags_MixedValue", int64_t(ImGuiItemFlags_::ImGuiItemFlags_MixedValue), das::LineInfo());
+		addIEx("ReadOnly", "ImGuiItemFlags_ReadOnly", int64_t(ImGuiItemFlags_::ImGuiItemFlags_ReadOnly), das::LineInfo());
+		addIEx("NoWindowHoverableCheck", "ImGuiItemFlags_NoWindowHoverableCheck", int64_t(ImGuiItemFlags_::ImGuiItemFlags_NoWindowHoverableCheck), das::LineInfo());
+		addIEx("AllowOverlap", "ImGuiItemFlags_AllowOverlap", int64_t(ImGuiItemFlags_::ImGuiItemFlags_AllowOverlap), das::LineInfo());
+		addIEx("Inputable", "ImGuiItemFlags_Inputable", int64_t(ImGuiItemFlags_::ImGuiItemFlags_Inputable), das::LineInfo());
+		addIEx("HasSelectionUserData", "ImGuiItemFlags_HasSelectionUserData", int64_t(ImGuiItemFlags_::ImGuiItemFlags_HasSelectionUserData), das::LineInfo());
+	}
+};
+

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -38,3 +38,4 @@ DAS_BIND_ENUM_CAST(ImDrawFlags_);
 DAS_BIND_ENUM_CAST(ImDrawListFlags_);
 DAS_BIND_ENUM_CAST(ImFontAtlasFlags_);
 DAS_BIND_ENUM_CAST(ImGuiViewportFlags_);
+DAS_BIND_ENUM_CAST(ImGuiItemFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -73,3 +73,5 @@ DAS_BASE_BIND_ENUM_GEN(ImFontAtlasFlags_,ImFontAtlasFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiViewportFlags_,ImGuiViewportFlags);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiItemFlags_,ImGuiItemFlags);
+

--- a/src/dasIMGUI.func_29.cpp
+++ b/src/dasIMGUI.func_29.cpp
@@ -86,21 +86,18 @@ void Module_dasIMGUI::initFunctions_29() {
 	addCtorAndUsing<ImGuiPlatformIO>(*this,lib,"ImGuiPlatformIO","ImGuiPlatformIO");
 	addCtorAndUsing<ImGuiPlatformMonitor>(*this,lib,"ImGuiPlatformMonitor","ImGuiPlatformMonitor");
 	addCtorAndUsing<ImGuiPlatformImeData>(*this,lib,"ImGuiPlatformImeData","ImGuiPlatformImeData");
+// from imgui_internal.h:3396:29
+	makeExtern< void (*)(int,bool) , ImGui::PushItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushItemFlag","ImGui::PushItemFlag")
+		->args({"option","enabled"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3397:29
+	makeExtern< void (*)() , ImGui::PopItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopItemFlag","ImGui::PopItemFlag")
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3719:29
 	makeExtern< void (*)(ImVec2,const char *,const char *,bool) , ImGui::RenderText , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderText","ImGui::RenderText")
 		->args({"pos","text","text_end","hide_text_after_hash"})
 		->arg_init(2,new ExprConstString(""))
 		->arg_init(3,new ExprConstBool(true))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3720:29
-	makeExtern< void (*)(ImVec2,const char *,const char *,float) , ImGui::RenderTextWrapped , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderTextWrapped","ImGui::RenderTextWrapped")
-		->args({"pos","text","text_end","wrap_width"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3724:29
-	makeExtern< void (*)(ImVec2,ImVec2,unsigned int,bool,float) , ImGui::RenderFrame , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrame","ImGui::RenderFrame")
-		->args({"p_min","p_max","fill_col","border","rounding"})
-		->arg_init(3,new ExprConstBool(true))
-		->arg_init(4,new ExprConstFloat(0))
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -12,6 +12,16 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_30() {
+// from imgui_internal.h:3720:29
+	makeExtern< void (*)(ImVec2,const char *,const char *,float) , ImGui::RenderTextWrapped , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderTextWrapped","ImGui::RenderTextWrapped")
+		->args({"pos","text","text_end","wrap_width"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3724:29
+	makeExtern< void (*)(ImVec2,ImVec2,unsigned int,bool,float) , ImGui::RenderFrame , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrame","ImGui::RenderFrame")
+		->args({"p_min","p_max","fill_col","border","rounding"})
+		->arg_init(3,new ExprConstBool(true))
+		->arg_init(4,new ExprConstFloat(0))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3725:29
 	makeExtern< void (*)(ImVec2,ImVec2,float) , ImGui::RenderFrameBorder , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrameBorder","ImGui::RenderFrameBorder")
 		->args({"p_min","p_max","rounding"})

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -72,3 +72,11 @@ def public with_tab_stop(tab_stop : bool; blk : block) {
     invoke(blk)
     PopTabStop()
 }
+
+def public with_item_flag(flag : ImGuiItemFlags; enabled : bool; blk : block) {
+    //! Run ``blk`` with ``PushItemFlag(flag, enabled)`` applied; matching ``PopItemFlag()`` on return.
+    //! For internal item flags lacking a dedicated guard (``AllowOverlap``, ``NoNav``, ``MixedValue``, ``ReadOnly``).
+    PushItemFlag(int(flag), enabled)
+    invoke(blk)
+    PopItemFlag()
+}


### PR DESCRIPTION
Third `imgui_internal.h` family on the one-family-per-PR rail: the **item-flag stack** (`PushItemFlag`/`PopItemFlag`).

### What's new
- **First internal enum** pulled into the curated binding — `ImGuiItemFlags` via `internal_allow_enum` in `bind/bind_imgui.das` (all 13 values: `None`…`HasSelectionUserData`).
- **`with_item_flag(flag, enabled) { ... }`** scope guard in `widgets/imgui_scope_builtin.das`.
- **`examples/features/internal_item_flag.das`** — proves the binding is usable at runtime.

### Why a scope guard, not a raw allow-list entry
Families 1–2 (`Render*`, `ShadeVerts*`) are one-shot draw calls, so they're exposed raw on `ALLOWED_IMGUI`. This family is a **push/pop pair**, so the v2 surface is a scope guard — exactly mirroring the existing `with_disabled` (which wraps the public `BeginDisabled`/`EndDisabled`). Consequently **no `ALLOWED_IMGUI` change is needed**: the wrapper module is never linted as root, same as the existing `BeginDisabled` / `PushItemWidth` / `PushFont` / … raw calls already living in `imgui_scope_builtin.das`.

`with_item_flag` covers the item flags **without** a dedicated public guard (`AllowOverlap`, `NoNav`, `MixedValue`, `ReadOnly`, …). `Disabled` / `ButtonRepeat` / `NoTabStop` keep their existing `with_disabled` / `with_button_repeat` / `with_tab_stop`.

### Verification
- Regen delta is additive: +1 enum (`ImGuiItemFlags`) + 2 `makeExtern` (`PushItemFlag`/`PopItemFlag`); the `func_29`→`func_30` churn is benign 20-per-chunk repacking (nothing dropped).
- `internal_item_flag.das` runs **headless clean (exit 0)** and windowed — MixedValue checkbox renders as an indeterminate dash, ReadOnly slider ignores drags, AllowOverlap lets a small button sit on a wide one.
- `format_file` clean, `lint` clean on all 3 `.das` files; pre-push hook green.

### Follow-up for a future binder rail (not in this PR)
Internal flag-typedefs don't auto-alias the way public ones do (`alias2type` only covers public `typedef int Foo;` → `enum Foo_`). So:
1. `PushItemFlag`'s `option` arg binds as `int`, not `ImGuiItemFlags` (the guard casts `int(flag)`).
2. `ImGuiItemFlags` gets `addEnumeration` but no `addEnumFlagOps` (no bitwise `|`/`&`).

Both are the same missing rail — teaching the binder the internal typedef→enum alias — and are forward-compatible with this guard's signature. Worth a dedicated follow-up if/when an internal family needs OR-combined flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)