### PR TITLE
imgui: bind internal popup / tooltip / menu *Ex entry points (family)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ SET(DAS_IMGUI_BIND_SRC
     ${DAS_IMGUI_DIR}/src/dasIMGUI.func_29.cpp
     ${DAS_IMGUI_DIR}/src/dasIMGUI.func_30.cpp
     ${DAS_IMGUI_DIR}/src/dasIMGUI.func_31.cpp
+    ${DAS_IMGUI_DIR}/src/dasIMGUI.func_32.cpp
 )
 
 # imgui app source files

--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -197,10 +197,29 @@ class ImguiGen : CppGenBind {
             // SetActiveID/SetFocusID/FocusTopMostWindowUnderOne neighbors take
             // ImGuiWindow* and are correctly out of scope.
             "ImGui::PushFocusScope", "ImGui::PopFocusScope", "ImGui::GetCurrentFocusScope",
-            "ImGui::FocusItem", "ImGui::ActivateItemByID", "ImGui::SetNextItemSelectionUserData"
+            "ImGui::FocusItem", "ImGui::ActivateItemByID", "ImGui::SetNextItemSelectionUserData",
+            // Internal popup / tooltip / menu *Ex entry points. All host-agnostic:
+            // ImGuiID(uint), ImGuiPopupFlags / ImGuiWindowFlags (public enums),
+            // int/bool/const char*, plus ImGuiTooltipFlags_ (internal enum, added to
+            // internal_allow_enum below — one real flag, OverridePrevious). Bound raw,
+            // like the Render* batch — the public popup/menu/tooltip *containers*
+            // already wrap the public Begin/End; these are the lower-level escape
+            // hatches (raw-id popups pairing with #169's with_override_id/GetID,
+            // icon-column menus, override-previous tooltips, popup-stack management).
+            // IsPopupOpen is an overload of the public const char* version; the
+            // makeExtern explicit-signature template arg disambiguates the
+            // address-taking (same as the two GetIDWithSeed overloads). The Begin*Ex
+            // pair with the already-public End* (EndPopup/EndTooltip/EndMenu). The
+            // ClosePopupsOverWindow / GetTopMost*PopupModal / FindBlockingModal /
+            // FindBestWindowPosForPopup* / GetPopupAllowedExtentRect neighbors take or
+            // return ImGuiWindow* and are correctly out of scope.
+            "ImGui::OpenPopupEx", "ImGui::ClosePopupToLevel", "ImGui::ClosePopupsExceptModals",
+            "ImGui::IsPopupOpen", "ImGui::BeginPopupEx",
+            "ImGui::BeginTooltipEx", "ImGui::BeginTooltipHidden",
+            "ImGui::BeginMenuEx", "ImGui::MenuItemEx"
         }
         internal_allow_enum <- {
-            "ImGuiItemFlags_", "ImGuiNavHighlightFlags_"
+            "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_popup_menu_ex.das
+++ b/examples/features/internal_popup_menu_ex.das
@@ -1,0 +1,140 @@
+options gen2
+
+require imgui/imgui_harness
+require strings
+
+// =============================================================================
+// FEATURE: internal_popup_menu_ex — the imgui_internal.h popup / tooltip / menu
+//          *Ex entry points. Cherry-picked into the v2 binding (bind_imgui.das
+//          internal_allow_func): OpenPopupEx, ClosePopupToLevel,
+//          ClosePopupsExceptModals, IsPopupOpen (raw-ImGuiID overload),
+//          BeginPopupEx, BeginTooltipEx, BeginTooltipHidden, BeginMenuEx,
+//          MenuItemEx. The four Begin*Ex pair with the public End* and are
+//          surfaced as the unbalance-proof with_popup_ex / with_tooltip_ex /
+//          with_tooltip_hidden / with_menu_ex guards (imgui_scope_builtin.das);
+//          the five one-shots are raw on the ALLOWED_IMGUI allow-list. This is
+//          the "binding is usable" gate: it calls the real bound API at runtime,
+//          not just compiles it.
+// SHOWS:   with_menu_ex (icon-column submenu) + MenuItemEx (icon + shortcut menu
+//          item) in a menu bar; OpenPopupEx + IsPopupOpen + with_popup_ex driving
+//          a popup by a precomputed ImGuiID (from GetID); ClosePopupToLevel /
+//          ClosePopupsExceptModals popup-stack control; with_tooltip_ex
+//          (OverridePrevious) on hover; with_tooltip_hidden measuring offscreen.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_popup_menu_ex.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_popup_menu_ex.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_popup_menu_ex.das
+// =============================================================================
+
+// ImGui IDs are conventionally shown as 8-digit hex.
+def private hex8(v : uint) : string {
+    let digits = "0123456789abcdef"
+    return build_string() $(var writer) {
+        writer |> write("0x")
+        for (i in range(8)) {
+            let nib = int((v >> uint((7 - i) * 4)) & 0xfu)
+            writer |> write(slice(digits, nib, nib + 1))
+        }
+    }
+}
+
+// Auto-open the raw-id popup once so the popup path runtime-exercises headlessly
+// (no click available); the "Open" button drives it interactively otherwise.
+var g_first_frame = true
+var g_last_menu_action = "(none yet)"
+
+[export]
+def init() {
+    harness_init("internal_popup_menu_ex - imgui_internal.h popup / tooltip / menu *Ex", 780, 600)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(740.0, 560.0), ImGuiCond.Always)
+    window(MAIN_WIN, (text = "internal_popup_menu_ex", closable = false,
+                      flags = ImGuiWindowFlags.MenuBar)) {
+
+        // ----- menu bar: with_menu_ex (icon submenu) + MenuItemEx (icon items) -----
+        // BeginMenuEx adds an icon column the public BeginMenu lacks; the body is
+        // the dropdown. The inner MenuItemEx carries icon + shortcut columns.
+        menu_bar(BAR) {
+            with_menu_ex("File", "F", true) {
+                if (MenuItemEx("New", "N", "Ctrl+N", false, true)) {
+                    g_last_menu_action = "File / New"
+                }
+                if (MenuItemEx("Open", "O", "Ctrl+O", false, true)) {
+                    g_last_menu_action = "File / Open"
+                }
+            }
+            with_menu_ex("Edit", "E", true) {
+                if (MenuItemEx("Copy", "C", "Ctrl+C", false, true)) {
+                    g_last_menu_action = "Edit / Copy"
+                }
+            }
+        }
+        text("with_menu_ex / MenuItemEx — last menu action: {g_last_menu_action}")
+        separator()
+
+        // ----- raw-ImGuiID popup: OpenPopupEx / IsPopupOpen / with_popup_ex -----
+        // The public popup container hashes a string id internally; the *Ex path
+        // takes a precomputed ImGuiID, so it pairs with GetID / with_override_id.
+        let pop_id = GetID("raw_id_popup")
+        text("popup id (GetID) = {hex8(pop_id)}; IsPopupOpen = {IsPopupOpen(pop_id, ImGuiPopupFlags.None)}")
+        if (button(OPEN_POPUP_BTN, (text = "OpenPopupEx(pop_id)"))) {
+            OpenPopupEx(pop_id, ImGuiPopupFlags.None)
+        }
+        if (g_first_frame) {
+            OpenPopupEx(pop_id, ImGuiPopupFlags.None)
+            g_first_frame = false
+        }
+        with_popup_ex(pop_id, ImGuiWindowFlags.None) {
+            text("raw-id popup body (with_popup_ex / BeginPopupEx)")
+            // MenuItemEx works inside popups too (context-menu styling).
+            if (MenuItemEx("Close to level 0", "X", "", false, true)) {
+                // Safe: we are inside the popup, so the stack has >= 1 level.
+                ClosePopupToLevel(0, true)
+            }
+            if (button(CLOSE_CUR_BTN, (text = "close_current_popup"))) {
+                close_current_popup()
+            }
+        }
+        if (button(CLOSE_ALL_BTN, (text = "ClosePopupsExceptModals()"))) {
+            ClosePopupsExceptModals()
+        }
+        separator()
+
+        // ----- tooltips: with_tooltip_ex (OverridePrevious) + with_tooltip_hidden -----
+        text("Hover me for an OverridePrevious tooltip (with_tooltip_ex)")
+        if (IsItemHovered()) {
+            with_tooltip_ex(ImGuiTooltipFlags.OverridePrevious, ImGuiWindowFlags.None) {
+                text("tooltip via with_tooltip_ex — replaces, not appends")
+            }
+        }
+        // with_tooltip_hidden begins an off-screen tooltip purely to MEASURE its
+        // content; nothing is shown. Run every frame to exercise the binding.
+        with_tooltip_hidden() {
+            text("measured offscreen by with_tooltip_hidden")
+        }
+        text("with_tooltip_hidden ran (offscreen measure — nothing shown)")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -38,6 +38,7 @@ addEnumeration(new Enumeration_ImDrawListFlags_());
 addEnumeration(new Enumeration_ImFontAtlasFlags_());
 addEnumeration(new Enumeration_ImGuiViewportFlags_());
 addEnumeration(new Enumeration_ImGuiItemFlags_());
+addEnumeration(new Enumeration_ImGuiTooltipFlags_());
 addEnumeration(new Enumeration_ImGuiNavHighlightFlags_());
 addEnumFlagOps<ImGuiWindowFlags_>(*this,lib,"ImGuiWindowFlags_");
 addEnumFlagOps<ImGuiChildFlags_>(*this,lib,"ImGuiChildFlags_");

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1033,6 +1033,18 @@ public:
 	}
 };
 
