### PR TITLE
imgui: bind internal Render* text helpers via wrappers (family #1 complete)

### DIFF
--- a/examples/features/internal_render_text.das
+++ b/examples/features/internal_render_text.das
@@ -1,0 +1,121 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_render_text — the imgui_internal.h Render* TEXT helpers, the
+//          last piece of family #1. RenderTextClipped / RenderTextClippedEx /
+//          RenderTextEllipsis can't bind directly: they carry a non-defaulted
+//          `const char* text_end` that must be NULL to mean "render the whole
+//          string", but daslang's string->const char* cast turns a null/empty
+//          string into "" (a pointer to '\0'), never nullptr — and these funcs
+//          feed text_end straight to CalcTextSizeA, which over-reads past the
+//          buffer on a non-null "" (verified: it crashes). So they are bound via
+//          thin C++ wrappers in src/dasIMGUI.main.cpp that pin text_end (and the
+//          text_size_if_known perf hint) to nullptr. This is the "binding is
+//          usable" gate — it calls the real wrapped API at runtime.
+// SHOWS:   RenderTextClipped (hard-clip text to a box, with alignment),
+//          RenderTextClippedEx (the same into an explicit drawlist),
+//          RenderTextEllipsis (truncate with a trailing ellipsis on overflow).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_render_text.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_render_text.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_render_text.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("internal_render_text - imgui_internal.h Render* text helpers", 760, 540)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+def private box(var dl : ImDrawList?; x, y, w, h : float; edge : uint) {
+    dl |> add_rect(ImVec2(x, y), ImVec2(x + w, y + h), edge, 0.0, ImDrawFlags.None, 2.0)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    let ink  = rgba(232u, 232u, 240u, 255u)
+    let edge = rgba(120u, 180u, 240u, 255u)
+
+    SetNextWindowSize(ImVec2(720.0, 500.0), ImGuiCond.Always)
+    window(TEXT_WIN, (text = "internal_render_text", closable = false,
+                      flags = ImGuiWindowFlags.None)) {
+        text("imgui_internal.h Render* text helpers - clip to a box / align / ellipsize.")
+        separator()
+
+        // RenderTextClipped - render text clipped to [pos_min, pos_max], aligned
+        // within the box by the align fraction. The wrapper draws into the current
+        // window drawlist (no explicit ImDrawList argument).
+        text("RenderTextClipped: aligned within a box (left / center / right), and hard-clipped.")
+        let o1 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            box(dl, o1.x + 12.0, o1.y + 8.0, 200.0, 28.0, edge)
+            box(dl, o1.x + 232.0, o1.y + 8.0, 200.0, 28.0, edge)
+            box(dl, o1.x + 452.0, o1.y + 8.0, 200.0, 28.0, edge)
+        }
+        RenderTextClipped(ImVec2(o1.x + 16.0, o1.y + 12.0), ImVec2(o1.x + 208.0, o1.y + 32.0), "left")
+        RenderTextClipped(ImVec2(o1.x + 236.0, o1.y + 12.0), ImVec2(o1.x + 428.0, o1.y + 32.0),
+                          "center", ImVec2(0.5, 0.0))
+        RenderTextClipped(ImVec2(o1.x + 456.0, o1.y + 12.0), ImVec2(o1.x + 648.0, o1.y + 32.0),
+                          "right", ImVec2(1.0, 0.0))
+        dummy(SPACER1, ImVec2(700.0, 44.0))
+        separator()
+
+        // A box narrower than the text hard-clips the overflow at the box edge.
+        text("RenderTextClipped with a too-narrow box: the overflow is hard-clipped (no ellipsis).")
+        let o2 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            box(dl, o2.x + 12.0, o2.y + 8.0, 240.0, 28.0, edge)
+        }
+        RenderTextClipped(ImVec2(o2.x + 16.0, o2.y + 12.0), ImVec2(o2.x + 248.0, o2.y + 32.0),
+                          "this string is wider than its clipping box")
+        dummy(SPACER2, ImVec2(700.0, 44.0))
+        separator()
+
+        // RenderTextClippedEx - identical, but renders into an explicit ImDrawList
+        // (here the window drawlist), so custom-widget code can target any list.
+        text("RenderTextClippedEx: the same, but into an explicit ImDrawList argument.")
+        let o3 = GetCursorScreenPos()
+        with_window_drawlist() $(var dl) {
+            box(dl, o3.x + 12.0, o3.y + 8.0, 300.0, 28.0, edge)
+            RenderTextClippedEx(dl, ImVec2(o3.x + 16.0, o3.y + 12.0), ImVec2(o3.x + 308.0, o3.y + 32.0),
+                                "drawn via RenderTextClippedEx", ImVec2(0.5, 0.0))
+        }
+        dummy(SPACER3, ImVec2(700.0, 44.0))
+        separator()
+
+        // RenderTextEllipsis - clip to the box, but truncate with a trailing "..."
+        // when the text overflows (clip_max_x / ellipsis_max_x mark the right edge).
+        text("RenderTextEllipsis: overflow is truncated with a trailing ellipsis.")
+        let o4 = GetCursorScreenPos()
+        let ex = o4.x + 12.0 + 220.0
+        with_window_drawlist() $(var dl) {
+            box(dl, o4.x + 12.0, o4.y + 8.0, 220.0, 28.0, edge)
+            RenderTextEllipsis(dl, ImVec2(o4.x + 16.0, o4.y + 12.0), ImVec2(ex, o4.y + 32.0),
+                               ex, ex, "this tab label is far too long to fit in its box")
+        }
+        dummy(SPACER4, ImVec2(700.0, 44.0))
+        separator()
+        text("All three are imgui_internal.h Render* text helpers (family #1), bound via C++ wrappers.")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/internal_render_text.das
+++ b/examples/features/internal_render_text.das
@@ -38,7 +38,6 @@ def update() {
     if (!harness_begin_frame()) return
     harness_new_frame()
 
-    let ink  = rgba(232u, 232u, 240u, 255u)
     let edge = rgba(120u, 180u, 240u, 255u)
 
     SetNextWindowSize(ImVec2(720.0, 500.0), ImGuiCond.Always)

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -39,6 +39,16 @@ namespace das {
     DAS_MOD_API void AddText( ImDrawList & drawList, const ImVec2& pos, ImU32 col, const char* text );
     DAS_MOD_API void AddText2( ImDrawList & drawList, const ImFont* font, float font_size, const ImVec2& pos, ImU32 col,
         const char* text_begin, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = nullptr);
+    // imgui_internal.h Render*Clipped / Ellipsis text helpers — text_end is forced to
+    // nullptr (a daslang string can't express the NULL these need for "auto-strlen";
+    // a non-null "" over-reads past the buffer → crash). text_size_if_known is forced
+    // to nullptr (let ImGui compute it — identical result, it is only a perf hint).
+    DAS_MOD_API void RenderTextClippedW( const ImVec2& pos_min, const ImVec2& pos_max, const char* text,
+        const ImVec2& align, const ImRect* clip_rect );
+    DAS_MOD_API void RenderTextClippedExW( ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max,
+        const char* text, const ImVec2& align, const ImRect* clip_rect );
+    DAS_MOD_API void RenderTextEllipsisW( ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max,
+        float clip_max_x, float ellipsis_max_x, const char* text );
     DAS_MOD_API ImColor HSV(float h, float s, float v, float a = 1.0f);
     DAS_MOD_API void ImGTB_Append ( ImGuiTextBuffer & buf, const char * txt );
     DAS_MOD_API int ImGTB_At ( ImGuiTextBuffer & buf, int32_t index );

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -319,6 +319,23 @@ namespace das {
         drawList.AddText(font,font_size,pos,col,text_begin,nullptr,wrap_width,cpu_fine_clip_rect);
     }
 
+    // imgui_internal.h Render*Clipped / Ellipsis — see aot_dasIMGUI.h for why
+    // text_end / text_size_if_known are pinned to nullptr.
+    void RenderTextClippedW( const ImVec2& pos_min, const ImVec2& pos_max, const char* text,
+        const ImVec2& align, const ImRect* clip_rect ) {
+        ImGui::RenderTextClipped(pos_min, pos_max, text, nullptr, nullptr, align, clip_rect);
+    }
+
+    void RenderTextClippedExW( ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max,
+        const char* text, const ImVec2& align, const ImRect* clip_rect ) {
+        ImGui::RenderTextClippedEx(draw_list, pos_min, pos_max, text, nullptr, nullptr, align, clip_rect);
+    }
+
+    void RenderTextEllipsisW( ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max,
+        float clip_max_x, float ellipsis_max_x, const char* text ) {
+        ImGui::RenderTextEllipsis(draw_list, pos_min, pos_max, clip_max_x, ellipsis_max_x, text, nullptr, nullptr);
+    }
+
     // ImColor
 
     ImColor HSV(float h, float s, float v, float a) {
@@ -514,6 +531,22 @@ namespace das {
                 ->args({"drawList","font","font_size","pos","col","text","wrap_width","cpu_fine_clip_rect"})
                     ->arg_init(6,new ExprConstFloat(0.0f))
                     ->arg_init(7,new ExprConstPtr());
+        // imgui_internal.h Render*Clipped / Ellipsis text helpers (wrappers pin text_end
+        // + text_size_if_known to nullptr — see das:: defs above). align defaults to
+        // ImVec2(0,0), clip_rect to null, so the common call is just (pos_min,pos_max,text).
+        addExtern<DAS_BIND_FUN(das::RenderTextClippedW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "RenderTextClipped",
+            SideEffects::worstDefault, "das::RenderTextClippedW")
+                ->args({"pos_min","pos_max","text","align","clip_rect"})
+                    ->arg_init(3,new ExprCall(LineInfo(),"ImVec2"))
+                    ->arg_init(4,new ExprConstPtr());
+        addExtern<DAS_BIND_FUN(das::RenderTextClippedExW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "RenderTextClippedEx",
+            SideEffects::worstDefault, "das::RenderTextClippedExW")
+                ->args({"draw_list","pos_min","pos_max","text","align","clip_rect"})
+                    ->arg_init(4,new ExprCall(LineInfo(),"ImVec2"))
+                    ->arg_init(5,new ExprConstPtr());
+        addExtern<DAS_BIND_FUN(das::RenderTextEllipsisW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "RenderTextEllipsis",
+            SideEffects::worstDefault, "das::RenderTextEllipsisW")
+                ->args({"draw_list","pos_min","pos_max","clip_max_x","ellipsis_max_x","text"});
         // variadic functions
         addExtern<DAS_BIND_FUN(das::Text)>(*this,lib,"Text",
             SideEffects::worstDefault,"das::Text");

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -125,6 +125,10 @@ let private ALLOWED_IMGUI : table<string> <- {
     "RenderColorRectWithAlphaCheckerboard", "RenderMouseCursor",
     "RenderArrow", "RenderBullet", "RenderCheckMark",
     "RenderArrowPointingAt", "RenderArrowDockMenu",
+    // Render*Clipped / Ellipsis text helpers — bound via manual C++ wrappers
+    // (dasIMGUI.main.cpp) that pin text_end/text_size_if_known to nullptr, since a
+    // daslang string can't pass the NULL these need (a non-null "" over-reads → crash).
+    "RenderTextClipped", "RenderTextClippedEx", "RenderTextEllipsis",
     // Vertex-shading draw helpers cherry-picked from imgui_internal.h (family 2).
     // Write over already-created ImDrawList vertices — host-agnostic, no v2 state.
     // Bound via bind_imgui.das internal_allow_func.


### PR DESCRIPTION
Finishes family #1 (follows #167). Binds the three `imgui_internal.h` text helpers — `RenderTextClipped` / `RenderTextClippedEx` / `RenderTextEllipsis` — that **can't bind directly**, via the existing manual-wrapper rail.

## Why they can't bind directly (verified, not theorized)

Each carries a non-defaulted `const char* text_end` that must be `NULL` to mean "render the whole string". But daslang's `string → const char*` cast coerces a null/empty string to `""` (a pointer to `'\0'`), **never `nullptr`** (`cast_arg<const char*>` / `das_string_cast`: `res ? res : (char*)""`).

These functions feed `text_end` straight to `ImFont::CalcTextSizeA`, which only does the `strlen` fallback when `text_end` is *actually* `NULL`. A non-null `""` pointer (a different buffer) makes the `while (s < text_end)` glyph loop over-read past the text buffer. I tested it directly:

```
CRASH: EXCEPTION_ACCESS_VIOLATION at ImFont::CalcTextSizeA <- ImGui::RenderTextEllipsis
```

`RenderText` survives the same `""` only because it routes through `FindRenderedTextEnd`, which has a `*p != '\0'` guard; the clipped/ellipsis path bypasses it.

## The fix

Thin C++ wrappers in `dasIMGUI.main.cpp` (the same rail as `AddText2` / `PassFilter`) that pin `text_end` and the `text_size_if_known` perf hint to `nullptr`, exposing `pos_min` / `pos_max` / `text` / `align` / `clip_rect` (the last two default to `ImVec2(0,0)` / null, so the common call is just `RenderTextClipped(pos_min, pos_max, text)`). No functionality lost: `text_end=nullptr` is "render whole string" (the only thing daslang strings can express anyway), and `text_size_if_known=nullptr` just lets ImGui compute the size (identical result).

| daslang signature |
|---|
| `RenderTextClipped(pos_min, pos_max, text [, align [, clip_rect]])` |
| `RenderTextClippedEx(draw_list, pos_min, pos_max, text [, align [, clip_rect]])` |
| `RenderTextEllipsis(draw_list, pos_min, pos_max, clip_max_x, ellipsis_max_x, text)` |

## Verification

After wrapping, the same test renders correctly with no crash — vertex delta matches a known-good `RenderText` for the same string (`40 == 40`, i.e. the full string, no over-read). New example `examples/features/internal_render_text.das` shows all three (clip + align + ellipsis) and runs clean headless (`exit 0`). Added to `ALLOWED_IMGUI`.

With this, **family #1 is complete** — every `imgui_internal.h` `Render*` helper is now bound (draw helpers in #163, ImRect-taking ones in #167, text helpers here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)