### PR TITLE
imgui: complete internal Render* family #1 — ImRect-taking helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ SET(DAS_IMGUI_BIND_SRC
     ${DAS_IMGUI_DIR}/src/dasIMGUI.func_28.cpp
     ${DAS_IMGUI_DIR}/src/dasIMGUI.func_29.cpp
     ${DAS_IMGUI_DIR}/src/dasIMGUI.func_30.cpp
+    ${DAS_IMGUI_DIR}/src/dasIMGUI.func_31.cpp
 )
 
 # imgui app source files

--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -166,10 +166,16 @@ class ImguiGen : CppGenBind {
             "ImGui::ShadeVertsTransformPos",
             "ImGui::PushItemFlag", "ImGui::PopItemFlag",
             "ImGui::CalcItemSize", "ImGui::CalcWrapWidthForPos",
-            "ImGui::GetContentRegionMaxAbs", "ImGui::ItemSize"
+            "ImGui::GetContentRegionMaxAbs", "ImGui::ItemSize",
+            // Family 1-complete — Render* helpers that were dropped from family 1
+            // because they take an ImRect; now that ImRect is aliased to float4
+            // (#166) they bind directly. RenderNavHighlight also pulls the
+            // ImGuiNavHighlightFlags_ enum (bound as int arg, like PushItemFlag).
+            "ImGui::RenderDragDropTargetRect", "ImGui::RenderNavHighlight",
+            "ImGui::RenderRectFilledRangeH", "ImGui::RenderRectFilledWithHole"
         }
         internal_allow_enum <- {
-            "ImGuiItemFlags_"
+            "ImGuiItemFlags_", "ImGuiNavHighlightFlags_"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_render_rects.das
+++ b/examples/features/internal_render_rects.das
@@ -1,0 +1,114 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_render_rects — completes the imgui_internal.h Render* family
+//          (#1) with the four helpers that take an ImRect and so were left out of
+//          the original family-1 PR. Now that ImRect is aliased to float4 (#166),
+//          they bind directly (bind_imgui.das internal_allow_func). An ImRect is a
+//          float4 of (Min.x, Min.y, Max.x, Max.y). RenderNavHighlight also pulls
+//          the ImGuiNavHighlightFlags_ enum (bound as an int arg, like PushItemFlag).
+//          This is the "binding is usable" gate — it calls the real bound API at
+//          runtime, not just compiles it.
+// SHOWS:   RenderRectFilledRangeH (fill a horizontal sub-range of a rounded rect),
+//          RenderRectFilledWithHole (fill an outer rect minus an inner rect),
+//          RenderDragDropTargetRect (the highlight drawn over a drag-drop target),
+//          RenderNavHighlight (the keyboard/gamepad nav focus ring).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_render_rects.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_render_rects.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_render_rects.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("internal_render_rects - imgui_internal.h Render* ImRect helpers", 760, 560)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    let ink   = rgba(232u, 232u, 240u, 255u)
+    let fill  = rgba(48u, 96u, 168u, 230u)
+    let edge  = rgba(120u, 180u, 240u, 255u)
+    let amber = rgba(232u, 168u, 64u, 230u)
+
+    SetNextWindowSize(ImVec2(720.0, 520.0), ImGuiCond.Always)
+    window(RECTS_WIN, (text = "internal_render_rects", closable = false,
+                       flags = ImGuiWindowFlags.None)) {
+        text("imgui_internal.h Render* helpers that take an ImRect (float4 Min/Max).")
+        separator()
+
+        // RenderRectFilledRangeH - fill a [x_start_norm, x_end_norm] sub-range of a
+        // rounded rect (the primitive behind progress bars / scrollbar grabs).
+        text("RenderRectFilledRangeH: fill a horizontal 0.12..0.68 sub-range of a rounded rect.")
+        let o1 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            let tx = o1.x + 12.0
+            let ty = o1.y + 10.0
+            let track = float4(tx, ty, tx + 420.0, ty + 34.0)
+            dl |> add_rect(ImVec2(tx, ty), ImVec2(tx + 420.0, ty + 34.0), edge, 6.0, ImDrawFlags.None, 2.0)
+            RenderRectFilledRangeH(dl, track, fill, 0.12, 0.68, 6.0)
+            dl |> add_text(ImVec2(tx + 8.0, ty + 9.0), ink, "0.12 .. 0.68")
+        }
+        dummy(SPACER1, ImVec2(700.0, 56.0))
+        separator()
+
+        // RenderRectFilledWithHole - fill the outer rect except the inner rect (a
+        // frame / focus mask). Both corners are ImRects.
+        text("RenderRectFilledWithHole: fill an outer rect minus an inner rect (a frame).")
+        let o2 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            let ox = o2.x + 12.0
+            let oy = o2.y + 8.0
+            let outer = float4(ox, oy, ox + 300.0, oy + 70.0)
+            let inner = float4(ox + 42.0, oy + 18.0, ox + 258.0, oy + 52.0)
+            RenderRectFilledWithHole(dl, outer, inner, amber, 6.0)
+            dl |> add_text(ImVec2(ox + 312.0, oy + 26.0), ink, "outer minus inner")
+        }
+        dummy(SPACER2, ImVec2(700.0, 88.0))
+        separator()
+
+        // RenderDragDropTargetRect - the highlight ImGui paints over an accepting
+        // drag-drop target. Draws into the current window's drawlist (no dl arg);
+        // the second ImRect clips the highlight.
+        text("RenderDragDropTargetRect: the highlight drawn over a drag-drop target.")
+        let o3 = GetCursorScreenPos()
+        let dropBB = float4(o3.x + 12.0, o3.y + 8.0, o3.x + 320.0, o3.y + 60.0)
+        let dropClip = float4(o3.x, o3.y, o3.x + 700.0, o3.y + 76.0)
+        RenderDragDropTargetRect(dropBB, dropClip)
+        dummy(SPACER3, ImVec2(700.0, 72.0))
+        separator()
+
+        // RenderNavHighlight - the keyboard/gamepad nav focus ring. It only paints the
+        // item whose id equals the current nav id; at rest that id is 0, so passing 0
+        // with AlwaysDraw shows the ring here. Tab/arrow nav moves it to the real item.
+        text("RenderNavHighlight: the nav focus ring (id 0 + AlwaysDraw to show at rest).")
+        let o4 = GetCursorScreenPos()
+        let navBB = float4(o4.x + 12.0, o4.y + 8.0, o4.x + 320.0, o4.y + 50.0)
+        RenderNavHighlight(navBB, 0u, int(ImGuiNavHighlightFlags.AlwaysDraw))
+        dummy(SPACER4, ImVec2(700.0, 62.0))
+        separator()
+        text("All four are imgui_internal.h Render* helpers, unblocked by ImRect (family #1).")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -38,6 +38,7 @@ addEnumeration(new Enumeration_ImDrawListFlags_());
 addEnumeration(new Enumeration_ImFontAtlasFlags_());
 addEnumeration(new Enumeration_ImGuiViewportFlags_());
 addEnumeration(new Enumeration_ImGuiItemFlags_());
