### PR TITLE
imgui: bind internal *Ex buttons + behavior-flags enum (family)

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -136,6 +136,11 @@ class ImguiGen : CppGenBind {
         }
     }
     def init_internal {
+        // ImGuiButtonFlagsPrivate_ (imgui_internal.h) extends the PUBLIC ImGuiButtonFlags
+        // set — its VALUES carry the public `ImGuiButtonFlags_` prefix, not their own
+        // enum name. Override the strip-prefix so they bind as ImGuiButtonFlagsPrivate.Repeat
+        // etc. (else enum_entry_name leaves the full `ImGuiButtonFlags_Repeat`).
+        enum_prefix |> insert("ImGuiButtonFlagsPrivate_", "ImGuiButtonFlags")
         // Family 1 — Render* draw helpers from imgui_internal.h. Every argument is
         // an already-bound public type (ImVec2, ImU32, ImDrawList*, ImGuiDir,
         // ImGuiMouseCursor, ImDrawFlags), so no internal struct/enum is pulled in.
@@ -227,10 +232,20 @@ class ImguiGen : CppGenBind {
             // nav_bb is a nullable ImRect* (no-lost-functionality DISCUSS — pinning
             // it to null would drop the separate-nav-rect feature).
             "ImGui::ItemHoverable", "ImGui::IsClippedEx",
-            "ImGui::CalcRoundingFlagsForRectInRect"
+            "ImGui::CalcRoundingFlagsForRectInRect",
+            // Widget *Ex buttons with behavior flags. ButtonEx/ArrowButtonEx take an
+            // ImGuiButtonFlags arg whose USEFUL values (Repeat, PressedOnClick, …) live
+            // in the internal ImGuiButtonFlagsPrivate_ enum (added to internal_allow_enum
+            // below); a cross-enum `|` rail in imgui_enums.das combines the public +
+            // private flags into one ImGuiButtonFlags the *Ex funcs accept. ButtonBehavior
+            // (bool* out-params) and ItemAdd (nullable nav_bb -> C++ wrapper) are the
+            // custom-widget primitives, deferred to the next family. ImageButtonEx is
+            // texture-centric (ImTextureID = void*), deferred to an image family.
+            "ImGui::ButtonEx", "ImGui::ArrowButtonEx"
         }
         internal_allow_enum <- {
-            "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_"
+            "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_",
+            "ImGuiButtonFlagsPrivate_"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_button_ex.das
+++ b/examples/features/internal_button_ex.das
@@ -1,0 +1,127 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_button_ex — the imgui_internal.h *Ex buttons that take a
+//          behavior-flags argument. Cherry-picked into the v2 binding
+//          (bind_imgui.das internal_allow_func): ButtonEx, ArrowButtonEx. Their
+//          ImGuiButtonFlags arg's USEFUL values (Repeat, PressedOnClick, …) live
+//          in the internal ImGuiButtonFlagsPrivate_ enum — bound here and combined
+//          with the public ImGuiButtonFlags via the cross-enum `|` rail in
+//          imgui_enums.das (both halves are one int-backed flag set). This is the
+//          "binding is usable" gate: it calls the real bound API at runtime.
+// SHOWS:   ButtonEx with Repeat (held fires repeatedly), PressedOnClick (fires on
+//          mouse-down not release), MouseButtonRight (responds only to right-click),
+//          and two private flags combined; ArrowButtonEx in all four directions
+//          with Repeat. The cross-enum `|` yields the single ImGuiButtonFlags the
+//          *Ex functions accept; a lone private flag uses `None | Private.X`.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_button_ex.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_button_ex.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_button_ex.das
+// =============================================================================
+
+var g_plain = 0
+var g_repeat = 0
+var g_press = 0
+var g_right = 0
+var g_combo = 0
+var g_arrow = "(none)"
+
+[export]
+def init() {
+    harness_init("internal_button_ex - imgui_internal.h *Ex buttons + behavior flags", 760, 540)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    let auto_sz = float2(0.0, 0.0)
+
+    SetNextWindowSize(ImVec2(720.0, 500.0), ImGuiCond.Always)
+    window(BTN_WIN, (text = "internal_button_ex", closable = false,
+                     flags = ImGuiWindowFlags.None)) {
+        text("ButtonEx(label, size, flags): public ImGuiButtonFlags + internal")
+        text("  ImGuiButtonFlagsPrivate, combined via the imgui_enums.das cross-enum `|`.")
+        separator()
+
+        // Plain ButtonEx — no behavior flags (same as the public button).
+        if (ButtonEx("Plain", auto_sz, ImGuiButtonFlags.None)) {
+            g_plain++
+        }
+        same_line()
+        text("clicks: {g_plain}")
+
+        // Repeat (private flag) — held down fires repeatedly.
+        if (ButtonEx("Hold to repeat", auto_sz, ImGuiButtonFlags.None | ImGuiButtonFlagsPrivate.Repeat)) {
+            g_repeat++
+        }
+        same_line()
+        text("repeat fires: {g_repeat}")
+
+        // PressedOnClick (private) — returns true on mouse-DOWN, not on release.
+        if (ButtonEx("Fire on press", auto_sz, ImGuiButtonFlags.None | ImGuiButtonFlagsPrivate.PressedOnClick)) {
+            g_press++
+        }
+        same_line()
+        text("press fires: {g_press}")
+
+        // MouseButtonRight (public) — responds only to the right mouse button.
+        if (ButtonEx("Right-click me", auto_sz, ImGuiButtonFlags.MouseButtonRight)) {
+            g_right++
+        }
+        same_line()
+        text("right-clicks: {g_right}")
+
+        // Two PRIVATE flags combined (private | private -> ImGuiButtonFlags).
+        if (ButtonEx("Repeat + on-press", auto_sz,
+                     ImGuiButtonFlagsPrivate.Repeat | ImGuiButtonFlagsPrivate.PressedOnClick)) {
+            g_combo++
+        }
+        same_line()
+        text("combo fires: {g_combo}")
+        separator()
+
+        // ArrowButtonEx in all four directions, each with the Repeat flag.
+        text("ArrowButtonEx(str_id, dir, size, flags): directional repeat buttons.")
+        let asz = float2(28.0, 28.0)
+        let rep = ImGuiButtonFlags.None | ImGuiButtonFlagsPrivate.Repeat
+        if (ArrowButtonEx("a_left", ImGuiDir.Left, asz, rep)) {
+            g_arrow = "Left"
+        }
+        same_line()
+        if (ArrowButtonEx("a_right", ImGuiDir.Right, asz, rep)) {
+            g_arrow = "Right"
+        }
+        same_line()
+        if (ArrowButtonEx("a_up", ImGuiDir.Up, asz, rep)) {
+            g_arrow = "Up"
+        }
+        same_line()
+        if (ArrowButtonEx("a_down", ImGuiDir.Down, asz, rep)) {
+            g_arrow = "Down"
+        }
+        same_line()
+        text("last arrow: {g_arrow}")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -38,6 +38,7 @@ addEnumeration(new Enumeration_ImDrawListFlags_());
 addEnumeration(new Enumeration_ImFontAtlasFlags_());
 addEnumeration(new Enumeration_ImGuiViewportFlags_());
 addEnumeration(new Enumeration_ImGuiItemFlags_());
+addEnumeration(new Enumeration_ImGuiButtonFlagsPrivate_());
 addEnumeration(new Enumeration_ImGuiTooltipFlags_());
 addEnumeration(new Enumeration_ImGuiNavHighlightFlags_());
 addEnumFlagOps<ImGuiWindowFlags_>(*this,lib,"ImGuiWindowFlags_");

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1033,6 +1033,35 @@ public:
 	}
 };
 
+// from imgui_internal.h:888:6
+class Enumeration_ImGuiButtonFlagsPrivate_ : public das::Enumeration {
+public:
+	Enumeration_ImGuiButtonFlagsPrivate_() : das::Enumeration("ImGuiButtonFlagsPrivate") {
+		external = true;
+		cppName = "ImGuiButtonFlagsPrivate_";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("PressedOnClick", "ImGuiButtonFlags_PressedOnClick", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnClick), das::LineInfo());
+		addIEx("PressedOnClickRelease", "ImGuiButtonFlags_PressedOnClickRelease", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnClickRelease), das::LineInfo());
+		addIEx("PressedOnClickReleaseAnywhere", "ImGuiButtonFlags_PressedOnClickReleaseAnywhere", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnClickReleaseAnywhere), das::LineInfo());
+		addIEx("PressedOnRelease", "ImGuiButtonFlags_PressedOnRelease", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnRelease), das::LineInfo());
+		addIEx("PressedOnDoubleClick", "ImGuiButtonFlags_PressedOnDoubleClick", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnDoubleClick), das::LineInfo());
+		addIEx("PressedOnDragDropHold", "ImGuiButtonFlags_PressedOnDragDropHold", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnDragDropHold), das::LineInfo());
+		addIEx("Repeat", "ImGuiButtonFlags_Repeat", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_Repeat), das::LineInfo());
+		addIEx("FlattenChildren", "ImGuiButtonFlags_FlattenChildren", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_FlattenChildren), das::LineInfo());
+		addIEx("AllowOverlap", "ImGuiButtonFlags_AllowOverlap", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_AllowOverlap), das::LineInfo());
+		addIEx("DontClosePopups", "ImGuiButtonFlags_DontClosePopups", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_DontClosePopups), das::LineInfo());
+		addIEx("AlignTextBaseLine", "ImGuiButtonFlags_AlignTextBaseLine", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_AlignTextBaseLine), das::LineInfo());
+		addIEx("NoKeyModifiers", "ImGuiButtonFlags_NoKeyModifiers", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_NoKeyModifiers), das::LineInfo());
+		addIEx("NoHoldingActiveId", "ImGuiButtonFlags_NoHoldingActiveId", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_NoHoldingActiveId), das::LineInfo());
+		addIEx("NoNavFocus", "ImGuiButtonFlags_NoNavFocus", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_NoNavFocus), das::LineInfo());
+		addIEx("NoHoveredOnFocus", "ImGuiButtonFlags_NoHoveredOnFocus", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_NoHoveredOnFocus), das::LineInfo());
+		addIEx("NoSetKeyOwner", "ImGuiButtonFlags_NoSetKeyOwner", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_NoSetKeyOwner), das::LineInfo());
+		addIEx("NoTestKeyOwner", "ImGuiButtonFlags_NoTestKeyOwner", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_NoTestKeyOwner), das::LineInfo());
+		addIEx("PressedOnMask_", "ImGuiButtonFlags_PressedOnMask_", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnMask_), das::LineInfo());
+		addIEx("PressedOnDefault_", "ImGuiButtonFlags_PressedOnDefault_", int64_t(ImGuiButtonFlagsPrivate_::ImGuiButtonFlags_PressedOnDefault_), das::LineInfo());
+	}
+};
+
 // from imgui_internal.h:970:6
 class Enumeration_ImGuiTooltipFlags_ : public das::Enumeration {
 public:

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -39,5 +39,6 @@ DAS_BIND_ENUM_CAST(ImDrawListFlags_);
 DAS_BIND_ENUM_CAST(ImFontAtlasFlags_);
 DAS_BIND_ENUM_CAST(ImGuiViewportFlags_);
 DAS_BIND_ENUM_CAST(ImGuiItemFlags_);
+DAS_BIND_ENUM_CAST(ImGuiButtonFlagsPrivate_);
 DAS_BIND_ENUM_CAST(ImGuiTooltipFlags_);
 DAS_BIND_ENUM_CAST(ImGuiNavHighlightFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -75,6 +75,8 @@ DAS_BASE_BIND_ENUM_GEN(ImGuiViewportFlags_,ImGuiViewportFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiItemFlags_,ImGuiItemFlags);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiButtonFlagsPrivate_,ImGuiButtonFlagsPrivate);
+
 DAS_BASE_BIND_ENUM_GEN(ImGuiTooltipFlags_,ImGuiTooltipFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiNavHighlightFlags_,ImGuiNavHighlightFlags);

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -25,6 +25,19 @@ void Module_dasIMGUI::initFunctions_32() {
 		->args({"r_in","r_outer","threshold"})
 		->res_type(makeType<ImDrawFlags_>(lib))
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3743:29
+	makeExtern< bool (*)(const char *,const ImVec2 &,int) , ImGui::ButtonEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"ButtonEx","ImGui::ButtonEx")
+		->args({"label","size_arg","flags"})
+		->arg_type(2,makeType<ImGuiButtonFlags_>(lib))
+		->arg_init(2,new ExprConstEnumeration(0,makeType<ImGuiButtonFlags_>(lib)))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3744:29
+	makeExtern< bool (*)(const char *,int,ImVec2,int) , ImGui::ArrowButtonEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"ArrowButtonEx","ImGui::ArrowButtonEx")
+		->args({"str_id","dir","size_arg","flags"})
+		->arg_type(1,makeType<ImGuiDir_>(lib))
+		->arg_type(3,makeType<ImGuiButtonFlags_>(lib))
+		->arg_init(3,new ExprConstEnumeration(0,makeType<ImGuiButtonFlags_>(lib)))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3767:29
 	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
 		->args({"id"})