+// from imgui_internal.h:970:6
+class Enumeration_ImGuiTooltipFlags_ : public das::Enumeration {
+public:
+	Enumeration_ImGuiTooltipFlags_() : das::Enumeration("ImGuiTooltipFlags") {
+		external = true;
+		cppName = "ImGuiTooltipFlags_";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("None", "ImGuiTooltipFlags_None", int64_t(ImGuiTooltipFlags_::ImGuiTooltipFlags_None), das::LineInfo());
+		addIEx("OverridePrevious", "ImGuiTooltipFlags_OverridePrevious", int64_t(ImGuiTooltipFlags_::ImGuiTooltipFlags_OverridePrevious), das::LineInfo());
+	}
+};
+
 // from imgui_internal.h:1594:6
 class Enumeration_ImGuiNavHighlightFlags_ : public das::Enumeration {
 public:

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -39,4 +39,5 @@ DAS_BIND_ENUM_CAST(ImDrawListFlags_);
 DAS_BIND_ENUM_CAST(ImFontAtlasFlags_);
 DAS_BIND_ENUM_CAST(ImGuiViewportFlags_);
 DAS_BIND_ENUM_CAST(ImGuiItemFlags_);
+DAS_BIND_ENUM_CAST(ImGuiTooltipFlags_);
 DAS_BIND_ENUM_CAST(ImGuiNavHighlightFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -75,5 +75,7 @@ DAS_BASE_BIND_ENUM_GEN(ImGuiViewportFlags_,ImGuiViewportFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiItemFlags_,ImGuiItemFlags);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiTooltipFlags_,ImGuiTooltipFlags);
+
 DAS_BASE_BIND_ENUM_GEN(ImGuiNavHighlightFlags_,ImGuiNavHighlightFlags);
 

--- a/src/dasIMGUI.func.decl.inc
+++ b/src/dasIMGUI.func.decl.inc
@@ -32,3 +32,4 @@ void initFunctions_28();
 void initFunctions_29();
 void initFunctions_30();
 void initFunctions_31();
+void initFunctions_32();

--- a/src/dasIMGUI.func.reg.inc
+++ b/src/dasIMGUI.func.reg.inc
@@ -32,3 +32,4 @@ initFunctions_28();
 initFunctions_29();
 initFunctions_30();
 initFunctions_31();
+initFunctions_32();

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -56,42 +56,48 @@ void Module_dasIMGUI::initFunctions_30() {
 // from imgui_internal.h:3397:29
 	makeExtern< void (*)() , ImGui::PopItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopItemFlag","ImGui::PopItemFlag")
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3455:29
-	makeExtern< void (*)() , ImGui::FocusItem , SimNode_ExtFuncCall , imguiTempFn>(lib,"FocusItem","ImGui::FocusItem")
+// from imgui_internal.h:3408:29
+	makeExtern< void (*)(unsigned int,int) , ImGui::OpenPopupEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"OpenPopupEx","ImGui::OpenPopupEx")
+		->args({"id","popup_flags"})
+		->arg_type(1,makeType<ImGuiPopupFlags_>(lib))
+		->arg_init(1,new ExprConstEnumeration(0,makeType<ImGuiPopupFlags_>(lib)))
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3456:29
-	makeExtern< void (*)(unsigned int) , ImGui::ActivateItemByID , SimNode_ExtFuncCall , imguiTempFn>(lib,"ActivateItemByID","ImGui::ActivateItemByID")
-		->args({"id"})
+// from imgui_internal.h:3409:29
+	makeExtern< void (*)(int,bool) , ImGui::ClosePopupToLevel , SimNode_ExtFuncCall , imguiTempFn>(lib,"ClosePopupToLevel","ImGui::ClosePopupToLevel")
+		->args({"remaining","restore_focus_to_window_under_popup"})
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3608:29
-	makeExtern< void (*)(unsigned int) , ImGui::PushFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushFocusScope","ImGui::PushFocusScope")
-		->args({"id"})
+// from imgui_internal.h:3411:29
+	makeExtern< void (*)() , ImGui::ClosePopupsExceptModals , SimNode_ExtFuncCall , imguiTempFn>(lib,"ClosePopupsExceptModals","ImGui::ClosePopupsExceptModals")
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3609:29
-	makeExtern< void (*)() , ImGui::PopFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopFocusScope","ImGui::PopFocusScope")
+// from imgui_internal.h:3412:29
+	makeExtern< bool (*)(unsigned int,int) , ImGui::IsPopupOpen , SimNode_ExtFuncCall , imguiTempFn>(lib,"IsPopupOpen","ImGui::IsPopupOpen")
+		->args({"id","popup_flags"})
+		->arg_type(1,makeType<ImGuiPopupFlags_>(lib))
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3610:29
-	makeExtern< unsigned int (*)() , ImGui::GetCurrentFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetCurrentFocusScope","ImGui::GetCurrentFocusScope")
+// from imgui_internal.h:3413:29
+	makeExtern< bool (*)(unsigned int,int) , ImGui::BeginPopupEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginPopupEx","ImGui::BeginPopupEx")
+		->args({"id","extra_flags"})
+		->arg_type(1,makeType<ImGuiWindowFlags_>(lib))
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3617:29
-	makeExtern< void (*)(const ImRect &,const ImRect &) , ImGui::RenderDragDropTargetRect , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderDragDropTargetRect","ImGui::RenderDragDropTargetRect")
-		->args({"bb","item_clip_rect"})
+// from imgui_internal.h:3414:29
+	makeExtern< bool (*)(int,int) , ImGui::BeginTooltipEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginTooltipEx","ImGui::BeginTooltipEx")
+		->args({"tooltip_flags","extra_window_flags"})
+		->arg_type(1,makeType<ImGuiWindowFlags_>(lib))
 		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3719:29
-	makeExtern< void (*)(ImVec2,const char *,const char *,bool) , ImGui::RenderText , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderText","ImGui::RenderText")
-		->args({"pos","text","text_end","hide_text_after_hash"})
+// from imgui_internal.h:3415:29
+	makeExtern< bool (*)() , ImGui::BeginTooltipHidden , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginTooltipHidden","ImGui::BeginTooltipHidden")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3425:29
+	makeExtern< bool (*)(const char *,const char *,bool) , ImGui::BeginMenuEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginMenuEx","ImGui::BeginMenuEx")
+		->args({"label","icon","enabled"})
+		->arg_init(2,new ExprConstBool(true))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3426:29
+	makeExtern< bool (*)(const char *,const char *,const char *,bool,bool) , ImGui::MenuItemEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"MenuItemEx","ImGui::MenuItemEx")
+		->args({"label","icon","shortcut","selected","enabled"})
 		->arg_init(2,new ExprConstString(""))