+addEnumeration(new Enumeration_ImGuiNavHighlightFlags_());
 addEnumFlagOps<ImGuiWindowFlags_>(*this,lib,"ImGuiWindowFlags_");
 addEnumFlagOps<ImGuiChildFlags_>(*this,lib,"ImGuiChildFlags_");
 addEnumFlagOps<ImGuiInputTextFlags_>(*this,lib,"ImGuiInputTextFlags_");

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1033,3 +1033,17 @@ public:
 	}
 };
 
+// from imgui_internal.h:1594:6
+class Enumeration_ImGuiNavHighlightFlags_ : public das::Enumeration {
+public:
+	Enumeration_ImGuiNavHighlightFlags_() : das::Enumeration("ImGuiNavHighlightFlags") {
+		external = true;
+		cppName = "ImGuiNavHighlightFlags_";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("None", "ImGuiNavHighlightFlags_None", int64_t(ImGuiNavHighlightFlags_::ImGuiNavHighlightFlags_None), das::LineInfo());
+		addIEx("Compact", "ImGuiNavHighlightFlags_Compact", int64_t(ImGuiNavHighlightFlags_::ImGuiNavHighlightFlags_Compact), das::LineInfo());
+		addIEx("AlwaysDraw", "ImGuiNavHighlightFlags_AlwaysDraw", int64_t(ImGuiNavHighlightFlags_::ImGuiNavHighlightFlags_AlwaysDraw), das::LineInfo());
+		addIEx("NoRounding", "ImGuiNavHighlightFlags_NoRounding", int64_t(ImGuiNavHighlightFlags_::ImGuiNavHighlightFlags_NoRounding), das::LineInfo());
+	}
+};
+

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -39,3 +39,4 @@ DAS_BIND_ENUM_CAST(ImDrawListFlags_);
 DAS_BIND_ENUM_CAST(ImFontAtlasFlags_);
 DAS_BIND_ENUM_CAST(ImGuiViewportFlags_);
 DAS_BIND_ENUM_CAST(ImGuiItemFlags_);
+DAS_BIND_ENUM_CAST(ImGuiNavHighlightFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -75,3 +75,5 @@ DAS_BASE_BIND_ENUM_GEN(ImGuiViewportFlags_,ImGuiViewportFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiItemFlags_,ImGuiItemFlags);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiNavHighlightFlags_,ImGuiNavHighlightFlags);
+

