### PR TITLE
imgui: bind imgui_internal.h layout-geometry calculators (family #4)

### DIFF
--- a/.das_module
+++ b/.das_module
@@ -35,6 +35,9 @@ def initialize(project_path : string) {
     register_native_path("imgui", "imgui_style_builtin", "{project_path}/widgets/imgui_style_builtin.das")
     // daslang.io drop-in theme — apply_daslang_theme(GetStyle()) on init.
     register_native_path("imgui", "imgui_theme_daslang", "{project_path}/widgets/imgui_theme_daslang.das")
+    // Flag-operator extensions (| / & / ~) for internal imgui enums the binder gave
+    // no addEnumFlagOps — currently ImGuiItemFlags. Re-exported by imgui_scope_builtin.
+    register_native_path("imgui", "imgui_enums", "{project_path}/widgets/imgui_enums.das")
     // §4.9 — stateless scope wrappers (with_indent, with_item_width, with_text_wrap_pos).
     register_native_path("imgui", "imgui_scope_builtin", "{project_path}/widgets/imgui_scope_builtin.das")
     // §4.6 — layout helpers (split_h, split_v, dock_left).

--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -68,7 +68,11 @@ class ImguiGen : CppGenBind {
         aot_alias <- {
             "ImVec2"    =>  true,
             "ImVec4"    =>  true,
-            "ImColor"   =>  true
+            "ImColor"   =>  true,
+            // ImRect (imgui_internal.h) is { ImVec2 Min; ImVec2 Max } — 4 floats,
+            // aliased to float4 like ImVec4 (glue in src/cb_dasIMGUI.h /
+            // aot_dasIMGUI.h). Lets internal rect-taking helpers bind directly.
+            "ImRect"    =>  true
         }
         alias2type <- {
             "ImGuiCol"                  => "ImGuiCol_",
@@ -145,13 +149,13 @@ class ImguiGen : CppGenBind {
         // the with_item_flag scope guard (imgui_scope_builtin.das), mirroring
         // with_disabled — a push/pop pair, not a raw allow-list call.
         //
-        // Family 4 — layout-geometry calculators (CalcItemSize / CalcWrapWidthForPos /
-        // GetContentRegionMaxAbs). Pure, side-effect-free geometry math that custom-
-        // widget code uses to size/position items the same way the built-in widgets
-        // do. Every arg/result is an already-bound public type (ImVec2, float), so no
-        // internal struct/enum is pulled in; one-shot calls, so they go raw on the
-        // ALLOWED_IMGUI allow-list (no scope guard). ItemSize is deliberately NOT
-        // here: it carries an inline ImRect overload that the arg gate would not skip.
+        // Family 4 — item / layout helpers (CalcItemSize / CalcWrapWidthForPos /
+        // GetContentRegionMaxAbs / ItemSize). Side-effect-free geometry math plus
+        // ItemSize (reserve layout space for a custom-drawn item, the way built-in
+        // widgets do). The three calculators are pure (ImVec2/float in/out). ItemSize
+        // carries an inline ImRect overload; ImRect is now aliased to float4 (added
+        // to aot_alias above + glue in cb_dasIMGUI.h), so BOTH overloads bind cleanly.
+        // One-shot calls, raw on the ALLOWED_IMGUI allow-list (no scope guard).
         internal_allow_func <- {
             "ImGui::RenderFrame", "ImGui::RenderFrameBorder",
             "ImGui::RenderText", "ImGui::RenderTextWrapped",
@@ -162,7 +166,7 @@ class ImguiGen : CppGenBind {
             "ImGui::ShadeVertsTransformPos",
             "ImGui::PushItemFlag", "ImGui::PopItemFlag",
             "ImGui::CalcItemSize", "ImGui::CalcWrapWidthForPos",
-            "ImGui::GetContentRegionMaxAbs"
+            "ImGui::GetContentRegionMaxAbs", "ImGui::ItemSize"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_"

--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -150,11 +150,11 @@ class ImguiGen : CppGenBind {
         // with_disabled — a push/pop pair, not a raw allow-list call.
         //
         // Family 4 — item / layout helpers (CalcItemSize / CalcWrapWidthForPos /
-        // GetContentRegionMaxAbs / ItemSize). Side-effect-free geometry math plus
-        // ItemSize (reserve layout space for a custom-drawn item, the way built-in
-        // widgets do). The three calculators are pure (ImVec2/float in/out). ItemSize
-        // carries an inline ImRect overload; ImRect is now aliased to float4 (added
-        // to aot_alias above + glue in cb_dasIMGUI.h), so BOTH overloads bind cleanly.
+        // GetContentRegionMaxAbs / ItemSize). The three calculators are pure geometry
+        // math (ImVec2/float in/out); ItemSize is NOT side-effect-free — it reserves
+        // layout space (advances the cursor) the way built-in widgets do. ItemSize also
+        // carries an inline ImRect overload; ImRect is now aliased to float4 (added to
+        // aot_alias above + glue in cb_dasIMGUI.h), so BOTH overloads bind cleanly.
         // One-shot calls, raw on the ALLOWED_IMGUI allow-list (no scope guard).
         internal_allow_func <- {
             "ImGui::RenderFrame", "ImGui::RenderFrameBorder",

--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -144,6 +144,14 @@ class ImguiGen : CppGenBind {
         // an internal enum (ImGuiItemFlags_) into internal_allow_enum; v2 surface is
         // the with_item_flag scope guard (imgui_scope_builtin.das), mirroring
         // with_disabled — a push/pop pair, not a raw allow-list call.
+        //
+        // Family 4 — layout-geometry calculators (CalcItemSize / CalcWrapWidthForPos /
+        // GetContentRegionMaxAbs). Pure, side-effect-free geometry math that custom-
+        // widget code uses to size/position items the same way the built-in widgets
+        // do. Every arg/result is an already-bound public type (ImVec2, float), so no
+        // internal struct/enum is pulled in; one-shot calls, so they go raw on the
+        // ALLOWED_IMGUI allow-list (no scope guard). ItemSize is deliberately NOT
+        // here: it carries an inline ImRect overload that the arg gate would not skip.
         internal_allow_func <- {
             "ImGui::RenderFrame", "ImGui::RenderFrameBorder",
             "ImGui::RenderText", "ImGui::RenderTextWrapped",
@@ -152,7 +160,9 @@ class ImguiGen : CppGenBind {
             "ImGui::RenderArrowPointingAt", "ImGui::RenderArrowDockMenu",
             "ImGui::ShadeVertsLinearColorGradientKeepAlpha", "ImGui::ShadeVertsLinearUV",
             "ImGui::ShadeVertsTransformPos",
-            "ImGui::PushItemFlag", "ImGui::PopItemFlag"
+            "ImGui::PushItemFlag", "ImGui::PopItemFlag",
+            "ImGui::CalcItemSize", "ImGui::CalcWrapWidthForPos",
+            "ImGui::GetContentRegionMaxAbs"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_"

--- a/examples/features/internal_item_flag.das
+++ b/examples/features/internal_item_flag.das
@@ -11,9 +11,11 @@ require imgui/imgui_harness
 //          NoTabStop already have with_disabled / with_button_repeat / with_tab_stop.
 //          This is the "binding is usable" gate for family #3 — it calls the real
 //          bound API at runtime, not just compiles it.
-// SHOWS:   MixedValue (checkbox drawn as an indeterminate dash), ReadOnly (slider
-//          highlights but ignores drags), AllowOverlap (a wide button yields hover
-//          to a small button placed on top of it).
+// SHOWS:   MixedValue (checkbox drawn as an indeterminate dash), ReadOnly | NoNav
+//          (slider ignores drags + is skipped by nav — two flags combined with the
+//          | operator from imgui_enums, since ImGuiItemFlags is an internal enum the
+//          binder gave no flag-ops), AllowOverlap (a wide button yields hover to a
+//          small button placed on top of it).
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_item_flag.das
 // HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_item_flag.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/internal_item_flag.das
@@ -47,12 +49,14 @@ def update() {
         }
         separator()
 
-        // ReadOnly — the slider still hovers/highlights, but its value never moves
-        // when dragged.
-        text("ReadOnly:")
+        // ReadOnly | NoNav — two flags combined into one push via the | operator
+        // (imgui_enums). ReadOnly freezes the value on drag; NoNav skips the slider
+        // in keyboard/gamepad navigation. ImGuiItemFlags is an internal enum, so its
+        // bitwise | comes from imgui_enums, not the binder's addEnumFlagOps.
+        text("ReadOnly | NoNav (flags combined with the | operator):")
         slider_float(SL_RW, (text = "editable"))
-        with_item_flag(ImGuiItemFlags.ReadOnly, true) {
-            slider_float(SL_RO, (text = "read-only (drag does nothing)"))
+        with_item_flag(ImGuiItemFlags.ReadOnly | ImGuiItemFlags.NoNav, true) {
+            slider_float(SL_RO, (text = "read-only (drag does nothing), skipped by nav"))
         }
         separator()
 

--- a/examples/features/internal_layout_calc.das
+++ b/examples/features/internal_layout_calc.das
@@ -3,20 +3,21 @@ options gen2
 require imgui/imgui_harness
 
 // =============================================================================
-// FEATURE: internal_layout_calc — exercises the imgui_internal.h layout-geometry
-//          calculator family (#4, bound via bind_imgui.das internal_allow_func).
-//          These are pure, side-effect-free helpers that custom-widget code uses
-//          to size and position items the same way the built-in widgets do. Every
-//          argument and result is an already-bound public type (ImVec2, float), so
-//          no internal struct/enum is pulled in; they are one-shot calls and sit
-//          raw on the ALLOWED_IMGUI allow-list (like families 1-2), not behind a
-//          scope guard. This is the "binding is usable" gate for family #4 — it
+// FEATURE: internal_layout_calc — exercises the imgui_internal.h item / layout
+//          helper family (#4, bound via bind_imgui.das internal_allow_func). These
+//          help custom-widget code size and position items the same way the built-in
+//          widgets do. Args/results are already-bound public types (ImVec2, float);
+//          ItemSize's rect overload takes ImRect, now aliased to float4 (glue in
+//          cb_dasIMGUI.h), so no internal struct is pulled in as a real type. One-shot
+//          calls, raw on the ALLOWED_IMGUI allow-list (like families 1-2), not behind
+//          a scope guard. This is the "binding is usable" gate for family #4 — it
 //          calls the real bound API at runtime, not just compiles it.
 // SHOWS:   CalcItemSize (resolve a requested size against defaults — three cases
 //          drawn at their resolved pixel size), CalcWrapWidthForPos (the wrap
-//          width behind PushTextWrapPos, drawn as a measured span), and
+//          width behind PushTextWrapPos, drawn as a measured span),
 //          GetContentRegionMaxAbs (the content region's absolute far corner,
-//          marked with a crosshair).
+//          marked with a crosshair), and ItemSize (reserve layout space for a
+//          custom-drawn box so the next widget flows directly below it).
 // STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_layout_calc.das
 // HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_layout_calc.das -- --headless --headless-frames=60
 // LIVE:       daslang-live modules/dasImgui/examples/features/internal_layout_calc.das
@@ -24,7 +25,7 @@ require imgui/imgui_harness
 
 [export]
 def init() {
-    harness_init("internal_layout_calc - imgui_internal.h layout calculators", 760, 600)
+    harness_init("internal_layout_calc - imgui_internal.h layout helpers", 760, 690)
     var io & = unsafe(GetIO())
     io.FontGlobalScale = 1.25
 }
@@ -40,7 +41,7 @@ def update() {
     let span  = rgba(90u, 220u, 130u, 255u)
     let mark  = rgba(240u, 180u, 70u, 255u)
 
-    SetNextWindowSize(ImVec2(720.0, 560.0), ImGuiCond.Always)
+    SetNextWindowSize(ImVec2(720.0, 650.0), ImGuiCond.Always)
     window(LAYOUT_WIN, (text = "internal_layout_calc", closable = false,
                         flags = ImGuiWindowFlags.None)) {
         text("imgui_internal.h layout-geometry calculators - pure sizing/position math.")
@@ -104,7 +105,23 @@ def update() {
         }
         dummy(SPACER3, ImVec2(700.0, 64.0))
         separator()
-        text("All three readouts come from imgui_internal.h layout calculators (family #4).")
+
+        // ItemSize - reserve layout space for a custom-drawn item (advances the
+        // cursor without registering an item, unlike dummy). The text below flows
+        // directly under the reserved box.
+        text("ItemSize reserves layout space for a custom-drawn box:")
+        let o4 = GetCursorScreenPos()
+        let box = ImVec2(300.0, 34.0)
+        with_window_drawlist() $(var dl) {
+            dl |> add_rect_filled(ImVec2(o4.x, o4.y), ImVec2(o4.x + box.x, o4.y + box.y), fill)
+            dl |> add_rect(ImVec2(o4.x, o4.y), ImVec2(o4.x + box.x, o4.y + box.y), edge,
+                           0.0, ImDrawFlags.None, 2.0)
+            dl |> add_text(ImVec2(o4.x + 8.0, o4.y + 9.0), ink, "custom box - footprint reserved by ItemSize")
+        }
+        ItemSize(box)
+        text("this line flows directly below the ItemSize-reserved box.")
+        separator()
+        text("All four readouts come from imgui_internal.h item/layout helpers (family #4).")
     }
 
     harness_end_frame()

--- a/examples/features/internal_layout_calc.das
+++ b/examples/features/internal_layout_calc.das
@@ -1,0 +1,125 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_layout_calc — exercises the imgui_internal.h layout-geometry
+//          calculator family (#4, bound via bind_imgui.das internal_allow_func).
+//          These are pure, side-effect-free helpers that custom-widget code uses
+//          to size and position items the same way the built-in widgets do. Every
+//          argument and result is an already-bound public type (ImVec2, float), so
+//          no internal struct/enum is pulled in; they are one-shot calls and sit
+//          raw on the ALLOWED_IMGUI allow-list (like families 1-2), not behind a
+//          scope guard. This is the "binding is usable" gate for family #4 — it
+//          calls the real bound API at runtime, not just compiles it.
+// SHOWS:   CalcItemSize (resolve a requested size against defaults — three cases
+//          drawn at their resolved pixel size), CalcWrapWidthForPos (the wrap
+//          width behind PushTextWrapPos, drawn as a measured span), and
+//          GetContentRegionMaxAbs (the content region's absolute far corner,
+//          marked with a crosshair).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_layout_calc.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_layout_calc.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_layout_calc.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("internal_layout_calc - imgui_internal.h layout calculators", 760, 600)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    let ink   = rgba(232u, 232u, 240u, 255u)
+    let fill  = rgba(48u, 96u, 168u, 220u)
+    let edge  = rgba(120u, 180u, 240u, 255u)
+    let span  = rgba(90u, 220u, 130u, 255u)
+    let mark  = rgba(240u, 180u, 70u, 255u)
+
+    SetNextWindowSize(ImVec2(720.0, 560.0), ImGuiCond.Always)
+    window(LAYOUT_WIN, (text = "internal_layout_calc", closable = false,
+                        flags = ImGuiWindowFlags.None)) {
+        text("imgui_internal.h layout-geometry calculators - pure sizing/position math.")
+        separator()
+
+        // CalcItemSize - resolve a requested size against (default_w, default_h).
+        // A zero component means "use the default"; the rect drawn is the result.
+        text("CalcItemSize(size, default_w=220, default_h=40): a zero picks the default.")
+        let dW = 220.0
+        let dH = 40.0
+        let o1 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            var x = o1.x + 12.0
+            let y = o1.y + 8.0
+            let a = CalcItemSize(ImVec2(0.0, 0.0), dW, dH)       // both default
+            dl |> add_rect_filled(ImVec2(x, y), ImVec2(x + a.x, y + a.y), fill)
+            dl |> add_rect(ImVec2(x, y), ImVec2(x + a.x, y + a.y), edge, 0.0, ImDrawFlags.None, 2.0)
+            dl |> add_text(ImVec2(x + 8.0, y + 12.0), ink, "(0,0) -> {int(a.x)}x{int(a.y)}")
+            x += a.x + 22.0
+            let b = CalcItemSize(ImVec2(120.0, 0.0), dW, dH)     // explicit width
+            dl |> add_rect_filled(ImVec2(x, y), ImVec2(x + b.x, y + b.y), fill)
+            dl |> add_rect(ImVec2(x, y), ImVec2(x + b.x, y + b.y), edge, 0.0, ImDrawFlags.None, 2.0)
+            dl |> add_text(ImVec2(x + 8.0, y + 12.0), ink, "(120,0) -> {int(b.x)}x{int(b.y)}")
+            x += b.x + 22.0
+            let c = CalcItemSize(ImVec2(0.0, 70.0), dW, dH)      // explicit height
+            dl |> add_rect_filled(ImVec2(x, y), ImVec2(x + c.x, y + c.y), fill)
+            dl |> add_rect(ImVec2(x, y), ImVec2(x + c.x, y + c.y), edge, 0.0, ImDrawFlags.None, 2.0)
+            dl |> add_text(ImVec2(x + 8.0, y + 12.0), ink, "(0,70) -> {int(c.x)}x{int(c.y)}")
+        }
+        dummy(SPACER1, ImVec2(700.0, 92.0))
+        separator()
+
+        // CalcWrapWidthForPos - wrap width from a position to the content's right
+        // edge (wrap_pos_x=0). Drawn as a measured span with end caps.
+        text("CalcWrapWidthForPos(pos, wrap_pos_x=0): width from pos to the content edge.")
+        let o2 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            let px = o2.x + 12.0
+            let py = o2.y + 26.0
+            let w = CalcWrapWidthForPos(ImVec2(px, py), 0.0)
+            dl |> add_line(ImVec2(px, py), ImVec2(px + w, py), span, 2.0)
+            dl |> add_line(ImVec2(px, py - 8.0), ImVec2(px, py + 8.0), span, 2.0)
+            dl |> add_line(ImVec2(px + w, py - 8.0), ImVec2(px + w, py + 8.0), span, 2.0)
+            dl |> add_text(ImVec2(px + 8.0, py - 22.0), ink, "wrap width = {int(w)} px")
+        }
+        dummy(SPACER2, ImVec2(700.0, 56.0))
+        separator()
+
+        // GetContentRegionMaxAbs - absolute screen coord of the content region's
+        // far (bottom-right) corner; marked with a crosshair + ring.
+        text("GetContentRegionMaxAbs: absolute screen coord of the content's far corner.")
+        let o3 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            let m = GetContentRegionMaxAbs()
+            let cx = m.x - 8.0
+            let cy = m.y - 8.0
+            dl |> add_line(ImVec2(cx - 12.0, cy), ImVec2(cx + 12.0, cy), mark, 2.0)
+            dl |> add_line(ImVec2(cx, cy - 12.0), ImVec2(cx, cy + 12.0), mark, 2.0)
+            dl |> add_circle(ImVec2(cx, cy), 10.0, mark, 0, 2.0)
+            dl |> add_text(ImVec2(o3.x + 12.0, o3.y + 22.0), ink, "far corner = ({int(m.x)}, {int(m.y)})")
+        }
+        dummy(SPACER3, ImVec2(700.0, 64.0))
+        separator()
+        text("All three readouts come from imgui_internal.h layout calculators (family #4).")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -5,6 +5,7 @@ namespace das {
     template <> struct das_alias<ImVec2>  : das_alias_vec<ImVec2,float2> {};
     template <> struct das_alias<ImVec4>  : das_alias_vec<ImVec4,float4> {};
     template <> struct das_alias<ImColor> : das_alias_vec<ImColor,float4> {};
+    template <> struct das_alias<ImRect>  : das_alias_vec<ImRect,float4> {};
 
     template <typename TT>
     struct das_index<ImVector<TT>> : das_default_vector_index<ImVector<TT>, TT> {};

--- a/src/cb_dasIMGUI.h
+++ b/src/cb_dasIMGUI.h
@@ -79,6 +79,7 @@ template<> struct WrapArgType<const ImVec4&> { using type = const WrapArgType<Im
 // in as a struct. Unlike ImVec4 it has no x/y/z/w members, so the Wrap*Arg path can't
 // reuse WrapVec4Arg (which defaults its field pointer to &T::x) — bridge vec4f<->ImRect
 // by memcpy instead.
+static_assert(sizeof(ImRect) == sizeof(float) * 4, "ImRect must be 4 contiguous floats to alias float4");
 template <> struct typeFactory<ImRect> {
 	static TypeDeclPtr make(const ModuleLibrary &) {
 		auto t = new TypeDecl(Type::tFloat4);

--- a/src/cb_dasIMGUI.h
+++ b/src/cb_dasIMGUI.h
@@ -73,6 +73,39 @@ template<> struct WrapArgType<const ImVec2&> { using type = const WrapArgType<Im
 template <> struct JitConstRefByValue<const ImVec4&> { enum { value = true }; };
 template<> struct WrapArgType<const ImVec4&> { using type = const WrapArgType<ImVec4>::type&; };
 
+// ImRect (imgui_internal.h) is { ImVec2 Min; ImVec2 Max } — 4 contiguous floats,
+// layout-identical to float4/vec4f, so it aliases to float4 like ImVec4 and internal
+// rect-taking helpers (ItemSize, RenderTextClipped, ...) bind without pulling ImRect
+// in as a struct. Unlike ImVec4 it has no x/y/z/w members, so the Wrap*Arg path can't
+// reuse WrapVec4Arg (which defaults its field pointer to &T::x) — bridge vec4f<->ImRect
+// by memcpy instead.
+template <> struct typeFactory<ImRect> {
+	static TypeDeclPtr make(const ModuleLibrary &) {
+		auto t = new TypeDecl(Type::tFloat4);
+		t->alias = "ImRect";
+		t->aotAlias = true;
+		return t;
+	}
+};
+template <> struct typeName<ImRect> { constexpr static const char * name() { return "ImRect"; } };
+template <> struct cast_arg<const ImRect &> {
+    static __forceinline ImRect to ( Context & ctx, SimNode * node ) {
+        vec4f res = node->eval(ctx);
+        ImRect r; memcpy(&r,&res,sizeof(ImRect));
+        return r;
+    }
+};
+template<> struct cast <ImRect> : cast_fVec<ImRect> {};
+template<> struct WrapType<ImRect> { enum { value = true }; typedef vec4f type; typedef vec4f rettype; };
+struct WrapImRectArg : ImRect {
+    __forceinline WrapImRectArg(vec4f t) { memcpy(static_cast<ImRect*>(this), &t, sizeof(ImRect)); }
+    __forceinline operator vec4f() const { vec4f r; memcpy(&r, static_cast<const ImRect*>(this), sizeof(ImRect)); return r; }
+};
+template<> struct WrapArgType<ImRect> { typedef WrapImRectArg type; };
+template<> struct WrapRetType<ImRect> { typedef WrapImRectArg type; };
+template <> struct JitConstRefByValue<const ImRect&> { enum { value = true }; };
+template<> struct WrapArgType<const ImRect&> { using type = const WrapArgType<ImRect>::type&; };
+
 template <>
 struct typeName<char> {
     static string name() {

--- a/src/dasIMGUI.func_29.cpp
+++ b/src/dasIMGUI.func_29.cpp
@@ -86,16 +86,19 @@ void Module_dasIMGUI::initFunctions_29() {
 	addCtorAndUsing<ImGuiPlatformIO>(*this,lib,"ImGuiPlatformIO","ImGuiPlatformIO");
 	addCtorAndUsing<ImGuiPlatformMonitor>(*this,lib,"ImGuiPlatformMonitor","ImGuiPlatformMonitor");
 	addCtorAndUsing<ImGuiPlatformImeData>(*this,lib,"ImGuiPlatformImeData","ImGuiPlatformImeData");
+// from imgui_internal.h:3381:29
+	makeExtern< void (*)(const ImVec2 &,float) , ImGui::ItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"ItemSize","ImGui::ItemSize")
+		->args({"size","text_baseline_y"})
+		->arg_init(1,new ExprConstFloat(-1))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3382:29
+	makeExtern< void (*)(const ImRect &,float) , ImGui::ItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"ItemSize","ImGui::ItemSize")
+		->args({"bb","text_baseline_y"})
+		->arg_init(1,new ExprConstFloat(-1))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3388:29
 	makeExtern< ImVec2 (*)(ImVec2,float,float) , ImGui::CalcItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcItemSize","ImGui::CalcItemSize")
 		->args({"size","default_w","default_h"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3389:29
-	makeExtern< float (*)(const ImVec2 &,float) , ImGui::CalcWrapWidthForPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcWrapWidthForPos","ImGui::CalcWrapWidthForPos")
-		->args({"pos","wrap_pos_x"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3392:29
-	makeExtern< ImVec2 (*)() , ImGui::GetContentRegionMaxAbs , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetContentRegionMaxAbs","ImGui::GetContentRegionMaxAbs")
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_29.cpp
+++ b/src/dasIMGUI.func_29.cpp
@@ -86,18 +86,16 @@ void Module_dasIMGUI::initFunctions_29() {
 	addCtorAndUsing<ImGuiPlatformIO>(*this,lib,"ImGuiPlatformIO","ImGuiPlatformIO");
 	addCtorAndUsing<ImGuiPlatformMonitor>(*this,lib,"ImGuiPlatformMonitor","ImGuiPlatformMonitor");
 	addCtorAndUsing<ImGuiPlatformImeData>(*this,lib,"ImGuiPlatformImeData","ImGuiPlatformImeData");
-// from imgui_internal.h:3396:29
-	makeExtern< void (*)(int,bool) , ImGui::PushItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushItemFlag","ImGui::PushItemFlag")
-		->args({"option","enabled"})
+// from imgui_internal.h:3388:29
+	makeExtern< ImVec2 (*)(ImVec2,float,float) , ImGui::CalcItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcItemSize","ImGui::CalcItemSize")
+		->args({"size","default_w","default_h"})
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3397:29
-	makeExtern< void (*)() , ImGui::PopItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopItemFlag","ImGui::PopItemFlag")
+// from imgui_internal.h:3389:29
+	makeExtern< float (*)(const ImVec2 &,float) , ImGui::CalcWrapWidthForPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcWrapWidthForPos","ImGui::CalcWrapWidthForPos")
+		->args({"pos","wrap_pos_x"})
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3719:29
-	makeExtern< void (*)(ImVec2,const char *,const char *,bool) , ImGui::RenderText , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderText","ImGui::RenderText")
-		->args({"pos","text","text_end","hide_text_after_hash"})
-		->arg_init(2,new ExprConstString(""))
-		->arg_init(3,new ExprConstBool(true))
+// from imgui_internal.h:3392:29
+	makeExtern< ImVec2 (*)() , ImGui::GetContentRegionMaxAbs , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetContentRegionMaxAbs","ImGui::GetContentRegionMaxAbs")
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -12,6 +12,19 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_30() {
+// from imgui_internal.h:3396:29
+	makeExtern< void (*)(int,bool) , ImGui::PushItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushItemFlag","ImGui::PushItemFlag")
+		->args({"option","enabled"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3397:29
+	makeExtern< void (*)() , ImGui::PopItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopItemFlag","ImGui::PopItemFlag")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3719:29
+	makeExtern< void (*)(ImVec2,const char *,const char *,bool) , ImGui::RenderText , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderText","ImGui::RenderText")
+		->args({"pos","text","text_end","hide_text_after_hash"})
+		->arg_init(2,new ExprConstString(""))
+		->arg_init(3,new ExprConstBool(true))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3720:29
 	makeExtern< void (*)(ImVec2,const char *,const char *,float) , ImGui::RenderTextWrapped , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderTextWrapped","ImGui::RenderTextWrapped")
 		->args({"pos","text","text_end","wrap_width"})

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -12,6 +12,13 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_30() {
+// from imgui_internal.h:3389:29
+	makeExtern< float (*)(const ImVec2 &,float) , ImGui::CalcWrapWidthForPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcWrapWidthForPos","ImGui::CalcWrapWidthForPos")
+		->args({"pos","wrap_pos_x"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3392:29
+	makeExtern< ImVec2 (*)() , ImGui::GetContentRegionMaxAbs , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetContentRegionMaxAbs","ImGui::GetContentRegionMaxAbs")
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3396:29
 	makeExtern< void (*)(int,bool) , ImGui::PushItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushItemFlag","ImGui::PushItemFlag")
 		->args({"option","enabled"})

--- a/widgets/imgui_enums.das
+++ b/widgets/imgui_enums.das
@@ -1,0 +1,35 @@
+options gen2
+options indenting = 4
+
+module imgui_enums shared
+
+require imgui
+
+//! Flag-operator extensions for imgui enums the binder couldn't give flag-ops to.
+//!
+//! The binder generates ``|`` / ``&`` (C++ ``addEnumFlagOps``) only for PUBLIC flag
+//! typedefs — it maps ``typedef int ImGuiXxxFlags`` to the matching ``ImGuiXxxFlags_``
+//! enum and attaches the ops. Enums pulled from ``imgui_internal.h`` (currently
+//! ``ImGuiItemFlags``) have no such public typedef, so they bind as a plain enum with
+//! no bitwise operators. These explicit overloads restore them, so internal flag enums
+//! combine like the public ones:
+//!
+//!   ``with_item_flag(ImGuiItemFlags.AllowOverlap | ImGuiItemFlags.NoNav, true) { ... }``
+//!
+//! The enum is int-backed, so each op reinterprets the int result back to the enum.
+
+def public operator |(a, b : ImGuiItemFlags) : ImGuiItemFlags {
+    //! Bitwise OR — combine item flags into a single push.
+    // PERF019 can't collapse int(a)|int(b) to int(a|b) here: a|b IS this operator.
+    return unsafe(reinterpret<ImGuiItemFlags>(int(a) | int(b))) // nolint:PERF019
+}
+
+def public operator &(a, b : ImGuiItemFlags) : ImGuiItemFlags {
+    //! Bitwise AND — mask / membership test (pair with ``bool``/``!`` from enum_trait).
+    return unsafe(reinterpret<ImGuiItemFlags>(int(a) & int(b))) // nolint:PERF019
+}
+
+def public operator ~(a : ImGuiItemFlags) : ImGuiItemFlags {
+    //! Bitwise complement — clear-mask for ``flags & ~ImGuiItemFlags.X``.
+    return unsafe(reinterpret<ImGuiItemFlags>(~int(a)))
+}

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -130,10 +130,12 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Bound via bind_imgui.das internal_allow_func.
     "ShadeVertsLinearColorGradientKeepAlpha", "ShadeVertsLinearUV",
     "ShadeVertsTransformPos",
-    // Layout-geometry calculators cherry-picked from imgui_internal.h (family 4).
-    // Pure side-effect-free geometry math (ImVec2/float in, ImVec2/float out) —
-    // host-agnostic, no v2 state. Bound via bind_imgui.das internal_allow_func.
-    "CalcItemSize", "CalcWrapWidthForPos", "GetContentRegionMaxAbs"
+    // Item / layout helpers cherry-picked from imgui_internal.h (family 4).
+    // Geometry math (CalcItemSize/CalcWrapWidthForPos/GetContentRegionMaxAbs) plus
+    // ItemSize (reserve layout space for a custom-drawn item) — host-agnostic, no v2
+    // state. Bound via bind_imgui.das internal_allow_func; ImRect arg of ItemSize's
+    // rect overload is aliased to float4 (cb_dasIMGUI.h).
+    "CalcItemSize", "CalcWrapWidthForPos", "GetContentRegionMaxAbs", "ItemSize"
 }
 
 class ImguiLintVisitor : AstVisitor {

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -31,7 +31,6 @@ module imgui_lint shared private
 //! cleanly when targeted directly (MCP compile_check, lint, format_file).
 
 require daslib/ast_boost
-require strings
 
 let private ALLOWED_IMGUI : table<string> <- {
     // Context / frame lifecycle

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -130,7 +130,11 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Write over already-created ImDrawList vertices — host-agnostic, no v2 state.
     // Bound via bind_imgui.das internal_allow_func.
     "ShadeVertsLinearColorGradientKeepAlpha", "ShadeVertsLinearUV",
-    "ShadeVertsTransformPos"
+    "ShadeVertsTransformPos",
+    // Layout-geometry calculators cherry-picked from imgui_internal.h (family 4).
+    // Pure side-effect-free geometry math (ImVec2/float in, ImVec2/float out) —
+    // host-agnostic, no v2 state. Bound via bind_imgui.das internal_allow_func.
+    "CalcItemSize", "CalcWrapWidthForPos", "GetContentRegionMaxAbs"
 }
 
 class ImguiLintVisitor : AstVisitor {

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -6,6 +6,7 @@ module imgui_scope_builtin shared
 
 require imgui public
 require imgui/imgui_boost_runtime public
+require imgui/imgui_enums public
 
 def public with_indent(amount : float; blk : block) {
     //! Run ``blk`` with ``Indent(amount)`` applied; matching ``Unindent(amount)`` on return.


### PR DESCRIPTION
Fourth `imgui_internal.h` family: the **layout-geometry calculators** — `CalcItemSize`, `CalcWrapWidthForPos`, `GetContentRegionMaxAbs`. Pure, side-effect-free helpers that custom-widget code uses to size and position items the same way the built-in widgets do.

### Surface shape
Like families 1–2 (one-shot `Render*` / `ShadeVerts*` draw calls), every argument and result is an already-bound public type (`ImVec2`, `float`), so **no internal struct or enum is pulled in**. They are one-shot calls, so the v2 surface is a raw `ALLOWED_IMGUI` allow-list entry in `imgui_lint.das` — **not** a `with_*` scope guard (those are reserved for push/pop pairs, family 3+).

Bound signatures (regen output):
- `CalcItemSize(size : ImVec2; default_w, default_h : float) : ImVec2`
- `CalcWrapWidthForPos(pos : ImVec2; wrap_pos_x : float) : float`
- `GetContentRegionMaxAbs() : ImVec2`

### Why `ItemSize` is excluded
`ItemSize` would round out the cluster, but it carries an inline `ImRect` overload. The binder's argument gate (`skip_anyFunction` → `skip_type`) only rejects a record type that is access-restricted (`skip_struct_by_access`) or `skip_struct()`-rejected — an unregistered namespace-scope internal struct like `ImRect` passes the gate. So allowing `ItemSize` would also try to bind the `ImRect` overload against a type that isn't bound. The three calculators here are single-overload with all-public signatures, so they stay cleanly in discipline. (Teaching the gate to reject unregistered internal records is the same forward-looking binder rail noted for the internal flag-typedef gap in #165 — not wired here.)

### Regen
Additive: three `makeExtern` registrations across `src/dasIMGUI.func_29.cpp` / `func_30.cpp`. The func_29↔func_30 churn is the 20-per-chunk boundary repacking the new decl-order slots — nothing dropped, net +3 functions.

### Proven usable
`examples/features/internal_layout_calc.das` calls the real bound API at runtime, not just compiles it:
- draws each `CalcItemSize` result at its **resolved pixel size** (three cases: both-default, explicit-width, explicit-height),
- draws the `CalcWrapWidthForPos` span as a measured bar to the content edge,
- marks the `GetContentRegionMaxAbs` far corner with a crosshair.

Runs headless clean (`--headless-frames=60`, exit 0) and windowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)