### PR TITLE
imgui: bind internal ID-stack seed / override helpers (family)

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -172,7 +172,18 @@ class ImguiGen : CppGenBind {
             // (#166) they bind directly. RenderNavHighlight also pulls the
             // ImGuiNavHighlightFlags_ enum (bound as int arg, like PushItemFlag).
             "ImGui::RenderDragDropTargetRect", "ImGui::RenderNavHighlight",
-            "ImGui::RenderRectFilledRangeH", "ImGui::RenderRectFilledWithHole"
+            "ImGui::RenderRectFilledRangeH", "ImGui::RenderRectFilledWithHole",
+            // ID-stack seed / override helpers. Pure ImGuiID(uint)/const char*/int
+            // in, ImGuiID/void out — no internal struct, enum, or nullable pointer.
+            // GetIDWithSeed's two-pointer overload mirrors the public GetID(begin,end):
+            // both halves are required, so it is NOT a text_end wrapper case. One
+            // allow-list entry covers both GetIDWithSeed overloads (gate keys on the
+            // bare spelling). GetActiveID is deliberately NOT here — it is already
+            // bound via the das::GetActiveID manual wrapper (Phase 2.1, predates this
+            // allow-list); re-adding it would double-bind "GetActiveID".
+            "ImGui::GetFocusID", "ImGui::GetHoveredID",
+            "ImGui::KeepAliveID", "ImGui::MarkItemEdited", "ImGui::PushOverrideID",
+            "ImGui::GetIDWithSeed", "ImGui::TreePushOverrideID"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_"

--- a/examples/features/internal_id_seed.das
+++ b/examples/features/internal_id_seed.das
@@ -1,0 +1,114 @@
+options gen2
+
+require imgui/imgui_harness
+require strings
+
+// =============================================================================
+// FEATURE: internal_id_seed — the imgui_internal.h ID-stack seed / override
+//          helpers. Cherry-picked into the v2 binding (bind_imgui.das
+//          internal_allow_func): GetIDWithSeed, GetFocusID, GetHoveredID,
+//          KeepAliveID, MarkItemEdited, PushOverrideID, TreePushOverrideID.
+//          Host-agnostic — they hash/seed an ImGuiID, query the active item ID,
+//          or push a raw ID onto the stack, all without v2 host state. This is
+//          the "binding is usable" gate: it calls the real bound API at runtime.
+// SHOWS:   GetIDWithSeed(n, seed) (same int, different seed => different ID);
+//          with_override_id (the new PushOverrideID scope guard — GetID under a
+//          raw seed, NOT hash-combined like with_id); GetHoveredID / GetFocusID
+//          (which item is hovered / focused this frame); KeepAliveID +
+//          MarkItemEdited (custom-widget ID plumbing); TreePushOverrideID +
+//          tree_pop (a tree level under an explicit override ID).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_id_seed.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_id_seed.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_id_seed.das
+// =============================================================================
+
+// ImGui IDs are conventionally shown as 8-digit hex (the metrics window does the
+// same); daslang's "{u}" interpolation is decimal, so format the nibbles by hand.
+def private hex8(v : uint) : string {
+    let digits = "0123456789abcdef"
+    return build_string() $(var writer) {
+        writer |> write("0x")
+        for (i in range(8)) {
+            let nib = int((v >> uint((7 - i) * 4)) & 0xfu)
+            writer |> write(slice(digits, nib, nib + 1))
+        }
+    }
+}
+
+[export]
+def init() {
+    harness_init("internal_id_seed - imgui_internal.h ID seed / override helpers", 760, 560)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(720.0, 520.0), ImGuiCond.Always)
+    window(ID_SEED_WIN, (text = "internal_id_seed", closable = false,
+                         flags = ImGuiWindowFlags.None)) {
+        // GetIDWithSeed(n, seed) — hash an int under an explicit seed, without
+        // touching the ID stack. Same int + different seed => different ID, which
+        // is how nested scopes keep their child IDs from colliding.
+        text("GetIDWithSeed(n, seed): hash an int under an explicit seed (no ID-stack push).")
+        text("  GetIDWithSeed(42, 0)    = {hex8(GetIDWithSeed(42, 0u))}")
+        text("  GetIDWithSeed(42, 1000) = {hex8(GetIDWithSeed(42, 1000u))}   (same int, new seed)")
+        separator()
+
+        // with_override_id — the new scope guard over PushOverrideID. Pushes the
+        // raw seed as-is (NOT hash-combined like with_id), so GetID("child") under
+        // it equals GetIDWithSeed("child".., 7777). Stable, explicitly-seeded IDs.
+        text("with_override_id(seed): GetID(\"child\") under a raw seed - a stable, explicitly-seeded string ID.")
+        with_override_id(7777u) {
+            let child_id = GetID("child")
+            text("  under override 7777: GetID(\"child\") = {hex8(child_id)}")
+        }
+        separator()
+
+        // GetHoveredID / GetFocusID — introspection. Hover or tab to a button and
+        // its ID shows up here (0 when nothing is hovered / focused).
+        text("GetHoveredID / GetFocusID: which item is hovered / focused this frame.")
+        button(BTN_A, (text = "hover me (A)"))
+        same_line()
+        button(BTN_B, (text = "or tab to me (B)"))
+        text("  hovered = {hex8(GetHoveredID())}   focused = {hex8(GetFocusID())}")
+        separator()
+
+        // KeepAliveID / MarkItemEdited — custom-widget ID plumbing. KeepAliveID
+        // stops an interacting-but-unsubmitted ID from being cleared this frame;
+        // MarkItemEdited drives IsItemDeactivatedAfterEdit for hand-rolled widgets.
+        text("KeepAliveID / MarkItemEdited: custom-widget ID plumbing.")
+        let custom_id = GetID("my_custom_widget")
+        KeepAliveID(custom_id)
+        MarkItemEdited(custom_id)
+        text("  KeepAliveID + MarkItemEdited called on {hex8(custom_id)}")
+        separator()
+
+        // TreePushOverrideID + tree_pop — open a tree depth level keyed by a raw
+        // override ID (vs TreeNode's hashed label). Used for stable tree IDs that
+        // survive relabeling / reordering.
+        text("TreePushOverrideID(id) + tree_pop(): a tree level under a raw override ID.")
+        TreePushOverrideID(GetID("explicit_tree"))
+        text("  ...content nested inside the explicit-ID tree level")
+        tree_pop()
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.func_29.cpp
+++ b/src/dasIMGUI.func_29.cpp
@@ -86,19 +86,15 @@ void Module_dasIMGUI::initFunctions_29() {
 	addCtorAndUsing<ImGuiPlatformIO>(*this,lib,"ImGuiPlatformIO","ImGuiPlatformIO");
 	addCtorAndUsing<ImGuiPlatformMonitor>(*this,lib,"ImGuiPlatformMonitor","ImGuiPlatformMonitor");
 	addCtorAndUsing<ImGuiPlatformImeData>(*this,lib,"ImGuiPlatformImeData","ImGuiPlatformImeData");
-// from imgui_internal.h:3381:29
-	makeExtern< void (*)(const ImVec2 &,float) , ImGui::ItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"ItemSize","ImGui::ItemSize")
-		->args({"size","text_baseline_y"})
-		->arg_init(1,new ExprConstFloat(-1))
+// from imgui_internal.h:3368:29
+	makeExtern< unsigned int (*)() , ImGui::GetFocusID , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetFocusID","ImGui::GetFocusID")
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3382:29
-	makeExtern< void (*)(const ImRect &,float) , ImGui::ItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"ItemSize","ImGui::ItemSize")
-		->args({"bb","text_baseline_y"})
-		->arg_init(1,new ExprConstFloat(-1))
+// from imgui_internal.h:3372:29
+	makeExtern< unsigned int (*)() , ImGui::GetHoveredID , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetHoveredID","ImGui::GetHoveredID")
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3388:29
-	makeExtern< ImVec2 (*)(ImVec2,float,float) , ImGui::CalcItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcItemSize","ImGui::CalcItemSize")
-		->args({"size","default_w","default_h"})
+// from imgui_internal.h:3374:29
+	makeExtern< void (*)(unsigned int) , ImGui::KeepAliveID , SimNode_ExtFuncCall , imguiTempFn>(lib,"KeepAliveID","ImGui::KeepAliveID")
+		->args({"id"})
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -12,6 +12,36 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_30() {
+// from imgui_internal.h:3375:29
+	makeExtern< void (*)(unsigned int) , ImGui::MarkItemEdited , SimNode_ExtFuncCall , imguiTempFn>(lib,"MarkItemEdited","ImGui::MarkItemEdited")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3376:29
+	makeExtern< void (*)(unsigned int) , ImGui::PushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushOverrideID","ImGui::PushOverrideID")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3377:29
+	makeExtern< unsigned int (*)(const char *,const char *,unsigned int) , ImGui::GetIDWithSeed , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetIDWithSeed","ImGui::GetIDWithSeed")
+		->args({"str_id_begin","str_id_end","seed"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3378:29
+	makeExtern< unsigned int (*)(int,unsigned int) , ImGui::GetIDWithSeed , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetIDWithSeed","ImGui::GetIDWithSeed")
+		->args({"n","seed"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3381:29
+	makeExtern< void (*)(const ImVec2 &,float) , ImGui::ItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"ItemSize","ImGui::ItemSize")
+		->args({"size","text_baseline_y"})
+		->arg_init(1,new ExprConstFloat(-1))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3382:29
+	makeExtern< void (*)(const ImRect &,float) , ImGui::ItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"ItemSize","ImGui::ItemSize")
+		->args({"bb","text_baseline_y"})
+		->arg_init(1,new ExprConstFloat(-1))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3388:29
+	makeExtern< ImVec2 (*)(ImVec2,float,float) , ImGui::CalcItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcItemSize","ImGui::CalcItemSize")
+		->args({"size","default_w","default_h"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3389:29
 	makeExtern< float (*)(const ImVec2 &,float) , ImGui::CalcWrapWidthForPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcWrapWidthForPos","ImGui::CalcWrapWidthForPos")
 		->args({"pos","wrap_pos_x"})
@@ -73,35 +103,6 @@ void Module_dasIMGUI::initFunctions_30() {
 		->args({"draw_list","pos","col","dir","scale"})
 		->arg_type(3,makeType<ImGuiDir_>(lib))
 		->arg_init(4,new ExprConstFloat(1))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3733:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int) , ImGui::RenderBullet , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderBullet","ImGui::RenderBullet")
-		->args({"draw_list","pos","col"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3734:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,float) , ImGui::RenderCheckMark , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderCheckMark","ImGui::RenderCheckMark")
-		->args({"draw_list","pos","col","sz"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3735:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,ImVec2,int,unsigned int) , ImGui::RenderArrowPointingAt , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowPointingAt","ImGui::RenderArrowPointingAt")
-		->args({"draw_list","pos","half_sz","direction","col"})
-		->arg_type(3,makeType<ImGuiDir_>(lib))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3736:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,float,unsigned int) , ImGui::RenderArrowDockMenu , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowDockMenu","ImGui::RenderArrowDockMenu")
-		->args({"draw_list","p_min","sz","col"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3737:29
-	makeExtern< void (*)(ImDrawList *,const ImRect &,unsigned int,float,float,float) , ImGui::RenderRectFilledRangeH , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledRangeH","ImGui::RenderRectFilledRangeH")
-		->args({"draw_list","rect","col","x_start_norm","x_end_norm","rounding"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3738:29
-	makeExtern< void (*)(ImDrawList *,const ImRect &,const ImRect &,unsigned int,float) , ImGui::RenderRectFilledWithHole , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledWithHole","ImGui::RenderRectFilledWithHole")
-		->args({"draw_list","outer","inner","col","rounding"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3807:29
-	makeExtern< void (*)(ImDrawList *,int,int,ImVec2,ImVec2,unsigned int,unsigned int) , ImGui::ShadeVertsLinearColorGradientKeepAlpha , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearColorGradientKeepAlpha","ImGui::ShadeVertsLinearColorGradientKeepAlpha")
-		->args({"draw_list","vert_start_idx","vert_end_idx","gradient_p0","gradient_p1","col0","col1"})
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_31.cpp
+++ b/src/dasIMGUI.func_31.cpp
@@ -12,6 +12,39 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_31() {
+// from imgui_internal.h:3733:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int) , ImGui::RenderBullet , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderBullet","ImGui::RenderBullet")
+		->args({"draw_list","pos","col"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3734:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,float) , ImGui::RenderCheckMark , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderCheckMark","ImGui::RenderCheckMark")
+		->args({"draw_list","pos","col","sz"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3735:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,ImVec2,int,unsigned int) , ImGui::RenderArrowPointingAt , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowPointingAt","ImGui::RenderArrowPointingAt")
+		->args({"draw_list","pos","half_sz","direction","col"})
+		->arg_type(3,makeType<ImGuiDir_>(lib))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3736:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,float,unsigned int) , ImGui::RenderArrowDockMenu , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowDockMenu","ImGui::RenderArrowDockMenu")
+		->args({"draw_list","p_min","sz","col"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3737:29
+	makeExtern< void (*)(ImDrawList *,const ImRect &,unsigned int,float,float,float) , ImGui::RenderRectFilledRangeH , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledRangeH","ImGui::RenderRectFilledRangeH")
+		->args({"draw_list","rect","col","x_start_norm","x_end_norm","rounding"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3738:29
+	makeExtern< void (*)(ImDrawList *,const ImRect &,const ImRect &,unsigned int,float) , ImGui::RenderRectFilledWithHole , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledWithHole","ImGui::RenderRectFilledWithHole")
+		->args({"draw_list","outer","inner","col","rounding"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3767:29
+	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3807:29
+	makeExtern< void (*)(ImDrawList *,int,int,ImVec2,ImVec2,unsigned int,unsigned int) , ImGui::ShadeVertsLinearColorGradientKeepAlpha , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearColorGradientKeepAlpha","ImGui::ShadeVertsLinearColorGradientKeepAlpha")
+		->args({"draw_list","vert_start_idx","vert_end_idx","gradient_p0","gradient_p1","col0","col1"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3808:29
 	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,const ImVec2 &,const ImVec2 &,const ImVec2 &,bool) , ImGui::ShadeVertsLinearUV , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearUV","ImGui::ShadeVertsLinearUV")
 		->args({"draw_list","vert_start_idx","vert_end_idx","a","b","uv_a","uv_b","clamp"})

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -95,7 +95,7 @@ def document_module_imgui_containers_builtin() {
 def document_module_imgui_id_builtin() {
     var mod = find_module("imgui_id_builtin")
     var groups <- array<DocGroup>(
-        group_by_regex("ID stack",      mod, %regex~^(push_id|pop_id|with_id|with_path)$%%),
+        group_by_regex("ID stack",      mod, %regex~^(push_id|pop_id|with_id|with_override_id|with_path)$%%),
         group_by_regex("Hashing",       mod, %regex~^(hash_id|get_id).*%%),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))
     )

--- a/widgets/imgui_id_builtin.das
+++ b/widgets/imgui_id_builtin.das
@@ -16,3 +16,15 @@ def public with_id(s : string; blk : block) {
     PopID()
     container_path_pop()
 }
+
+def public with_override_id(id : uint; blk : block) {
+    //! Run ``blk`` with raw ``id`` pushed via ``PushOverrideID`` (as-is, NOT
+    //! hash-combined like ``with_id``), popped on return. For stable, explicitly
+    //! controlled IDs — custom widgets, addressing into ImGuiStorage, or seeding a
+    //! string ID (``GetID`` under the override equals ``GetIDWithSeed(.., id)``).
+    container_path_push("{id}")
+    PushOverrideID(id)
+    invoke(blk)
+    PopID()
+    container_path_pop()
+}

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -145,7 +145,13 @@ let private ALLOWED_IMGUI : table<string> <- {
     // draw into the current window; RenderRectFilledRangeH/WithHole take an ImDrawList.
     // Host-agnostic, no v2 state. Bound via bind_imgui.das internal_allow_func.
     "RenderDragDropTargetRect", "RenderNavHighlight",
-    "RenderRectFilledRangeH", "RenderRectFilledWithHole"
+    "RenderRectFilledRangeH", "RenderRectFilledWithHole",
+    // ID-stack seed / override helpers cherry-picked from imgui_internal.h.
+    // Host-agnostic: hash/seed an ImGuiID, query the active/hovered/focus ID, or
+    // push a raw override onto the ID stack. Bound via bind_imgui.das
+    // internal_allow_func. GetActiveID is bound separately (das::GetActiveID wrapper).
+    "GetFocusID", "GetHoveredID", "KeepAliveID", "MarkItemEdited",
+    "PushOverrideID", "GetIDWithSeed", "TreePushOverrideID"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
Next `imgui_internal.h` family after #168 — the **ID-stack seed / override helpers**. This is the lowest-friction candidate from the survey (verdict *bindable-as-is*, no new C++ wrapper, regen only).

## What's bound

Added to `internal_allow_func` (regen only — no new C++ wrapper rail):

| daslang | C++ signature |
|---|---|
| `GetIDWithSeed(n, seed)` / `GetIDWithSeed(begin, end, seed)` | `ImGuiID(int, ImGuiID)` / `ImGuiID(const char*, const char*, ImGuiID)` |
| `GetFocusID()` / `GetHoveredID()` | `ImGuiID()` |
| `KeepAliveID(id)` / `MarkItemEdited(id)` | `void(ImGuiID)` |
| `PushOverrideID(id)` / `TreePushOverrideID(id)` | `void(ImGuiID)` |

All host-agnostic: hash/seed an `ImGuiID`, query the active/hovered/focus item ID, or push a raw ID onto the stack. Every arg is an already-bound public type (`ImGuiID → uint`, `const char*`, `int`), so no internal struct/enum is pulled in.

Two things worth a look:

- **`GetFocusID` is `inline` without `IMGUI_API`** (unlike the rest). It still binds via the `makeExtern< … , &ImGui::GetFocusID , … >` address-taking path like any other — verified in the regen output. So `GetActiveID`'s manual `das::GetActiveID` wrapper (Phase 2.1) was a *historical artifact* (it predates `internal_allow_func`), not a sign these inline getters need wrapping. `GetActiveID` is intentionally **not** re-added here — it would double-bind `"GetActiveID"`.
- **`GetIDWithSeed(begin, end, seed)`** is bound for parity but takes a string *slice* (begin/end into the same buffer). Two separate daslang strings would compute a garbage `end - begin`, so it's bound-but-not-exercised exactly like the public `GetID(begin, end)` (also bound, never called in-tree). The idiomatic string-seed path is `with_override_id(seed) { GetID(str) }`.

## New rail — please eyeball

`PushOverrideID`/`TreePushOverrideID` mutate the ID stack and need pop partners, but raw `PushID`/`PopID` aren't on the v2 surface (`with_id` is the guard). Per the *port = API discovery, add the rail in the same PR* norm, this adds:

```
def public with_override_id(id : uint; blk : block)  // imgui_id_builtin.das
```

the `PushOverrideID`/`PopID` mirror of `with_id` (raw push, NOT hash-combined). `TreePushOverrideID` pairs with the existing `tree_pop()` wrapper, so it needs no new guard. Flagging this since it's genuinely new public API, not just a binding — happy to drop it and defer the two override-push members if you'd rather keep this PR pure-binding.

## Verification

- Regenerated via the junction trick; only the 8 `makeExtern`s + chunk reflow landed (no functions lost, no new func chunk → CMakeLists untouched). EOL-only `.inc` churn reverted.
- Rebuilt `dasModuleImgui.shared_module` on Windows (MSVC).
- New example `examples/features/internal_id_seed.das` exercises all members (int-seed, `with_override_id`, hovered/focus introspection, `KeepAliveID`/`MarkItemEdited`, `TreePushOverrideID` + `tree_pop`) and runs clean headless (`exit 0`).
- `format --verify` + lint clean on all 4 changed `.das` (pre-push hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)