--- a/src/dasIMGUI.func.decl.inc
+++ b/src/dasIMGUI.func.decl.inc
@@ -31,3 +31,4 @@ void initFunctions_27();
 void initFunctions_28();
 void initFunctions_29();
 void initFunctions_30();
+void initFunctions_31();

--- a/src/dasIMGUI.func.reg.inc
+++ b/src/dasIMGUI.func.reg.inc
@@ -31,3 +31,4 @@ initFunctions_27();
 initFunctions_28();
 initFunctions_29();
 initFunctions_30();
+initFunctions_31();

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -26,6 +26,10 @@ void Module_dasIMGUI::initFunctions_30() {
 // from imgui_internal.h:3397:29
 	makeExtern< void (*)() , ImGui::PopItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopItemFlag","ImGui::PopItemFlag")
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3617:29
+	makeExtern< void (*)(const ImRect &,const ImRect &) , ImGui::RenderDragDropTargetRect , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderDragDropTargetRect","ImGui::RenderDragDropTargetRect")
+		->args({"bb","item_clip_rect"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3719:29
 	makeExtern< void (*)(ImVec2,const char *,const char *,bool) , ImGui::RenderText , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderText","ImGui::RenderText")
 		->args({"pos","text","text_end","hide_text_after_hash"})
@@ -53,6 +57,11 @@ void Module_dasIMGUI::initFunctions_30() {
 		->arg_init(6,new ExprConstFloat(0))
 		->arg_type(7,makeType<ImDrawFlags_>(lib))
 		->arg_init(7,new ExprConstEnumeration(0,makeType<ImDrawFlags_>(lib)))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3727:29
+	makeExtern< void (*)(const ImRect &,unsigned int,int) , ImGui::RenderNavHighlight , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderNavHighlight","ImGui::RenderNavHighlight")
+		->args({"bb","id","flags"})
+		->arg_init(2,new ExprConstInt(0))
 		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3729:29
 	makeExtern< void (*)(ImVec2,float,int,unsigned int,unsigned int,unsigned int) , ImGui::RenderMouseCursor , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderMouseCursor","ImGui::RenderMouseCursor")
@@ -82,17 +91,17 @@ void Module_dasIMGUI::initFunctions_30() {
 	makeExtern< void (*)(ImDrawList *,ImVec2,float,unsigned int) , ImGui::RenderArrowDockMenu , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowDockMenu","ImGui::RenderArrowDockMenu")
 		->args({"draw_list","p_min","sz","col"})
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3737:29
+	makeExtern< void (*)(ImDrawList *,const ImRect &,unsigned int,float,float,float) , ImGui::RenderRectFilledRangeH , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledRangeH","ImGui::RenderRectFilledRangeH")
+		->args({"draw_list","rect","col","x_start_norm","x_end_norm","rounding"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3738:29
+	makeExtern< void (*)(ImDrawList *,const ImRect &,const ImRect &,unsigned int,float) , ImGui::RenderRectFilledWithHole , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledWithHole","ImGui::RenderRectFilledWithHole")
+		->args({"draw_list","outer","inner","col","rounding"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3807:29
 	makeExtern< void (*)(ImDrawList *,int,int,ImVec2,ImVec2,unsigned int,unsigned int) , ImGui::ShadeVertsLinearColorGradientKeepAlpha , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearColorGradientKeepAlpha","ImGui::ShadeVertsLinearColorGradientKeepAlpha")
 		->args({"draw_list","vert_start_idx","vert_end_idx","gradient_p0","gradient_p1","col0","col1"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3808:29
-	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,const ImVec2 &,const ImVec2 &,const ImVec2 &,bool) , ImGui::ShadeVertsLinearUV , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearUV","ImGui::ShadeVertsLinearUV")
-		->args({"draw_list","vert_start_idx","vert_end_idx","a","b","uv_a","uv_b","clamp"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3809:29
-	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,float,float,const ImVec2 &) , ImGui::ShadeVertsTransformPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsTransformPos","ImGui::ShadeVertsTransformPos")
-		->args({"draw_list","vert_start_idx","vert_end_idx","pivot_in","cos_a","sin_a","pivot_out"})
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_31.cpp
+++ b/src/dasIMGUI.func_31.cpp
@@ -1,0 +1,25 @@
+// this file is generated via Daslang automatic binder
+// all user modifications will be lost after this file is re-generated
+
+#include "daScript/misc/platform.h"
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_interop.h"
+#include "daScript/ast/ast_handle.h"
+#include "daScript/ast/ast_typefactory_bind.h"
+#include "daScript/simulate/bind_enum.h"
+#include "dasIMGUI.h"
+#include "need_dasIMGUI.h"
+namespace das {
+#include "dasIMGUI.func.aot.decl.inc"
+void Module_dasIMGUI::initFunctions_31() {
+// from imgui_internal.h:3808:29
+	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,const ImVec2 &,const ImVec2 &,const ImVec2 &,bool) , ImGui::ShadeVertsLinearUV , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearUV","ImGui::ShadeVertsLinearUV")
+		->args({"draw_list","vert_start_idx","vert_end_idx","a","b","uv_a","uv_b","clamp"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3809:29
+	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,float,float,const ImVec2 &) , ImGui::ShadeVertsTransformPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsTransformPos","ImGui::ShadeVertsTransformPos")
+		->args({"draw_list","vert_start_idx","vert_end_idx","pivot_in","cos_a","sin_a","pivot_out"})
+		->addToModule(*this, SideEffects::worstDefault);
+}
+}
+

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -135,7 +135,13 @@ let private ALLOWED_IMGUI : table<string> <- {
     // ItemSize (reserve layout space for a custom-drawn item) — host-agnostic, no v2
     // state. Bound via bind_imgui.das internal_allow_func; ImRect arg of ItemSize's
     // rect overload is aliased to float4 (cb_dasIMGUI.h).
-    "CalcItemSize", "CalcWrapWidthForPos", "GetContentRegionMaxAbs", "ItemSize"
+    "CalcItemSize", "CalcWrapWidthForPos", "GetContentRegionMaxAbs", "ItemSize",
+    // Family 1-complete — Render* helpers that take an ImRect, dropped from family 1
+    // until ImRect was aliased to float4 (#166). RenderDragDropTargetRect/RenderNavHighlight
+    // draw into the current window; RenderRectFilledRangeH/WithHole take an ImDrawList.
+    // Host-agnostic, no v2 state. Bound via bind_imgui.das internal_allow_func.
+    "RenderDragDropTargetRect", "RenderNavHighlight",
+    "RenderRectFilledRangeH", "RenderRectFilledWithHole"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
Follow-up to #166. Binds the four `imgui_internal.h` `Render*` helpers that were dropped from the original family-1 PR (#163) **because they take an `ImRect`**. Now that #166 aliased `ImRect` to `float4`, they bind directly — no struct pulled in, no functionality lost.

## Bound (all args already-bound public types)

| helper | signature | draws into |
|---|---|---|
| `RenderDragDropTargetRect` | `(bb : ImRect, item_clip_rect : ImRect)` | current window |
| `RenderNavHighlight` | `(bb : ImRect, id : uint, flags : int)` | current window |
| `RenderRectFilledRangeH` | `(dl, rect : ImRect, col, x_start_norm, x_end_norm, rounding)` | given drawlist |
| `RenderRectFilledWithHole` | `(dl, outer : ImRect, inner : ImRect, col, rounding)` | given drawlist |

`ImRect` is a `float4` of `(Min.x, Min.y, Max.x, Max.y)`. `RenderNavHighlight` also pulls the `ImGuiNavHighlightFlags_` enum into `internal_allow_enum` (bound as an `int` arg, exactly like `PushItemFlag`'s flags).

## Example

`examples/features/internal_render_rects.das` draws all four and runs clean headless (`exit 0` = the real bound API executed, not just compiled). Added to `ALLOWED_IMGUI` (one-shot calls, like families 1–2 — no scope guard).

## Build note

`func_30` was full at 20 funcs/chunk, so the binder spilled `ShadeVerts*` into a new `func_31.cpp`. `CMakeLists.txt` is hardcoded (not glob), so it gets the new chunk explicitly. Nothing dropped — the pair just relocated.

## Deliberately NOT here: the text trio

`RenderTextClipped` / `RenderTextClippedEx` / `RenderTextEllipsis` are **not** bindable directly. They carry a non-defaulted `const char* text_end` that must be `NULL` to mean "render the whole string" — but daslang's `string → const char*` cast coerces a null/empty string to `""` (pointer to `'\0'`), **never `nullptr`** (`cast_arg<const char*>` / `das_string_cast`). A `text_end` pointing at a separate `""` buffer makes `text_end - text` garbage → broken render. This is exactly why `AddText`/`PassFilter`/`AddText2`/`ImGTB_Append` are all hand-wrapped to pass `nullptr`.

Per the standing "no lost functionality / discuss before a custom wrapper" rule, the text trio needs the manual-wrapper rail (`dasIMGUI.main.cpp` + `aot_dasIMGUI.h` decl + skip-list) and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)