-		->arg_init(3,new ExprConstBool(true))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3720:29
-	makeExtern< void (*)(ImVec2,const char *,const char *,float) , ImGui::RenderTextWrapped , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderTextWrapped","ImGui::RenderTextWrapped")
-		->args({"pos","text","text_end","wrap_width"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3724:29
-	makeExtern< void (*)(ImVec2,ImVec2,unsigned int,bool,float) , ImGui::RenderFrame , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrame","ImGui::RenderFrame")
-		->args({"p_min","p_max","fill_col","border","rounding"})
-		->arg_init(3,new ExprConstBool(true))
-		->arg_init(4,new ExprConstFloat(0))
+		->arg_init(3,new ExprConstBool(false))
+		->arg_init(4,new ExprConstBool(true))
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_31.cpp
+++ b/src/dasIMGUI.func_31.cpp
@@ -12,6 +12,43 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_31() {
+// from imgui_internal.h:3455:29
+	makeExtern< void (*)() , ImGui::FocusItem , SimNode_ExtFuncCall , imguiTempFn>(lib,"FocusItem","ImGui::FocusItem")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3456:29
+	makeExtern< void (*)(unsigned int) , ImGui::ActivateItemByID , SimNode_ExtFuncCall , imguiTempFn>(lib,"ActivateItemByID","ImGui::ActivateItemByID")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3608:29
+	makeExtern< void (*)(unsigned int) , ImGui::PushFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"PushFocusScope","ImGui::PushFocusScope")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3609:29
+	makeExtern< void (*)() , ImGui::PopFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopFocusScope","ImGui::PopFocusScope")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3610:29
+	makeExtern< unsigned int (*)() , ImGui::GetCurrentFocusScope , SimNode_ExtFuncCall , imguiTempFn>(lib,"GetCurrentFocusScope","ImGui::GetCurrentFocusScope")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3617:29
+	makeExtern< void (*)(const ImRect &,const ImRect &) , ImGui::RenderDragDropTargetRect , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderDragDropTargetRect","ImGui::RenderDragDropTargetRect")
+		->args({"bb","item_clip_rect"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3719:29
+	makeExtern< void (*)(ImVec2,const char *,const char *,bool) , ImGui::RenderText , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderText","ImGui::RenderText")
+		->args({"pos","text","text_end","hide_text_after_hash"})
+		->arg_init(2,new ExprConstString(""))
+		->arg_init(3,new ExprConstBool(true))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3720:29
+	makeExtern< void (*)(ImVec2,const char *,const char *,float) , ImGui::RenderTextWrapped , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderTextWrapped","ImGui::RenderTextWrapped")
+		->args({"pos","text","text_end","wrap_width"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3724:29
+	makeExtern< void (*)(ImVec2,ImVec2,unsigned int,bool,float) , ImGui::RenderFrame , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrame","ImGui::RenderFrame")
+		->args({"p_min","p_max","fill_col","border","rounding"})
+		->arg_init(3,new ExprConstBool(true))
+		->arg_init(4,new ExprConstFloat(0))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3725:29
 	makeExtern< void (*)(ImVec2,ImVec2,float) , ImGui::RenderFrameBorder , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderFrameBorder","ImGui::RenderFrameBorder")
 		->args({"p_min","p_max","rounding"})
@@ -64,26 +101,6 @@ void Module_dasIMGUI::initFunctions_31() {
 // from imgui_internal.h:3738:29
 	makeExtern< void (*)(ImDrawList *,const ImRect &,const ImRect &,unsigned int,float) , ImGui::RenderRectFilledWithHole , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledWithHole","ImGui::RenderRectFilledWithHole")
 		->args({"draw_list","outer","inner","col","rounding"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3767:29
-	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
-		->args({"id"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3770:29
-	makeExtern< void (*)(ImGuiSelectionUserData) , ImGui::SetNextItemSelectionUserData , SimNode_ExtFuncCall , imguiTempFn>(lib,"SetNextItemSelectionUserData","ImGui::SetNextItemSelectionUserData")
-		->args({"selection_user_data"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3807:29
-	makeExtern< void (*)(ImDrawList *,int,int,ImVec2,ImVec2,unsigned int,unsigned int) , ImGui::ShadeVertsLinearColorGradientKeepAlpha , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearColorGradientKeepAlpha","ImGui::ShadeVertsLinearColorGradientKeepAlpha")
-		->args({"draw_list","vert_start_idx","vert_end_idx","gradient_p0","gradient_p1","col0","col1"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3808:29
-	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,const ImVec2 &,const ImVec2 &,const ImVec2 &,bool) , ImGui::ShadeVertsLinearUV , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearUV","ImGui::ShadeVertsLinearUV")
-		->args({"draw_list","vert_start_idx","vert_end_idx","a","b","uv_a","uv_b","clamp"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3809:29
-	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,float,float,const ImVec2 &) , ImGui::ShadeVertsTransformPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsTransformPos","ImGui::ShadeVertsTransformPos")
-		->args({"draw_list","vert_start_idx","vert_end_idx","pivot_in","cos_a","sin_a","pivot_out"})
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -1,0 +1,37 @@
+// this file is generated via Daslang automatic binder
+// all user modifications will be lost after this file is re-generated
+
+#include "daScript/misc/platform.h"
+#include "daScript/ast/ast.h"
+#include "daScript/ast/ast_interop.h"
+#include "daScript/ast/ast_handle.h"
+#include "daScript/ast/ast_typefactory_bind.h"
+#include "daScript/simulate/bind_enum.h"
+#include "dasIMGUI.h"
+#include "need_dasIMGUI.h"
+namespace das {
+#include "dasIMGUI.func.aot.decl.inc"
+void Module_dasIMGUI::initFunctions_32() {
+// from imgui_internal.h:3767:29
+	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
+		->args({"id"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3770:29
+	makeExtern< void (*)(ImGuiSelectionUserData) , ImGui::SetNextItemSelectionUserData , SimNode_ExtFuncCall , imguiTempFn>(lib,"SetNextItemSelectionUserData","ImGui::SetNextItemSelectionUserData")
+		->args({"selection_user_data"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3807:29
+	makeExtern< void (*)(ImDrawList *,int,int,ImVec2,ImVec2,unsigned int,unsigned int) , ImGui::ShadeVertsLinearColorGradientKeepAlpha , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearColorGradientKeepAlpha","ImGui::ShadeVertsLinearColorGradientKeepAlpha")
+		->args({"draw_list","vert_start_idx","vert_end_idx","gradient_p0","gradient_p1","col0","col1"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3808:29
+	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,const ImVec2 &,const ImVec2 &,const ImVec2 &,bool) , ImGui::ShadeVertsLinearUV , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsLinearUV","ImGui::ShadeVertsLinearUV")
+		->args({"draw_list","vert_start_idx","vert_end_idx","a","b","uv_a","uv_b","clamp"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3809:29
+	makeExtern< void (*)(ImDrawList *,int,int,const ImVec2 &,float,float,const ImVec2 &) , ImGui::ShadeVertsTransformPos , SimNode_ExtFuncCall , imguiTempFn>(lib,"ShadeVertsTransformPos","ImGui::ShadeVertsTransformPos")
+		->args({"draw_list","vert_start_idx","vert_end_idx","pivot_in","cos_a","sin_a","pivot_out"})
+		->addToModule(*this, SideEffects::worstDefault);
+}
+}
+

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -157,7 +157,19 @@ let private ALLOWED_IMGUI : table<string> <- {
     // focus/activate an item by ID, or set the next item's selection user-data.
     // Bound via bind_imgui.das internal_allow_func; v2 guard with_focus_scope.
     "PushFocusScope", "PopFocusScope", "GetCurrentFocusScope",
-    "FocusItem", "ActivateItemByID", "SetNextItemSelectionUserData"
+    "FocusItem", "ActivateItemByID", "SetNextItemSelectionUserData",
+    // Internal popup / tooltip / menu *Ex one-shots cherry-picked from
+    // imgui_internal.h. Host-agnostic escape hatches below the public
+    // popup/menu/tooltip wrappers: open/query/close popups by raw ImGuiID,
+    // manage the popup stack, submit an icon/shortcut menu item. Bound via
+    // bind_imgui.das internal_allow_func. The Begin*Ex (BeginPopupEx /
+    // BeginTooltipEx / BeginTooltipHidden / BeginMenuEx) are NOT here — they
+    // pair with the public End* and are surfaced as the unbalance-proof
+    // with_popup_ex / with_tooltip_ex / with_tooltip_hidden / with_menu_ex
+    // guards (imgui_scope_builtin.das). MenuItemEx is the icon/shortcut
+    // escape hatch alongside the wrapped `menu_item` widget.
+    "OpenPopupEx", "ClosePopupToLevel", "ClosePopupsExceptModals",
+    "IsPopupOpen", "MenuItemEx"
 }
 
 class ImguiLintVisitor : AstVisitor {

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -89,3 +89,52 @@ def public with_focus_scope(id : uint; blk : block) {
     invoke(blk)
     PopFocusScope()
 }
+
+def public with_popup_ex(id : uint; window_flags : ImGuiWindowFlags; blk : block) : bool {
+    //! `BeginPopupEx(id, window_flags)` / `EndPopup()` — only-on-true. Lower-level
+    //! `popup` for a precomputed ImGuiID (e.g. from ``with_override_id``/``GetID``);
+    //! the popup must already be open (``OpenPopupEx(id)``). Returns whether it is open.
+    let opened = BeginPopupEx(id, window_flags)
+    if (opened) {
+        invoke(blk)
+        EndPopup()
+    }
+    return opened
+}
+
+def public with_tooltip_ex(tooltip_flags : ImGuiTooltipFlags; window_flags : ImGuiWindowFlags; blk : block) : bool {
+    //! `BeginTooltipEx(tooltip_flags, window_flags)` / `EndTooltip()` — only-on-true.
+    //! Like `tooltip` but with flag control: ``ImGuiTooltipFlags.OverridePrevious``
+    //! replaces an already-submitted tooltip instead of appending. Returns whether it opened.
+    // ImGuiTooltipFlags is an internal enum (no arg-remap), so it binds as int;
+    // ImGuiWindowFlags is a public flag enum that binds as the enum type.
+    let opened = BeginTooltipEx(int(tooltip_flags), window_flags)
+    if (opened) {
+        invoke(blk)
+        EndTooltip()
+    }
+    return opened
+}
+
+def public with_tooltip_hidden(blk : block) : bool {
+    //! `BeginTooltipHidden()` / `EndTooltip()` — only-on-true. Begins an off-screen
+    //! tooltip used to MEASURE content (its rect) without showing it. Returns whether it opened.
+    let opened = BeginTooltipHidden()
+    if (opened) {
+        invoke(blk)
+        EndTooltip()
+    }
+    return opened
+}
+
+def public with_menu_ex(lbl : string; icon : string; enabled : bool; blk : block) : bool {
+    //! `BeginMenuEx(lbl, icon, enabled)` / `EndMenu()` — only-on-true. Like `menu`
+    //! but with an ``icon`` column (pass ``""`` for none); ``blk`` is the dropdown body.
+    //! Returns whether the dropdown is open.
+    let opened = BeginMenuEx(lbl, icon, enabled)
+    if (opened) {
+        invoke(blk)
+        EndMenu()
+    }
+    return opened
+}


### PR DESCRIPTION
Next `imgui_internal.h` family after #170 — the **popup / tooltip / menu `*Ex` entry points** (rank 3 from the survey: *bindable-as-is*, low cost, no new C++ wrapper).

## What's bound

Added to `internal_allow_func` (regen only):

| daslang | C++ signature |
|---|---|
| `OpenPopupEx(id, popup_flags)` | `void(ImGuiID, ImGuiPopupFlags)` |
| `ClosePopupToLevel(remaining, restore_focus)` | `void(int, bool)` |
| `ClosePopupsExceptModals()` | `void()` |
| `IsPopupOpen(id, popup_flags)` | `bool(ImGuiID, ImGuiPopupFlags)` |
| `BeginPopupEx(id, extra_flags)` | `bool(ImGuiID, ImGuiWindowFlags)` |
| `BeginTooltipEx(tooltip_flags, extra_window_flags)` | `bool(ImGuiTooltipFlags, ImGuiWindowFlags)` |
| `BeginTooltipHidden()` | `bool()` |
| `BeginMenuEx(label, icon, enabled)` | `bool(const char*, const char*, bool)` |
| `MenuItemEx(label, icon, shortcut, selected, enabled)` | `bool(const char*, const char*, const char*, bool, bool)` |

Plus one new internal enum in `internal_allow_enum`: **`ImGuiTooltipFlags_`** (one real flag, `OverridePrevious`).

`IsPopupOpen` is an overload of the public `const char*` version — the `makeExtern` explicit-signature template arg disambiguates the address-taking (same mechanism as the two `GetIDWithSeed` overloads in #169). The `ClosePopupsOverWindow` / `GetTopMost*PopupModal` / `FindBlockingModal` / `FindBestWindowPosForPopup*` / `GetPopupAllowedExtentRect` neighbors take or return `ImGuiWindow*` and are correctly out of scope.

## v2 surface

The four `Begin*Ex` pair with the **public** `End*` (`EndPopup` / `EndTooltip` / `EndMenu`), so they're surfaced as unbalance-proof scope guards in `imgui_scope_builtin.das` (neither lint- nor doc-gated, like `with_focus_scope`):

- `with_popup_ex(id, window_flags, blk) : bool`
- `with_tooltip_ex(tooltip_flags, window_flags, blk) : bool`
- `with_tooltip_hidden(blk) : bool`
- `with_menu_ex(lbl, icon, enabled, blk) : bool`

Each is only-on-true (runs `blk` only if the begin succeeded, then calls the matching `End*`) and returns whether it opened.

The five one-shots are raw on `ALLOWED_IMGUI` alongside the Render* batch. `MenuItemEx` is the icon/shortcut escape hatch next to the wrapped `menu_item` widget.

Arg-typing note: public flag typedefs (`ImGuiPopupFlags`, `ImGuiWindowFlags`) bind as the das enum, but internal enums added via `internal_allow_enum` (`ImGuiTooltipFlags`, like `ImGuiItemFlags`) keep their `int` arg — so `with_tooltip_ex` casts `int(tooltip_flags)`, mirroring `with_item_flag`.

## Verification

- Regenerated via the junction trick; net **+9 makeExterns**, chunk-reflow verified (overflow into a new **`func_32`** chunk — every function removed from `func_31` reappears in `func_32`, **0 lost**). CMakeLists registers `func_32.cpp`; EOL-only `.inc` churn reverted.
- Rebuilt `dasModuleImgui.shared_module` on Windows (MSVC) — `func_32.cpp` compiles.
- New `examples/features/internal_popup_menu_ex.das` exercises all 9: a menu bar (`with_menu_ex` + `MenuItemEx`), a raw-`ImGuiID` popup auto-opened on the first frame so the popup path + `MenuItemEx`-in-popup + `IsPopupOpen` run **headlessly**, the popup-stack controls (`ClosePopupToLevel` / `ClosePopupsExceptModals`), and both tooltip guards (`with_tooltip_hidden` runs every frame as an offscreen measure). Clean headless (`exit 0`).
- **Docs gate checked locally** (`imgui2rst.das` regen → `grep '^Uncategorized$'` = none) — the new guards live in the un-gated `imgui_scope_builtin.das`, so no `imgui2rst.das` categorization is needed.
- `format --verify` + lint clean on all 4 changed `.das` (pre-push hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)