### PR TITLE
imgui: bind internal focus-scope / activation helpers (family)

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -176,14 +176,28 @@ class ImguiGen : CppGenBind {
             // ID-stack seed / override helpers. Pure ImGuiID(uint)/const char*/int
             // in, ImGuiID/void out — no internal struct, enum, or nullable pointer.
             // GetIDWithSeed's two-pointer overload mirrors the public GetID(begin,end):
-            // both halves are required, so it is NOT a text_end wrapper case. One
-            // allow-list entry covers both GetIDWithSeed overloads (gate keys on the
-            // bare spelling). GetActiveID is deliberately NOT here — it is already
+            // both halves are required, so it is NOT a text_end wrapper case. FOOTGUN:
+            // begin/end must point into the SAME buffer — two distinct das strings
+            // compute a garbage end-begin (OOB read in ImGui's hash loop), exactly
+            // like public GetID(begin,end) (bound for parity, never called in-tree).
+            // For a seeded string ID from das, use with_override_id(seed){GetID(str)}.
+            // One allow-list entry covers both GetIDWithSeed overloads (gate keys on
+            // the bare spelling). GetActiveID is deliberately NOT here — it is already
             // bound via the das::GetActiveID manual wrapper (Phase 2.1, predates this
             // allow-list); re-adding it would double-bind "GetActiveID".
             "ImGui::GetFocusID", "ImGui::GetHoveredID",
             "ImGui::KeepAliveID", "ImGui::MarkItemEdited", "ImGui::PushOverrideID",
-            "ImGui::GetIDWithSeed", "ImGui::TreePushOverrideID"
+            "ImGui::GetIDWithSeed", "ImGui::TreePushOverrideID",
+            // Focus-scope + activation stack. Pure ImGuiID(uint)/int64/void — no
+            // internal struct/enum/pointer. PushFocusScope/PopFocusScope are a
+            // stack (v2 guard with_focus_scope, imgui_scope_builtin.das);
+            // GetCurrentFocusScope is inline (binds via the makeExtern
+            // address-taking path, like GetFocusID). SetNextItemSelectionUserData
+            // takes ImGuiSelectionUserData (typedef ImS64 -> int64 workhorse). The
+            // SetActiveID/SetFocusID/FocusTopMostWindowUnderOne neighbors take
+            // ImGuiWindow* and are correctly out of scope.
+            "ImGui::PushFocusScope", "ImGui::PopFocusScope", "ImGui::GetCurrentFocusScope",
+            "ImGui::FocusItem", "ImGui::ActivateItemByID", "ImGui::SetNextItemSelectionUserData"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_"

--- a/examples/features/internal_focus_scope.das
+++ b/examples/features/internal_focus_scope.das
@@ -71,12 +71,15 @@ def update() {
         FocusItem()
         separator()
 
-        // ActivateItemByID — queue an item (named by ID) to activate on the next
-        // frame, when that item is next submitted. Activation is the "press" state.
-        text("ActivateItemByID(id): queue an item to activate by ID (fires next frame).")
-        let act_id = GetID("activation_target")
+        // ActivateItemByID — queue an item (by ID) to activate on the next frame
+        // when it is next submitted. We render a real button, take its id via
+        // GetItemID(), and re-queue it every frame, so it stays in the activated
+        // (pressed) state — proof the queued activation actually applies.
+        text("ActivateItemByID(id): queue an item to activate by ID (applied next frame).")
+        button(ACT_TARGET, (text = "held active by ActivateItemByID"))
+        let act_id = GetItemID()
         ActivateItemByID(act_id)
-        text("  queued activation of id {hex8(act_id)} (applied when that item next renders)")
+        text("  re-activating the button above by its id {hex8(act_id)} each frame")
         separator()
 
         // SetNextItemSelectionUserData — tag the NEXT item with a multi-select

--- a/examples/features/internal_focus_scope.das
+++ b/examples/features/internal_focus_scope.das
@@ -1,0 +1,105 @@
+options gen2
+
+require imgui/imgui_harness
+require strings
+
+// =============================================================================
+// FEATURE: internal_focus_scope — the imgui_internal.h focus-scope / activation
+//          helpers. Cherry-picked into the v2 binding (bind_imgui.das
+//          internal_allow_func): PushFocusScope, PopFocusScope,
+//          GetCurrentFocusScope, FocusItem, ActivateItemByID,
+//          SetNextItemSelectionUserData. Host-agnostic — they group items into a
+//          focus scope (keyboard/gamepad nav + multi-select), focus/activate an
+//          item by ID, or tag the next item's selection data, all without v2 host
+//          state. This is the "binding is usable" gate: it calls the real bound
+//          API at runtime, not just compiles it.
+// SHOWS:   with_focus_scope (the new PushFocusScope/PopFocusScope guard) with
+//          GetCurrentFocusScope reading 0 outside the scope and the pushed id
+//          inside; FocusItem (focus the last-submitted item); ActivateItemByID
+//          (queue an item to activate by ID next frame); SetNextItemSelectionUserData
+//          (tag the next item with multi-select user-data).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_focus_scope.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_focus_scope.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_focus_scope.das
+// =============================================================================
+
+// ImGui IDs / focus-scope ids are conventionally shown as 8-digit hex.
+def private hex8(v : uint) : string {
+    let digits = "0123456789abcdef"
+    return build_string() $(var writer) {
+        writer |> write("0x")
+        for (i in range(8)) {
+            let nib = int((v >> uint((7 - i) * 4)) & 0xfu)
+            writer |> write(slice(digits, nib, nib + 1))
+        }
+    }
+}
+
+[export]
+def init() {
+    harness_init("internal_focus_scope - imgui_internal.h focus scope / activation", 760, 560)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(720.0, 520.0), ImGuiCond.Always)
+    window(FOCUS_WIN, (text = "internal_focus_scope", closable = false,
+                       flags = ImGuiWindowFlags.None)) {
+        // with_focus_scope + GetCurrentFocusScope — focus scopes group items for
+        // keyboard/gamepad nav and multi-select. GetCurrentFocusScope reads the
+        // scope id we are outputting into (0 at the top level).
+        text("with_focus_scope(id): group items into a focus scope (nav / multi-select).")
+        text("  outside any scope: GetCurrentFocusScope() = {hex8(GetCurrentFocusScope())}")
+        let scope_id = GetID("my_scope")
+        with_focus_scope(scope_id) {
+            text("  inside scope {hex8(scope_id)}: GetCurrentFocusScope() = {hex8(GetCurrentFocusScope())}")
+            button(IN_SCOPE_A, (text = "item A (in scope)"))
+            same_line()
+            button(IN_SCOPE_B, (text = "item B (in scope)"))
+        }
+        separator()
+
+        // FocusItem — focus the last-submitted item (the nav/keyboard target),
+        // without selecting or activating it.
+        text("FocusItem(): focuses the last item (the keyboard/gamepad nav target).")
+        button(FOCUS_TARGET, (text = "this button is programmatically focused"))
+        FocusItem()
+        separator()
+
+        // ActivateItemByID — queue an item (named by ID) to activate on the next
+        // frame, when that item is next submitted. Activation is the "press" state.
+        text("ActivateItemByID(id): queue an item to activate by ID (fires next frame).")
+        let act_id = GetID("activation_target")
+        ActivateItemByID(act_id)
+        text("  queued activation of id {hex8(act_id)} (applied when that item next renders)")
+        separator()
+
+        // SetNextItemSelectionUserData — tag the NEXT item with a multi-select
+        // user-data value (read back via the multi-select API / ImGuiItemFlags
+        // HasSelectionUserData). Here it tags a plain selectable.
+        text("SetNextItemSelectionUserData(data): tag the next item for multi-select.")
+        SetNextItemSelectionUserData(int64(42))
+        selectable(SEL_ITEM, (text = "selectable tagged with selection user-data 42"))
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/examples/features/internal_id_seed.das
+++ b/examples/features/internal_id_seed.das
@@ -8,8 +8,8 @@ require strings
 //          helpers. Cherry-picked into the v2 binding (bind_imgui.das
 //          internal_allow_func): GetIDWithSeed, GetFocusID, GetHoveredID,
 //          KeepAliveID, MarkItemEdited, PushOverrideID, TreePushOverrideID.
-//          Host-agnostic — they hash/seed an ImGuiID, query the active item ID,
-//          or push a raw ID onto the stack, all without v2 host state. This is
+//          Host-agnostic — they hash/seed an ImGuiID, query the hovered/focused
+//          item ID, or push a raw ID onto the stack, all without v2 host state. This is
 //          the "binding is usable" gate: it calls the real bound API at runtime.
 // SHOWS:   GetIDWithSeed(n, seed) (same int, different seed => different ID);
 //          with_override_id (the new PushOverrideID scope guard — GetID under a

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -56,6 +56,23 @@ void Module_dasIMGUI::initFunctions_30() {
 // from imgui_internal.h:3397:29
 	makeExtern< void (*)() , ImGui::PopItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopItemFlag","ImGui::PopItemFlag")
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3455:29
+	makeExtern< void (*)() , ImGui::FocusItem , SimNode_ExtFuncCall , imguiTempFn>(lib,"FocusItem","ImGui::FocusItem")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3456:29
+	makeExtern< void (*)(unsigned int) , ImGui::ActivateItemByID , SimNode_ExtFuncCall , imguiTempFn>(lib,"ActivateItemByID","ImGui::ActivateItemByID")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3608:29
+	makeExtern< void (*)(unsigned int) , ImGui::PushFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushFocusScope","ImGui::PushFocusScope")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3609:29
+	makeExtern< void (*)() , ImGui::PopFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopFocusScope","ImGui::PopFocusScope")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3610:29
+	makeExtern< unsigned int (*)() , ImGui::GetCurrentFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetCurrentFocusScope","ImGui::GetCurrentFocusScope")
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3617:29
 	makeExtern< void (*)(const ImRect &,const ImRect &) , ImGui::RenderDragDropTargetRect , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderDragDropTargetRect","ImGui::RenderDragDropTargetRect")
 		->args({"bb","item_clip_rect"})
@@ -75,34 +92,6 @@ void Module_dasIMGUI::initFunctions_30() {
 		->args({"p_min","p_max","fill_col","border","rounding"})
 		->arg_init(3,new ExprConstBool(true))
 		->arg_init(4,new ExprConstFloat(0))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3725:29
-	makeExtern< void (*)(ImVec2,ImVec2,float) , ImGui::RenderFrameBorder , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrameBorder","ImGui::RenderFrameBorder")
-		->args({"p_min","p_max","rounding"})
-		->arg_init(2,new ExprConstFloat(0))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3726:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,ImVec2,unsigned int,float,ImVec2,float,int) , ImGui::RenderColorRectWithAlphaCheckerboard , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderColorRectWithAlphaCheckerboard","ImGui::RenderColorRectWithAlphaCheckerboard")
-		->args({"draw_list","p_min","p_max","fill_col","grid_step","grid_off","rounding","flags"})
-		->arg_init(6,new ExprConstFloat(0))
-		->arg_type(7,makeType<ImDrawFlags_>(lib))
-		->arg_init(7,new ExprConstEnumeration(0,makeType<ImDrawFlags_>(lib)))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3727:29
-	makeExtern< void (*)(const ImRect &,unsigned int,int) , ImGui::RenderNavHighlight , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderNavHighlight","ImGui::RenderNavHighlight")
-		->args({"bb","id","flags"})
-		->arg_init(2,new ExprConstInt(0))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3729:29
-	makeExtern< void (*)(ImVec2,float,int,unsigned int,unsigned int,unsigned int) , ImGui::RenderMouseCursor , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderMouseCursor","ImGui::RenderMouseCursor")
-		->args({"pos","scale","mouse_cursor","col_fill","col_border","col_shadow"})
-		->arg_type(2,makeType<ImGuiMouseCursor_>(lib))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3732:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,int,float) , ImGui::RenderArrow , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrow","ImGui::RenderArrow")
-		->args({"draw_list","pos","col","dir","scale"})
-		->arg_type(3,makeType<ImGuiDir_>(lib))
-		->arg_init(4,new ExprConstFloat(1))
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_31.cpp
+++ b/src/dasIMGUI.func_31.cpp
@@ -12,6 +12,34 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_31() {
+// from imgui_internal.h:3725:29
+	makeExtern< void (*)(ImVec2,ImVec2,float) , ImGui::RenderFrameBorder , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrameBorder","ImGui::RenderFrameBorder")
+		->args({"p_min","p_max","rounding"})
+		->arg_init(2,new ExprConstFloat(0))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3726:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,ImVec2,unsigned int,float,ImVec2,float,int) , ImGui::RenderColorRectWithAlphaCheckerboard , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderColorRectWithAlphaCheckerboard","ImGui::RenderColorRectWithAlphaCheckerboard")
+		->args({"draw_list","p_min","p_max","fill_col","grid_step","grid_off","rounding","flags"})
+		->arg_init(6,new ExprConstFloat(0))
+		->arg_type(7,makeType<ImDrawFlags_>(lib))
+		->arg_init(7,new ExprConstEnumeration(0,makeType<ImDrawFlags_>(lib)))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3727:29
+	makeExtern< void (*)(const ImRect &,unsigned int,int) , ImGui::RenderNavHighlight , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderNavHighlight","ImGui::RenderNavHighlight")
+		->args({"bb","id","flags"})
+		->arg_init(2,new ExprConstInt(0))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3729:29
+	makeExtern< void (*)(ImVec2,float,int,unsigned int,unsigned int,unsigned int) , ImGui::RenderMouseCursor , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderMouseCursor","ImGui::RenderMouseCursor")
+		->args({"pos","scale","mouse_cursor","col_fill","col_border","col_shadow"})
+		->arg_type(2,makeType<ImGuiMouseCursor_>(lib))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3732:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,int,float) , ImGui::RenderArrow , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrow","ImGui::RenderArrow")
+		->args({"draw_list","pos","col","dir","scale"})
+		->arg_type(3,makeType<ImGuiDir_>(lib))
+		->arg_init(4,new ExprConstFloat(1))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3733:29
 	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int) , ImGui::RenderBullet , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderBullet","ImGui::RenderBullet")
 		->args({"draw_list","pos","col"})
@@ -40,6 +68,10 @@ void Module_dasIMGUI::initFunctions_31() {
 // from imgui_internal.h:3767:29
 	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
 		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3770:29
+	makeExtern< void (*)(ImGuiSelectionUserData) , ImGui::SetNextItemSelectionUserData , SimNode_ExtFuncCall , imguiTempFn>(lib,"SetNextItemSelectionUserData","ImGui::SetNextItemSelectionUserData")
+		->args({"selection_user_data"})
 		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3807:29
 	makeExtern< void (*)(ImDrawList *,int,int,ImVec2,ImVec2,unsigned int,unsigned int) , ImGui::ShadeVertsLinearColorGradientKeepAlpha , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearColorGradientKeepAlpha","ImGui::ShadeVertsLinearColorGradientKeepAlpha")

--- a/widgets/imgui_id_builtin.das
+++ b/widgets/imgui_id_builtin.das
@@ -18,10 +18,9 @@ def public with_id(s : string; blk : block) {
 }
 
 def public with_override_id(id : uint; blk : block) {
-    //! Run ``blk`` with raw ``id`` pushed via ``PushOverrideID`` (as-is, NOT
-    //! hash-combined like ``with_id``), popped on return. For stable, explicitly
-    //! controlled IDs — custom widgets, addressing into ImGuiStorage, or seeding a
-    //! string ID (``GetID`` under the override equals ``GetIDWithSeed(.., id)``).
+    //! Like ``with_id`` but pushes ``id`` onto the ID stack RAW (as-is, not hashed),
+    //! always popping on return. Use it to pin an exact, stable ID — one that
+    //! survives renaming the widget; ``GetID`` under it equals ``GetIDWithSeed(.., id)``.
     container_path_push("{id}")
     PushOverrideID(id)
     invoke(blk)

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -45,7 +45,7 @@ let private ALLOWED_IMGUI : table<string> <- {
     "GetIO", "GetStyle", "GetVersion",
     "IsItemHovered", "IsItemActive", "IsItemClicked", "IsItemFocused",
     "IsItemActivated", "IsItemDeactivated", "IsItemDeactivatedAfterEdit",
-    "IsItemToggledOpen", "IsItemVisible", "IsItemEdited",
+    "IsItemToggledOpen", "IsItemVisible", "IsItemEdited", "GetItemID",
     "IsAnyItemHovered", "IsAnyItemActive", "IsAnyItemFocused",
     "IsWindowFocused", "IsWindowHovered",
     // Mouse / keyboard state queries — pure reads, no widget host.
@@ -147,7 +147,7 @@ let private ALLOWED_IMGUI : table<string> <- {
     "RenderDragDropTargetRect", "RenderNavHighlight",
     "RenderRectFilledRangeH", "RenderRectFilledWithHole",
     // ID-stack seed / override helpers cherry-picked from imgui_internal.h.
-    // Host-agnostic: hash/seed an ImGuiID, query the active/hovered/focus ID, or
+    // Host-agnostic: hash/seed an ImGuiID, query the hovered/focus ID, or
     // push a raw override onto the ID stack. Bound via bind_imgui.das
     // internal_allow_func. GetActiveID is bound separately (das::GetActiveID wrapper).
     "GetFocusID", "GetHoveredID", "KeepAliveID", "MarkItemEdited",

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -151,7 +151,13 @@ let private ALLOWED_IMGUI : table<string> <- {
     // push a raw override onto the ID stack. Bound via bind_imgui.das
     // internal_allow_func. GetActiveID is bound separately (das::GetActiveID wrapper).
     "GetFocusID", "GetHoveredID", "KeepAliveID", "MarkItemEdited",
-    "PushOverrideID", "GetIDWithSeed", "TreePushOverrideID"
+    "PushOverrideID", "GetIDWithSeed", "TreePushOverrideID",
+    // Focus-scope + activation stack cherry-picked from imgui_internal.h.
+    // Host-agnostic: push/query a focus scope (nav + multi-select grouping),
+    // focus/activate an item by ID, or set the next item's selection user-data.
+    // Bound via bind_imgui.das internal_allow_func; v2 guard with_focus_scope.
+    "PushFocusScope", "PopFocusScope", "GetCurrentFocusScope",
+    "FocusItem", "ActivateItemByID", "SetNextItemSelectionUserData"
 }
 
 class ImguiLintVisitor : AstVisitor {

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -84,7 +84,7 @@ def public with_item_flag(flag : ImGuiItemFlags; enabled : bool; blk : block) {
 
 def public with_focus_scope(id : uint; blk : block) {
     //! Run ``blk`` inside focus scope ``id`` (``PushFocusScope``); matching ``PopFocusScope()`` on return.
-    //! Focus scopes group items for keyboard/gamepad nav and multi-select; ``id`` is a raw ImGuiID (e.g. ``GetID("list")``).
+    //! Focus scopes group items for keyboard/gamepad nav and multi-select; ``id`` is an ImGuiID (uint), e.g. ``GetID("list")``.
     PushFocusScope(id)
     invoke(blk)
     PopFocusScope()

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -81,3 +81,11 @@ def public with_item_flag(flag : ImGuiItemFlags; enabled : bool; blk : block) {
     invoke(blk)
     PopItemFlag()
 }
+
+def public with_focus_scope(id : uint; blk : block) {
+    //! Run ``blk`` inside focus scope ``id`` (``PushFocusScope``); matching ``PopFocusScope()`` on return.
+    //! Focus scopes group items for keyboard/gamepad nav and multi-select; ``id`` is a raw ImGuiID (e.g. ``GetID("list")``).
+    PushFocusScope(id)
+    invoke(blk)
+    PopFocusScope()
+}


### PR DESCRIPTION
Next `imgui_internal.h` family after #169 — the **focus-scope / activation stack** (rank 2 from the survey: *bindable-as-is*, low cost, no new C++ wrapper).

## What's bound

Added to `internal_allow_func` (regen only):

| daslang | C++ signature |
|---|---|
| `PushFocusScope(id)` / `PopFocusScope()` | `void(ImGuiID)` / `void()` |
| `GetCurrentFocusScope()` | `ImGuiID()` |
| `FocusItem()` | `void()` |
| `ActivateItemByID(id)` | `void(ImGuiID)` |
| `SetNextItemSelectionUserData(data)` | `void(ImGuiSelectionUserData)` |

All host-agnostic, already-bound types: `ImGuiID → uint`, `void`, and `ImGuiSelectionUserData` (`typedef ImS64 → int64` workhorse — verified the binding accepts `int64`). `GetCurrentFocusScope` is `inline`-without-`IMGUI_API` and binds via the `makeExtern` address-taking path, same as `GetFocusID` in #169. The `SetActiveID` / `SetFocusID` / `FocusTopMostWindowUnderOne` neighbors take `ImGuiWindow*` and are correctly out of scope.

## New guard

`PushFocusScope`/`PopFocusScope` are a stack, so this adds the `with_focus_scope(id, blk)` guard — the focus-scope mirror of `with_item_flag` (same `imgui_scope_builtin.das`, same Push/invoke/Pop shape). That module isn't doc-generated (like `with_item_flag`), so no imgui2rst.das categorization is needed.

## Folds in the two deferred #169 review nits (bundle-doc-nits rule)

- **`with_override_id` docstring** rewritten in plainer language (was jargon-heavy) — "like `with_id` but pushes `id` RAW (not hashed), always pops; pins an exact ID that survives renaming."
- **`bind_imgui.das`** now documents the `GetIDWithSeed(begin, end, seed)` same-buffer footgun *at the allow-list entry*, pointing to `with_override_id(seed) { GetID(str) }`.
- **`internal_id_seed.das`** header: "active item ID" → "hovered/focused item ID" (it doesn't bind `GetActiveID`).

## Verification

- Regenerated via the junction trick; net **+6 makeExterns**, chunk-reflow verified (every function removed from func_30 reappears in func_31 — nothing lost, no new func chunk → CMakeLists untouched). EOL-only `.inc` churn reverted.
- Rebuilt `dasModuleImgui.shared_module` on Windows (MSVC).
- New `examples/features/internal_focus_scope.das` exercises all 6 members (scope guard + `GetCurrentFocusScope` read, `FocusItem`, `ActivateItemByID`, `SetNextItemSelectionUserData`) — clean headless (`exit 0`).
- **Docs gate checked locally this time** (`imgui2rst.das` regen → `grep '^Uncategorized$'` = none) so the docs CI won't trip like #169 did.
- `format --verify` + lint clean on all 6 changed `.das` (pre-push hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)