### PR TITLE
imgui: bind ItemAdd + ButtonBehavior custom-widget primitives (family)

### DIFF
--- a/examples/features/internal_item_add_button_behavior.das
+++ b/examples/features/internal_item_add_button_behavior.das
@@ -1,0 +1,130 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_item_add_button_behavior — assemble a working button entirely
+//          from the imgui_internal.h primitives the public `button` widget is built
+//          on. Cherry-picked into the v2 binding via manual C++ wrappers
+//          (dasIMGUI.main.cpp): ItemAdd (two overloads — with / without a separate
+//          nav rect) and ButtonBehavior (the press/hover/hold state machine; its two
+//          state outputs come back through bool& args, written into plain das vars).
+//          ItemSize / GetID / GetCursorScreenPos are already-public layout + identity
+//          helpers. This is the "binding is usable" gate: it calls the real bound API
+//          at runtime, not just compiles it.
+// SHOWS:   a hand-rolled `custom_button` (GetID + GetCursorScreenPos -> ItemSize ->
+//          ItemAdd -> ButtonBehavior -> drawlist render) used three ways: a plain
+//          click button, a Repeat button (ButtonBehavior + ImGuiButtonFlagsPrivate.Repeat
+//          combined via PR #173's cross-enum `|` rail — fires while held), and one that
+//          uses the 4-arg ItemAdd overload to give the item a nav rect larger than its
+//          visual box. Live hovered / held readout proves the state machine runs.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_item_add_button_behavior.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_item_add_button_behavior.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_item_add_button_behavior.das
+// =============================================================================
+
+var g_plain = 0
+var g_repeat = 0
+var g_nav = 0
+
+def private button_fill(hovered, held : bool) : uint {
+    let idle = rgba(60u, 90u, 140u, 255u)
+    let hover = rgba(90u, 150u, 230u, 255u)
+    let down = rgba(40u, 60u, 100u, 255u)
+    return held ? down : (hovered ? hover : idle)
+}
+
+def private draw_box(bb : float4; lbl : string; fill : uint) {
+    let ink = rgba(235u, 240u, 250u, 255u)
+    with_window_drawlist() $(var dl) {
+        dl |> add_rect_filled(ImVec2(bb.x, bb.y), ImVec2(bb.z, bb.w), fill, 4.0, ImDrawFlags.None)
+        dl |> add_text(ImVec2(bb.x + 10.0, bb.y + 8.0), ink, lbl)
+    }
+}
+
+// The hand-rolled button — every step the public `button` performs, in user code.
+// Returns (pressed, hovered, held); the latter two are ButtonBehavior's bool& outputs.
+def private custom_button(str_id : string; w, h : float; flags : ImGuiButtonFlags) : tuple<bool; bool; bool> {
+    let p = GetCursorScreenPos()
+    let bb = float4(p.x, p.y, p.x + w, p.y + h)
+    let id = GetID(str_id)
+    ItemSize(bb)                        // reserve layout space (advances the cursor)
+    // register the item; bail (item is clipped) if ItemAdd returns false
+    if (!ItemAdd(bb, id)) return (false, false, false)
+    var hovered = false
+    var held = false
+    let pressed = ButtonBehavior(bb, id, hovered, held, flags)
+    draw_box(bb, str_id, button_fill(hovered, held))
+    return (pressed, hovered, held)
+}
+
+[export]
+def init() {
+    harness_init("internal_item_add_button_behavior - hand-rolled button from primitives", 760, 560)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(720.0, 520.0), ImGuiCond.Always)
+    window(CB_WIN, (text = "internal_item_add_button_behavior", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+        text("A button assembled from imgui_internal.h primitives:")
+        text("  ItemSize -> ItemAdd -> ButtonBehavior -> drawlist render.")
+        separator()
+
+        // ----- 1. plain click button -----
+        let r1 = custom_button("custom: click me", 220.0, 36.0, ImGuiButtonFlags.None)
+        g_plain++ if (r1._0)
+        same_line()
+        text("clicks: {g_plain}   hovered={r1._1} held={r1._2}")
+
+        // ----- 2. repeat button — fires while held (ButtonBehavior + Repeat flag) -----
+        let repeat_flags = ImGuiButtonFlags.None | ImGuiButtonFlagsPrivate.Repeat
+        let r2 = custom_button("custom: hold to repeat", 220.0, 36.0, repeat_flags)
+        g_repeat++ if (r2._0)
+        same_line()
+        text("repeat fires: {g_repeat}   hovered={r2._1} held={r2._2}")
+        separator()
+
+        // ----- 3. ItemAdd 4-arg overload: a nav rect larger than the click box -----
+        // The nav rect is what keyboard nav scrolls-to / highlights when the item is
+        // focused; here it is inflated 16px around the visual button box.
+        text("ItemAdd 4-arg overload — explicit nav rect (inflated around the box):")
+        let p3 = GetCursorScreenPos()
+        let bb3 = float4(p3.x, p3.y, p3.x + 220.0, p3.y + 36.0)
+        let nav3 = float4(bb3.x - 16.0, bb3.y - 16.0, bb3.z + 16.0, bb3.w + 16.0)
+        let id3 = GetID("custom: nav rect")
+        ItemSize(bb3)
+        if (ItemAdd(bb3, id3, nav3)) {
+            var h3 = false
+            var d3 = false
+            if (ButtonBehavior(bb3, id3, h3, d3, ImGuiButtonFlags.None)) {
+                g_nav++
+            }
+            draw_box(bb3, "custom: nav rect", button_fill(h3, d3))
+        }
+        dummy(SP3, ImVec2(700.0, 10.0))
+        text("nav-rect clicks: {g_nav}")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -49,6 +49,10 @@ namespace das {
         const char* text, const ImVec2& align, const ImRect* clip_rect );
     DAS_MOD_API void RenderTextEllipsisW( ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max,
         float clip_max_x, float ellipsis_max_x, const char* text );
+    // imgui_internal.h custom-widget primitives — ItemAdd (two overloads) + ButtonBehavior.
+    DAS_MOD_API bool ItemAddW( const ImRect& bb, ImGuiID id, ImGuiItemFlags extra_flags = 0 );
+    DAS_MOD_API bool ItemAddNavW( const ImRect& bb, ImGuiID id, const ImRect& nav_bb, ImGuiItemFlags extra_flags = 0 );
+    DAS_MOD_API bool ButtonBehaviorW( const ImRect& bb, ImGuiID id, bool& out_hovered, bool& out_held, ImGuiButtonFlags_ flags );
     DAS_MOD_API ImColor HSV(float h, float s, float v, float a = 1.0f);
     DAS_MOD_API void ImGTB_Append ( ImGuiTextBuffer & buf, const char * txt );
     DAS_MOD_API int ImGTB_At ( ImGuiTextBuffer & buf, int32_t index );

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -336,6 +336,22 @@ namespace das {
         ImGui::RenderTextEllipsis(draw_list, pos_min, pos_max, clip_max_x, ellipsis_max_x, text, nullptr, nullptr);
     }
 
+    // imgui_internal.h ItemAdd — two overloads so the optional separate nav rect
+    // stays a clean by-value arg instead of a nullable pointer at the call site.
+    bool ItemAddW( const ImRect& bb, ImGuiID id, ImGuiItemFlags extra_flags ) {
+        return ImGui::ItemAdd(bb, id, nullptr, extra_flags);
+    }
+
+    bool ItemAddNavW( const ImRect& bb, ImGuiID id, const ImRect& nav_bb, ImGuiItemFlags extra_flags ) {
+        return ImGui::ItemAdd(bb, id, &nav_bb, extra_flags);
+    }
+
+    // imgui_internal.h ButtonBehavior — out_hovered / out_held exposed as bool&
+    // (das passes plain vars, write-back via SideEffects::modifyArgument).
+    bool ButtonBehaviorW( const ImRect& bb, ImGuiID id, bool& out_hovered, bool& out_held, ImGuiButtonFlags_ flags ) {
+        return ImGui::ButtonBehavior(bb, id, &out_hovered, &out_held, flags);
+    }
+
     // ImColor
 
     ImColor HSV(float h, float s, float v, float a) {
@@ -547,6 +563,22 @@ namespace das {
         addExtern<DAS_BIND_FUN(das::RenderTextEllipsisW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "RenderTextEllipsis",
             SideEffects::worstDefault, "das::RenderTextEllipsisW")
                 ->args({"draw_list","pos_min","pos_max","clip_max_x","ellipsis_max_x","text"});
+        // imgui_internal.h custom-widget primitives. ItemAdd is two overloads
+        // (arity 3 = no nav rect / arity 4 = explicit nav rect); ButtonBehavior
+        // returns its two state outputs through bool& args. extra_flags is the
+        // internal ImGuiItemFlags (binds as int); flags is the public
+        // ImGuiButtonFlags (das enum, combines via the imgui_enums.das `|` rail).
+        addExtern<DAS_BIND_FUN(das::ItemAddW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "ItemAdd",
+            SideEffects::worstDefault, "das::ItemAddW")
+                ->args({"bb","id","extra_flags"})
+                    ->arg_init(2,new ExprConstInt(0));
+        addExtern<DAS_BIND_FUN(das::ItemAddNavW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "ItemAdd",
+            SideEffects::worstDefault, "das::ItemAddNavW")
+                ->args({"bb","id","nav_bb","extra_flags"})
+                    ->arg_init(3,new ExprConstInt(0));
+        addExtern<DAS_BIND_FUN(das::ButtonBehaviorW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "ButtonBehavior",
+            SideEffects::worstDefault, "das::ButtonBehaviorW")
+                ->args({"bb","id","out_hovered","out_held","flags"});
         // variadic functions
         addExtern<DAS_BIND_FUN(das::Text)>(*this,lib,"Text",
             SideEffects::worstDefault,"das::Text");

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -347,7 +347,8 @@ namespace das {
     }
 
     // imgui_internal.h ButtonBehavior — out_hovered / out_held exposed as bool&
-    // (das passes plain vars, write-back via SideEffects::modifyArgument).
+    // (das passes plain vars; write-back works, registered SideEffects::worstDefault
+    // below since the call also touches ImGui global hover / active-id state).
     bool ButtonBehaviorW( const ImRect& bb, ImGuiID id, bool& out_hovered, bool& out_held, ImGuiButtonFlags_ flags ) {
         return ImGui::ButtonBehavior(bb, id, &out_hovered, &out_held, flags);
     }
@@ -563,11 +564,13 @@ namespace das {
         addExtern<DAS_BIND_FUN(das::RenderTextEllipsisW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "RenderTextEllipsis",
             SideEffects::worstDefault, "das::RenderTextEllipsisW")
                 ->args({"draw_list","pos_min","pos_max","clip_max_x","ellipsis_max_x","text"});
-        // imgui_internal.h custom-widget primitives. ItemAdd is two overloads
-        // (arity 3 = no nav rect / arity 4 = explicit nav rect); ButtonBehavior
-        // returns its two state outputs through bool& args. extra_flags is the
-        // internal ImGuiItemFlags (binds as int); flags is the public
-        // ImGuiButtonFlags (das enum, combines via the imgui_enums.das `|` rail).
+        // imgui_internal.h custom-widget primitives. ItemAdd is two overloads —
+        // without / with an explicit nav rect. extra_flags defaults, so the das
+        // calls are ItemAdd(bb,id[,flags]) and ItemAdd(bb,id,nav_bb[,flags]); at
+        // three args the nav overload is picked by float4 nav_bb vs int flags.
+        // ButtonBehavior returns its two state outputs through bool& args.
+        // extra_flags is the internal ImGuiItemFlags (binds as int); flags is the
+        // public ImGuiButtonFlags (das enum, combines via the imgui_enums.das `|` rail).
         addExtern<DAS_BIND_FUN(das::ItemAddW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "ItemAdd",
             SideEffects::worstDefault, "das::ItemAddW")
                 ->args({"bb","id","extra_flags"})

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -179,7 +179,13 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Internal *Ex buttons with behavior flags (Repeat / PressedOnClick / …, from the
     // ImGuiButtonFlagsPrivate_ enum combined via the imgui_enums.das cross-enum `|`).
     // Raw escape hatches next to the wrapped `button` / `arrow_button` widgets.
-    "ButtonEx", "ArrowButtonEx"
+    "ButtonEx", "ArrowButtonEx",
+    // Custom-widget primitives — reserve layout + register an item (ItemAdd, two
+    // overloads) and run the press/hover/hold state machine over a rect
+    // (ButtonBehavior). Bound via manual C++ wrappers (dasIMGUI.main.cpp): ItemAdd's
+    // optional nav rect is a clean by-value overload, ButtonBehavior's two state
+    // outputs come back through bool& args.
+    "ItemAdd", "ButtonBehavior"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
The `imgui_internal.h` primitives the public `button` widget is built on: **`ItemAdd`** (reserve + register an item) and **`ButtonBehavior`** (the press / hover / hold state machine). Both via manual C++ wrappers in `dasIMGUI.main.cpp` (the same rail as the `RenderText*W` text trio), so the das call sites stay idiomatic:

- **`ItemAdd` is two overloads.** Arity-3 `ItemAdd(bb, id, extra_flags=0)` passes `nullptr` for the optional nav rect; arity-4 `ItemAdd(bb, id, nav_bb, extra_flags=0)` takes the nav rect by value and passes its address. Keeps the separate-nav-rect feature without a nullable pointer at the call site.
- **`ButtonBehavior` returns its two state outputs through `bool&` args** (das passes plain `var`s, write-back works via `SideEffects::worstDefault` — the `sincos` precedent), so no `safe_addr` / `bool?` at the call site. `flags` is the public `ImGuiButtonFlags` enum and combines with the internal `ImGuiButtonFlagsPrivate` behavior flags via #173's cross-enum `|` rail.

`bb` / `nav_bb` marshal as `float4` (ImRect alias, #166); `ItemAdd`'s `extra_flags` is the internal `ImGuiItemFlags` (binds as int). `ItemAdd` / `ButtonBehavior` added to `ALLOWED_IMGUI` (raw escape hatches). `aot_dasIMGUI.h` carries the three decls.

> Note: `nav_bb` (`const ImRect*`) and the `bool*` out-params would all bind raw too (like `clip_rect` in the text wrappers and `p_open` in `ShowDemoWindow`) — the manual wrappers are an **ergonomics** choice (clean overloads + `bool&` outputs), not a marshalling necessity.

**Example** `internal_item_add_button_behavior.das` assembles a hand-rolled button (`ItemSize` → `ItemAdd` → `ButtonBehavior` → drawlist render) three ways: a plain click button, a Repeat button (held fires repeatedly), and one exercising the 4-arg `ItemAdd` nav-rect overload. Clean headless (exit 0); lint + format clean; ran windowed.

Pure manual-wrapper PR — **no regen, no func-chunk churn.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)