--- a/widgets/imgui_enums.das
+++ b/widgets/imgui_enums.das
@@ -33,3 +33,26 @@ def public operator ~(a : ImGuiItemFlags) : ImGuiItemFlags {
     //! Bitwise complement — clear-mask for ``flags & ~ImGuiItemFlags.X``.
     return unsafe(reinterpret<ImGuiItemFlags>(~int(a)))
 }
+
+//! Cross-enum ``|`` for the button-flag pair. ``ImGuiButtonFlags`` (public — the 3
+//! mouse-button selectors) and ``ImGuiButtonFlagsPrivate`` (internal — the behavior
+//! flags ``Repeat`` / ``PressedOnClick`` / …) are one conceptual flag set split across
+//! two C++ ``enum`` blocks. These overloads let either combine into the single
+//! ``ImGuiButtonFlags`` that ``ButtonEx`` / ``ArrowButtonEx`` accept:
+//!
+//!   ``ButtonEx("x", size, ImGuiButtonFlags.MouseButtonRight | ImGuiButtonFlagsPrivate.Repeat)``
+//!
+//! A lone private flag uses ``ImGuiButtonFlags.None | ImGuiButtonFlagsPrivate.X``.
+
+def public operator |(a : ImGuiButtonFlags; b : ImGuiButtonFlagsPrivate) : ImGuiButtonFlags {
+    return unsafe(reinterpret<ImGuiButtonFlags>(int(a) | int(b)))
+}
+
+def public operator |(a : ImGuiButtonFlagsPrivate; b : ImGuiButtonFlags) : ImGuiButtonFlags {
+    return unsafe(reinterpret<ImGuiButtonFlags>(int(a) | int(b)))
+}
+
+def public operator |(a, b : ImGuiButtonFlagsPrivate) : ImGuiButtonFlags {
+    //! Two private flags combine into ``ImGuiButtonFlags`` (the *Ex arg type).
+    return unsafe(reinterpret<ImGuiButtonFlags>(int(a) | int(b))) // nolint:PERF019
+}

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -175,7 +175,11 @@ let private ALLOWED_IMGUI : table<string> <- {
     // a rect (ItemHoverable), test whether it is clipped (IsClippedEx), compute
     // which corners to round for a rect inset in another (CalcRoundingFlagsForRectInRect).
     // Bound via bind_imgui.das internal_allow_func.
-    "ItemHoverable", "IsClippedEx", "CalcRoundingFlagsForRectInRect"
+    "ItemHoverable", "IsClippedEx", "CalcRoundingFlagsForRectInRect",
+    // Internal *Ex buttons with behavior flags (Repeat / PressedOnClick / …, from the
+    // ImGuiButtonFlagsPrivate_ enum combined via the imgui_enums.das cross-enum `|`).
+    // Raw escape hatches next to the wrapped `button` / `arrow_button` widgets.
+    "ButtonEx", "ArrowButtonEx"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
`ButtonEx` + `ArrowButtonEx` from `imgui_internal.h`, via `internal_allow_func` (regen only). Their `ImGuiButtonFlags` arg's useful values (`Repeat`, `PressedOnClick`, …) live in the internal `ImGuiButtonFlagsPrivate_` enum, added to `internal_allow_enum` with an `enum_prefix` override so its values strip the public `ImGuiButtonFlags_` prefix (`ImGuiButtonFlagsPrivate.Repeat`, not `...ImGuiButtonFlags_Repeat`).

Public `ImGuiButtonFlags` + internal `ImGuiButtonFlagsPrivate` are one int-backed flag set split across two C++ enum blocks; a cross-enum `|` rail in `imgui_enums.das` combines them into the single `ImGuiButtonFlags` the `*Ex` functions accept (mirrors the existing `ImGuiItemFlags` ops). Raw on `ALLOWED_IMGUI` (escape hatches next to the wrapped `button` / `arrow_button`).

**Depends on daScript typer fix [#3010](https://github.com/GaijinEntertainment/daScript/pull/3010) — now merged.** The cross-enum `|` requires the typer to honor a user `operator |(E1;E2)` over mismatched enums.

`ImageButtonEx` (texture-centric) and `ButtonBehavior` + `ItemAdd` (custom-widget primitives, nullable `nav_bb` → C++ wrapper) are the next families.

Regen: net +2 makeExterns, no new func chunk, EOL churn reverted. Example `internal_button_ex.das` exercises `Repeat` / `PressedOnClick` / `MouseButtonRight` / combined flags + `ArrowButtonEx` in 4 directions; clean headless (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)