### PR TITLE
imgui: bind internal item hit-test / rounding geometry helpers (family)

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -216,7 +216,18 @@ class ImguiGen : CppGenBind {
             "ImGui::OpenPopupEx", "ImGui::ClosePopupToLevel", "ImGui::ClosePopupsExceptModals",
             "ImGui::IsPopupOpen", "ImGui::BeginPopupEx",
             "ImGui::BeginTooltipEx", "ImGui::BeginTooltipHidden",
-            "ImGui::BeginMenuEx", "ImGui::MenuItemEx"
+            "ImGui::BeginMenuEx", "ImGui::MenuItemEx",
+            // Internal item hit-test / rounding geometry helpers — the building
+            // blocks a custom-widget author needs below the public widget API.
+            // All take ImRect (aliased to float4) + ImGuiID(uint); ItemHoverable
+            // also takes ImGuiItemFlags (internal enum, binds as int like
+            // PushItemFlag); CalcRoundingFlagsForRectInRect returns ImDrawFlags
+            // (public enum). No nullable pointers / ImGuiWindow* — they read the
+            // current window implicitly. ItemAdd is deliberately NOT here: its
+            // nav_bb is a nullable ImRect* (no-lost-functionality DISCUSS — pinning
+            // it to null would drop the separate-nav-rect feature).
+            "ImGui::ItemHoverable", "ImGui::IsClippedEx",
+            "ImGui::CalcRoundingFlagsForRectInRect"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_"

--- a/examples/features/internal_item_hittest.das
+++ b/examples/features/internal_item_hittest.das
@@ -1,0 +1,115 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_item_hittest — the imgui_internal.h item hit-test / rounding
+//          geometry helpers a custom-widget author needs below the public widget
+//          API. Cherry-picked into the v2 binding (bind_imgui.das
+//          internal_allow_func): ItemHoverable, IsClippedEx,
+//          CalcRoundingFlagsForRectInRect. All take an ImRect (aliased to float4
+//          as (min.x, min.y, max.x, max.y)) + an ImGuiID(uint); they read the
+//          current window implicitly, so no ImGuiWindow* and no v2 host state.
+//          This is the "binding is usable" gate: it calls the real bound API at
+//          runtime, not just compiles it.
+// SHOWS:   ItemHoverable (hit-test a hand-drawn rect by its bb + id, recolour on
+//          hover); IsClippedEx (cull test — a visible rect vs. one pushed far
+//          offscreen); CalcRoundingFlagsForRectInRect (round only the corners of
+//          an inner rect that sit away from the outer rect's corners, e.g. a tab
+//          nested in a bar).
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_item_hittest.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_item_hittest.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_item_hittest.das
+// =============================================================================
+
+def private box(var dl : ImDrawList?; x, y, w, h : float; edge : uint) {
+    dl |> add_rect(ImVec2(x, y), ImVec2(x + w, y + h), edge, 0.0, ImDrawFlags.None, 2.0)
+}
+
+[export]
+def init() {
+    harness_init("internal_item_hittest - imgui_internal.h item hit-test / geometry", 760, 560)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    let edge = rgba(120u, 180u, 240u, 255u)
+    let fill_idle = rgba(60u, 90u, 140u, 255u)
+    let fill_hover = rgba(90u, 150u, 230u, 255u)
+
+    SetNextWindowSize(ImVec2(720.0, 520.0), ImGuiCond.Always)
+    window(HIT_WIN, (text = "internal_item_hittest", closable = false,
+                     flags = ImGuiWindowFlags.None)) {
+
+        // ----- ItemHoverable: hit-test a hand-drawn rect by its bb + id -----
+        text("ItemHoverable(bb, id): hit-test a custom rect (hover it to recolour).")
+        let o1 = GetCursorScreenPos()
+        let hb_min = ImVec2(o1.x + 12.0, o1.y + 8.0)
+        let hb_max = ImVec2(o1.x + 220.0, o1.y + 44.0)
+        // ImRect is float4 = (min.x, min.y, max.x, max.y). 0 = ImGuiItemFlags.None.
+        let bb = float4(hb_min.x, hb_min.y, hb_max.x, hb_max.y)
+        let hovered = ItemHoverable(bb, GetID("hover_rect"), 0)
+        with_window_drawlist() $(var dl) {
+            dl |> add_rect_filled(hb_min, hb_max, hovered ? fill_hover : fill_idle, 4.0, ImDrawFlags.None)
+            box(dl, hb_min.x, hb_min.y, hb_max.x - hb_min.x, hb_max.y - hb_min.y, edge)
+        }
+        dummy(SP1, ImVec2(700.0, 48.0))
+        text("  hovered = {hovered}")
+        separator()
+
+        // ----- IsClippedEx: cull test — visible rect vs. one pushed offscreen -----
+        text("IsClippedEx(bb, id): is a rect outside the visible clip region (cull test)?")
+        let o2 = GetCursorScreenPos()
+        let vis_bb = float4(o2.x + 12.0, o2.y + 8.0, o2.x + 200.0, o2.y + 40.0)
+        // Same width, but pushed far below the window — outside the clip rect.
+        let off_bb = float4(o2.x + 12.0, o2.y + 4000.0, o2.x + 200.0, o2.y + 4032.0)
+        let vis_clipped = IsClippedEx(vis_bb, GetID("vis_rect"))
+        let off_clipped = IsClippedEx(off_bb, GetID("off_rect"))
+        with_window_drawlist() $(var dl) {
+            box(dl, o2.x + 12.0, o2.y + 8.0, 188.0, 32.0, edge)
+        }
+        dummy(SP2, ImVec2(700.0, 40.0))
+        text("  visible rect clipped = {vis_clipped}    offscreen rect clipped = {off_clipped}")
+        separator()
+
+        // ----- CalcRoundingFlagsForRectInRect: round only the "free" corners -----
+        text("CalcRoundingFlagsForRectInRect(r_in, r_outer, threshold): round only the")
+        text("  inner-rect corners that sit away from the outer rect (e.g. a tab in a bar).")
+        let o3 = GetCursorScreenPos()
+        let outer_min = ImVec2(o3.x + 12.0, o3.y + 8.0)
+        let outer_max = ImVec2(o3.x + 320.0, o3.y + 88.0)
+        // Inner rect pinned to the outer's top-left corner; its bottom-right is "free".
+        let inner_min = outer_min
+        let inner_max = ImVec2(o3.x + 160.0, o3.y + 48.0)
+        let r_outer = float4(outer_min.x, outer_min.y, outer_max.x, outer_max.y)
+        let r_in = float4(inner_min.x, inner_min.y, inner_max.x, inner_max.y)
+        let round_flags = CalcRoundingFlagsForRectInRect(r_in, r_outer, 16.0)
+        with_window_drawlist() $(var dl) {
+            dl |> add_rect(outer_min, outer_max, edge, 0.0, ImDrawFlags.None, 2.0)
+            dl |> add_rect_filled(inner_min, inner_max, fill_idle, 12.0, round_flags)
+        }
+        dummy(SP3, ImVec2(700.0, 92.0))
+        text("  computed ImDrawFlags = {int(round_flags)} (only corners away from the outer edges round)")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -38,6 +38,14 @@ void Module_dasIMGUI::initFunctions_30() {
 		->args({"bb","text_baseline_y"})
 		->arg_init(1,new ExprConstFloat(-1))
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3384:29
+	makeExtern< bool (*)(const ImRect &,unsigned int,int) , ImGui::ItemHoverable , SimNode_ExtFuncCall , imguiTempFn>(lib,"ItemHoverable","ImGui::ItemHoverable")
+		->args({"bb","id","item_flags"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3386:29
+	makeExtern< bool (*)(const ImRect &,unsigned int) , ImGui::IsClippedEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"IsClippedEx","ImGui::IsClippedEx")
+		->args({"bb","id"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3388:29
 	makeExtern< ImVec2 (*)(ImVec2,float,float) , ImGui::CalcItemSize , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcItemSize","ImGui::CalcItemSize")
 		->args({"size","default_w","default_h"})
@@ -86,18 +94,6 @@ void Module_dasIMGUI::initFunctions_30() {
 		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3415:29
 	makeExtern< bool (*)() , ImGui::BeginTooltipHidden , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginTooltipHidden","ImGui::BeginTooltipHidden")
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3425:29
-	makeExtern< bool (*)(const char *,const char *,bool) , ImGui::BeginMenuEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginMenuEx","ImGui::BeginMenuEx")
-		->args({"label","icon","enabled"})
-		->arg_init(2,new ExprConstBool(true))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3426:29
-	makeExtern< bool (*)(const char *,const char *,const char *,bool,bool) , ImGui::MenuItemEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"MenuItemEx","ImGui::MenuItemEx")
-		->args({"label","icon","shortcut","selected","enabled"})
-		->arg_init(2,new ExprConstString(""))
-		->arg_init(3,new ExprConstBool(false))
-		->arg_init(4,new ExprConstBool(true))
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_31.cpp
+++ b/src/dasIMGUI.func_31.cpp
@@ -12,6 +12,18 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_31() {
+// from imgui_internal.h:3425:29
+	makeExtern< bool (*)(const char *,const char *,bool) , ImGui::BeginMenuEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginMenuEx","ImGui::BeginMenuEx")
+		->args({"label","icon","enabled"})
+		->arg_init(2,new ExprConstBool(true))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3426:29
+	makeExtern< bool (*)(const char *,const char *,const char *,bool,bool) , ImGui::MenuItemEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"MenuItemEx","ImGui::MenuItemEx")
+		->args({"label","icon","shortcut","selected","enabled"})
+		->arg_init(2,new ExprConstString(""))
+		->arg_init(3,new ExprConstBool(false))
+		->arg_init(4,new ExprConstBool(true))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3455:29
 	makeExtern< void (*)() , ImGui::FocusItem , SimNode_ExtFuncCall , imguiTempFn>(lib,"FocusItem","ImGui::FocusItem")
 		->addToModule(*this, SideEffects::worstDefault);
@@ -93,14 +105,6 @@ void Module_dasIMGUI::initFunctions_31() {
 // from imgui_internal.h:3736:29
 	makeExtern< void (*)(ImDrawList *,ImVec2,float,unsigned int) , ImGui::RenderArrowDockMenu , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowDockMenu","ImGui::RenderArrowDockMenu")
 		->args({"draw_list","p_min","sz","col"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3737:29
-	makeExtern< void (*)(ImDrawList *,const ImRect &,unsigned int,float,float,float) , ImGui::RenderRectFilledRangeH , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledRangeH","ImGui::RenderRectFilledRangeH")
-		->args({"draw_list","rect","col","x_start_norm","x_end_norm","rounding"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3738:29
-	makeExtern< void (*)(ImDrawList *,const ImRect &,const ImRect &,unsigned int,float) , ImGui::RenderRectFilledWithHole , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledWithHole","ImGui::RenderRectFilledWithHole")
-		->args({"draw_list","outer","inner","col","rounding"})
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -12,6 +12,19 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_32() {
+// from imgui_internal.h:3737:29
+	makeExtern< void (*)(ImDrawList *,const ImRect &,unsigned int,float,float,float) , ImGui::RenderRectFilledRangeH , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledRangeH","ImGui::RenderRectFilledRangeH")
+		->args({"draw_list","rect","col","x_start_norm","x_end_norm","rounding"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3738:29
+	makeExtern< void (*)(ImDrawList *,const ImRect &,const ImRect &,unsigned int,float) , ImGui::RenderRectFilledWithHole , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledWithHole","ImGui::RenderRectFilledWithHole")
+		->args({"draw_list","outer","inner","col","rounding"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3739:29
+	makeExtern< int (*)(const ImRect &,const ImRect &,float) , ImGui::CalcRoundingFlagsForRectInRect , SimNode_ExtFuncCall , imguiTempFn>(lib,"CalcRoundingFlagsForRectInRect","ImGui::CalcRoundingFlagsForRectInRect")
+		->args({"r_in","r_outer","threshold"})
+		->res_type(makeType<ImDrawFlags_>(lib))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3767:29
 	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
 		->args({"id"})

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -169,7 +169,13 @@ let private ALLOWED_IMGUI : table<string> <- {
     // guards (imgui_scope_builtin.das). MenuItemEx is the icon/shortcut
     // escape hatch alongside the wrapped `menu_item` widget.
     "OpenPopupEx", "ClosePopupToLevel", "ClosePopupsExceptModals",
-    "IsPopupOpen", "MenuItemEx"
+    "IsPopupOpen", "MenuItemEx",
+    // Internal item hit-test / rounding geometry one-shots cherry-picked from
+    // imgui_internal.h. Host-agnostic helpers for custom-widget code: hit-test
+    // a rect (ItemHoverable), test whether it is clipped (IsClippedEx), compute
+    // which corners to round for a rect inset in another (CalcRoundingFlagsForRectInRect).
+    // Bound via bind_imgui.das internal_allow_func.
+    "ItemHoverable", "IsClippedEx", "CalcRoundingFlagsForRectInRect"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
Next `imgui_internal.h` family — the low-level **item hit-test / rounding geometry** helpers a custom-widget author needs below the public widget API.

## What's bound

Added to `internal_allow_func` (regen only):

| daslang | C++ signature | use |
|---|---|---|
| `ItemHoverable(bb, id, item_flags)` | `bool(const ImRect&, ImGuiID, ImGuiItemFlags)` | hit-test a hand-drawn rect |
| `IsClippedEx(bb, id)` | `bool(const ImRect&, ImGuiID)` | cull test (is a rect outside the clip region) |
| `CalcRoundingFlagsForRectInRect(r_in, r_outer, threshold)` | `ImDrawFlags(const ImRect&, const ImRect&, float)` | which corners to round for a rect inset in another |

All take `ImRect` (aliased to `float4` as `(min.x, min.y, max.x, max.y)`) + `ImGuiID` (`uint`); they read the current window implicitly, so **no `ImGuiWindow*`, no nullable pointers**. `ItemHoverable`'s `ImGuiItemFlags` binds as `int` (internal enum, no arg-remap, like `PushItemFlag`); `CalcRoundingFlagsForRectInRect` returns the public `ImDrawFlags` enum.

Raw on `ALLOWED_IMGUI` — one-shot queries, like the family-4 `CalcItemSize` / `GetContentRegionMaxAbs` batch. No `Begin`/`End`, so no scope guard.

## Context: rank-4 "RenderText terminus" was already done

The text helpers (`RenderTextClipped` / `RenderTextClippedEx` / `RenderTextEllipsis`) that carry the non-defaulted `text_end` + nullable `text_size_if_known` were **already bound in Family 1** via the `*W` null-pinning wrappers in `dasIMGUI.main.cpp`. So `CalcRoundingFlagsForRectInRect` was the only remaining rounding-flags piece — folded into this hit-test family.

## Deferred (no-lost-functionality DISCUSS, flagged for a later family)

- **`ItemAdd`** — its `nav_bb` is a nullable `ImRect*`; pinning it to null (the `*W`-wrapper pattern) would drop the separate-nav-rect feature, so it needs a design decision first.
- **Widget `*Ex`** (`ButtonEx` / `ArrowButtonEx` / `ImageButtonEx` / `ButtonBehavior`) — the useful behavior flags (`PressedOnClick`, `Repeat`, …) live in the private `ImGuiButtonFlagsPrivate_` enum, separate from the public `ImGuiButtonFlags`. How to expose that cross-enum OR is a genuine API decision I'll bring up before binding that family.

## Verification

- Regenerated via the junction trick; net **+3 makeExterns**, chunk-reflow verified (slots into existing chunks, **0 functions lost**, no new func chunk → CMakeLists untouched). EOL-only `.inc` churn reverted.
- Rebuilt `dasModuleImgui.shared_module` on Windows (MSVC).
- New `examples/features/internal_item_hittest.das` exercises all three at runtime: `ItemHoverable` recolours a rect on hover, `IsClippedEx` compares a visible vs. an offscreen rect, `CalcRoundingFlagsForRectInRect` draws an inner rect rounded only on its free (away-from-outer) corner. Clean headless (`exit 0`).
- **Docs gate checked locally** (`imgui2rst.das` regen → `grep '^Uncategorized$'` = none).
- `format --verify` + lint clean on all 3 changed `.das` (pre-push hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)