### PR TITLE
imgui: bind axis-aligned layout primitives — Splitter + Scrollbar (family)

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -141,6 +141,9 @@ class ImguiGen : CppGenBind {
         // enum name. Override the strip-prefix so they bind as ImGuiButtonFlagsPrivate.Repeat
         // etc. (else enum_entry_name leaves the full `ImGuiButtonFlags_Repeat`).
         enum_prefix |> insert("ImGuiButtonFlagsPrivate_", "ImGuiButtonFlags")
+        // ImGuiAxis's tag has no trailing underscore but its values are ImGuiAxis_X /
+        // ImGuiAxis_Y, so strip the full "ImGuiAxis_" prefix (default would leave "_X").
+        enum_prefix |> insert("ImGuiAxis", "ImGuiAxis_")
         // Family 1 — Render* draw helpers from imgui_internal.h. Every argument is
         // an already-bound public type (ImVec2, ImU32, ImDrawList*, ImGuiDir,
         // ImGuiMouseCursor, ImDrawFlags), so no internal struct/enum is pulled in.
@@ -241,11 +244,20 @@ class ImguiGen : CppGenBind {
             // (bool* out-params) and ItemAdd (nullable nav_bb -> C++ wrapper) are the
             // custom-widget primitives, deferred to the next family. ImageButtonEx is
             // texture-centric (ImTextureID = void*), deferred to an image family.
-            "ImGui::ButtonEx", "ImGui::ArrowButtonEx"
+            "ImGui::ButtonEx", "ImGui::ArrowButtonEx",
+            // Axis-aligned interactive layout primitives. Scrollbar(axis) draws the
+            // current window's scrollbar on the given axis — binds raw (one ImGuiAxis
+            // arg). Its lower-level sibling ScrollbarEx (ImS64* scroll out-param) and
+            // SplitterBehavior (float* size1/size2 out-params) are manual C++ wrappers
+            // (dasIMGUI.main.cpp) so the out-params come back through int64& / float&.
+            "ImGui::Scrollbar"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_",
-            "ImGuiButtonFlagsPrivate_"
+            "ImGuiButtonFlagsPrivate_",
+            // Axis selector (None=-1 / X=0 / Y=1) for the scrollbar / splitter
+            // behavior primitives. Plain enum, tag has no trailing underscore.
+            "ImGuiAxis"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_splitter_scrollbar.das
+++ b/examples/features/internal_splitter_scrollbar.das
@@ -1,0 +1,128 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_splitter_scrollbar — the imgui_internal.h axis-aligned
+//          interactive layout primitives. Cherry-picked into the v2 binding:
+//          Scrollbar(axis) raw (bind_imgui.das internal_allow_func); ScrollbarEx
+//          (ImS64& scroll out-param) and SplitterBehavior (float& size1/size2
+//          out-params) as manual C++ wrappers (dasIMGUI.main.cpp), so their in/out
+//          numeric state comes back through references. New internal enum ImGuiAxis
+//          (None / X / Y). This is the "binding is usable" gate: it drives the real
+//          bound API at runtime, not just compiles it.
+// SHOWS:   a draggable vertical SPLITTER resizing two panes (drag the bar — the two
+//          widths update live via float& out-params); a custom vertical SCROLLBAR
+//          (ScrollbarEx) driving a scrolling list of rows through an ImS64& position;
+//          and Scrollbar(axis) drawing a child window's own scrollbar.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_splitter_scrollbar.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_splitter_scrollbar.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_splitter_scrollbar.das
+// =============================================================================
+
+var g_left = 240.0
+var g_right = 300.0
+var g_scroll = int64(0)
+
+[export]
+def init() {
+    harness_init("internal_splitter_scrollbar - splitter + scrollbar behaviors", 820, 600)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    let ink = rgba(235u, 240u, 250u, 255u)
+    let pane_l = rgba(55u, 85u, 130u, 255u)
+    let pane_r = rgba(70u, 110u, 70u, 255u)
+    let bar_col = rgba(150u, 160u, 180u, 255u)
+
+    SetNextWindowSize(ImVec2(780.0, 560.0), ImGuiCond.Always)
+    window(SS_WIN, (text = "internal_splitter_scrollbar", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        // ----- SplitterBehavior: drag the bar to resize two panes -----
+        text("SplitterBehavior(bb, id, axis, size1, size2, min1, min2): drag the bar.")
+        let pane_h = 150.0
+        let bar_w = 8.0
+        let o = GetCursorScreenPos()
+        let bar_x = o.x + g_left
+        let split_bb = float4(bar_x, o.y, bar_x + bar_w, o.y + pane_h)
+        // float& size1/size2 -> g_left / g_right update in place on drag.
+        let dragging = SplitterBehavior(split_bb, GetID("vsplitter"), ImGuiAxis.X, g_left, g_right, 80.0, 80.0)
+        with_window_drawlist() $(var dl) {
+            dl |> add_rect_filled(ImVec2(o.x, o.y), ImVec2(o.x + g_left, o.y + pane_h), pane_l, 4.0, ImDrawFlags.None)
+            dl |> add_rect_filled(ImVec2(bar_x, o.y), ImVec2(bar_x + bar_w, o.y + pane_h), bar_col, 0.0, ImDrawFlags.None)
+            dl |> add_rect_filled(ImVec2(bar_x + bar_w, o.y), ImVec2(bar_x + bar_w + g_right, o.y + pane_h), pane_r, 4.0, ImDrawFlags.None)
+            dl |> add_text(ImVec2(o.x + 12.0, o.y + 10.0), ink, "left pane")
+            dl |> add_text(ImVec2(bar_x + bar_w + 12.0, o.y + 10.0), ink, "right pane")
+        }
+        dummy(SP1, ImVec2(g_left + bar_w + g_right, pane_h + 6.0))
+        text("  left = {int(g_left)}px   right = {int(g_right)}px   (dragging = {dragging})")
+        separator()
+
+        // ----- ScrollbarEx: a custom scrollbar driving a scrolling row list -----
+        text("ScrollbarEx(bb, id, axis, scroll, avail, contents, flags): drag to scroll.")
+        let view_h = 200.0
+        let row_h = 30.0
+        let n_rows = 40
+        let content_h = float(n_rows) * row_h
+        let v = GetCursorScreenPos()
+        let list_w = 560.0
+        let sb_w = 16.0
+        let view_top = v.y
+        let view_bot = v.y + view_h
+        let sb_bb = float4(v.x + list_w + 6.0, view_top, v.x + list_w + 6.0 + sb_w, view_bot)
+        // ImS64& scroll -> g_scroll updates as the grab is dragged.
+        let scrolled = ScrollbarEx(sb_bb, GetID("custom_scrollbar"), ImGuiAxis.Y, g_scroll,
+                                   int64(view_h), int64(content_h), ImDrawFlags.None)
+        with_window_drawlist() $(var dl) {
+            dl |> add_rect_filled(ImVec2(v.x, view_top), ImVec2(v.x + list_w, view_bot),
+                                  rgba(35u, 40u, 55u, 255u), 0.0, ImDrawFlags.None)
+            for (i in range(n_rows)) {
+                let ry = view_top + float(i) * row_h - float(g_scroll)
+                continue if (ry + row_h < view_top || ry > view_bot)
+                let band = (i % 2 == 0) ? rgba(50u, 58u, 78u, 255u) : rgba(42u, 49u, 66u, 255u)
+                dl |> add_rect_filled(ImVec2(v.x + 2.0, ry + 2.0), ImVec2(v.x + list_w - 2.0, ry + row_h - 2.0),
+                                      band, 0.0, ImDrawFlags.None)
+                dl |> add_text(ImVec2(v.x + 12.0, ry + 7.0), ink, "row {i}")
+            }
+        }
+        dummy(SP2, ImVec2(list_w + sb_w + 12.0, view_h + 6.0))
+        text("  scroll = {int(g_scroll)} / {int(content_h - view_h)}   (held = {scrolled})")
+        separator()
+
+        // ----- Scrollbar(axis): a child window's own scrollbar (raw binding) -----
+        // NoScrollbar suppresses the child's auto scrollbar so the manual
+        // Scrollbar(ImGuiAxis.Y) below is the only one drawn for the (overflowing) child.
+        text("Scrollbar(axis): the raw current-window scrollbar, drawn in this child:")
+        child(SS_CHILD, (text = "scroll_child", size = float2(560.0f, 96.0f),
+                         child_flags = ImGuiChildFlags.Border,
+                         window_flags = ImGuiWindowFlags.NoScrollbar)) {
+            text("a child whose content is taller than its frame:")
+            dummy(CHILD_FILL, ImVec2(1.0, 240.0))
+            text("...bottom of the child content.")
+            Scrollbar(ImGuiAxis.Y)
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -53,6 +53,10 @@ namespace das {
     DAS_MOD_API bool ItemAddW( const ImRect& bb, ImGuiID id, ImGuiItemFlags extra_flags = 0 );
     DAS_MOD_API bool ItemAddNavW( const ImRect& bb, ImGuiID id, const ImRect& nav_bb, ImGuiItemFlags extra_flags = 0 );
     DAS_MOD_API bool ButtonBehaviorW( const ImRect& bb, ImGuiID id, bool& out_hovered, bool& out_held, ImGuiButtonFlags_ flags );
+    DAS_MOD_API bool ScrollbarExW( const ImRect& bb, ImGuiID id, ImGuiAxis axis, ImS64& scroll_v,
+        ImS64 avail_v, ImS64 contents_v, ImDrawFlags_ flags );
+    DAS_MOD_API bool SplitterBehaviorW( const ImRect& bb, ImGuiID id, ImGuiAxis axis, float& size1, float& size2,
+        float min_size1, float min_size2, float hover_extend = 0.0f, float hover_visibility_delay = 0.0f, ImU32 bg_col = 0 );
     DAS_MOD_API ImColor HSV(float h, float s, float v, float a = 1.0f);
     DAS_MOD_API void ImGTB_Append ( ImGuiTextBuffer & buf, const char * txt );
     DAS_MOD_API int ImGTB_At ( ImGuiTextBuffer & buf, int32_t index );

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -40,6 +40,7 @@ addEnumeration(new Enumeration_ImGuiViewportFlags_());
 addEnumeration(new Enumeration_ImGuiItemFlags_());
 addEnumeration(new Enumeration_ImGuiButtonFlagsPrivate_());
 addEnumeration(new Enumeration_ImGuiTooltipFlags_());
+addEnumeration(new Enumeration_ImGuiAxis());
 addEnumeration(new Enumeration_ImGuiNavHighlightFlags_());
 addEnumFlagOps<ImGuiWindowFlags_>(*this,lib,"ImGuiWindowFlags_");
 addEnumFlagOps<ImGuiChildFlags_>(*this,lib,"ImGuiChildFlags_");

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1074,6 +1074,19 @@ public:
 	}
 };
 
+// from imgui_internal.h:994:6
+class Enumeration_ImGuiAxis : public das::Enumeration {
+public:
+	Enumeration_ImGuiAxis() : das::Enumeration("ImGuiAxis") {
+		external = true;
+		cppName = "ImGuiAxis";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("None", "ImGuiAxis_None", int64_t(ImGuiAxis::ImGuiAxis_None), das::LineInfo());
+		addIEx("X", "ImGuiAxis_X", int64_t(ImGuiAxis::ImGuiAxis_X), das::LineInfo());
+		addIEx("Y", "ImGuiAxis_Y", int64_t(ImGuiAxis::ImGuiAxis_Y), das::LineInfo());
+	}
+};
+
 // from imgui_internal.h:1594:6
 class Enumeration_ImGuiNavHighlightFlags_ : public das::Enumeration {
 public:

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -41,4 +41,5 @@ DAS_BIND_ENUM_CAST(ImGuiViewportFlags_);
 DAS_BIND_ENUM_CAST(ImGuiItemFlags_);
 DAS_BIND_ENUM_CAST(ImGuiButtonFlagsPrivate_);
 DAS_BIND_ENUM_CAST(ImGuiTooltipFlags_);
+DAS_BIND_ENUM_CAST(ImGuiAxis);
 DAS_BIND_ENUM_CAST(ImGuiNavHighlightFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -79,5 +79,7 @@ DAS_BASE_BIND_ENUM_GEN(ImGuiButtonFlagsPrivate_,ImGuiButtonFlagsPrivate);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiTooltipFlags_,ImGuiTooltipFlags);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiAxis,ImGuiAxis);
+
 DAS_BASE_BIND_ENUM_GEN(ImGuiNavHighlightFlags_,ImGuiNavHighlightFlags);
 

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -38,6 +38,10 @@ void Module_dasIMGUI::initFunctions_32() {
 		->arg_type(3,makeType<ImGuiButtonFlags_>(lib))
 		->arg_init(3,new ExprConstEnumeration(0,makeType<ImGuiButtonFlags_>(lib)))
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3754:29
+	makeExtern< void (*)(ImGuiAxis) , ImGui::Scrollbar , SimNode_ExtFuncCall , imguiTempFn>(lib,"Scrollbar","ImGui::Scrollbar")
+		->args({"axis"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3767:29
 	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
 		->args({"id"})

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -353,6 +353,23 @@ namespace das {
         return ImGui::ButtonBehavior(bb, id, &out_hovered, &out_held, flags);
     }
 
+    // imgui_internal.h ScrollbarEx — low-level scrollbar over an explicit rect.
+    // p_scroll_v is an in/out scroll position; exposed as ImS64& (das var passed in,
+    // updated on drag). avail_v / contents_v are the visible / total content extents.
+    bool ScrollbarExW( const ImRect& bb, ImGuiID id, ImGuiAxis axis, ImS64& scroll_v,
+        ImS64 avail_v, ImS64 contents_v, ImDrawFlags_ flags ) {
+        return ImGui::ScrollbarEx(bb, id, axis, &scroll_v, avail_v, contents_v, flags);
+    }
+
+    // imgui_internal.h SplitterBehavior — draggable splitter bar. size1 / size2 are
+    // the two pane sizes (in/out floats, exposed as float&): on drag the bar moves
+    // and both are updated, clamped to min_size1 / min_size2.
+    bool SplitterBehaviorW( const ImRect& bb, ImGuiID id, ImGuiAxis axis, float& size1, float& size2,
+        float min_size1, float min_size2, float hover_extend, float hover_visibility_delay, ImU32 bg_col ) {
+        return ImGui::SplitterBehavior(bb, id, axis, &size1, &size2, min_size1, min_size2,
+            hover_extend, hover_visibility_delay, bg_col);
+    }
+
     // ImColor
 
     ImColor HSV(float h, float s, float v, float a) {
@@ -582,6 +599,21 @@ namespace das {
         addExtern<DAS_BIND_FUN(das::ButtonBehaviorW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "ButtonBehavior",
             SideEffects::worstDefault, "das::ButtonBehaviorW")
                 ->args({"bb","id","out_hovered","out_held","flags"});
+        // imgui_internal.h scrollbar / splitter behaviors. Both take an ImGuiAxis +
+        // ImRect (float4) and return their in/out numeric state through references —
+        // ScrollbarEx's scroll pos as ImS64&, SplitterBehavior's two pane sizes as
+        // float&. SplitterBehavior's hover_extend / hover_visibility_delay / bg_col
+        // default, so the common call is (bb, id, axis, size1, size2, min1, min2).
+        addExtern<DAS_BIND_FUN(das::ScrollbarExW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "ScrollbarEx",
+            SideEffects::worstDefault, "das::ScrollbarExW")
+                ->args({"bb","id","axis","scroll_v","avail_v","contents_v","flags"});
+        addExtern<DAS_BIND_FUN(das::SplitterBehaviorW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "SplitterBehavior",
+            SideEffects::worstDefault, "das::SplitterBehaviorW")
+                ->args({"bb","id","axis","size1","size2","min_size1","min_size2",
+                        "hover_extend","hover_visibility_delay","bg_col"})
+                    ->arg_init(7,new ExprConstFloat(0.0f))
+                    ->arg_init(8,new ExprConstFloat(0.0f))
+                    ->arg_init(9,new ExprConstUInt(0));
         // variadic functions
         addExtern<DAS_BIND_FUN(das::Text)>(*this,lib,"Text",
             SideEffects::worstDefault,"das::Text");

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -185,7 +185,11 @@ let private ALLOWED_IMGUI : table<string> <- {
     // (ButtonBehavior). Bound via manual C++ wrappers (dasIMGUI.main.cpp): ItemAdd's
     // optional nav rect is a clean by-value overload, ButtonBehavior's two state
     // outputs come back through bool& args.
-    "ItemAdd", "ButtonBehavior"
+    "ItemAdd", "ButtonBehavior",
+    // Axis-aligned interactive layout primitives. Scrollbar(axis) is raw
+    // (internal_allow_func); ScrollbarEx (ImS64& scroll out-param) and
+    // SplitterBehavior (float& size1/size2 out-params) are manual C++ wrappers.
+    "Scrollbar", "ScrollbarEx", "SplitterBehavior"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
The `imgui_internal.h` interactive layout behaviors over a rect: **`SplitterBehavior`** (draggable split bar) and **`ScrollbarEx`** (low-level scrollbar), plus the high-level **`Scrollbar(axis)`**. New internal enum **`ImGuiAxis`** (None / X / Y) via `internal_allow_enum` — with an `enum_prefix` override since its tag has no trailing underscore but its values are `ImGuiAxis_X` / `ImGuiAxis_Y` (so they strip to `X` / `Y`, not `_X` / `_Y`).

- **`Scrollbar(axis)`** is raw (`internal_allow_func`, regen).
- **`SplitterBehavior`** and **`ScrollbarEx`** carry in/out numeric state through pointers (`float* size1/size2`, `ImS64* p_scroll_v`), so they get manual C++ wrappers (`dasIMGUI.main.cpp`) exposing those as **`float&` / `ImS64&`** — das passes plain `var`s, write-back via the `sincos` / `ButtonBehavior` precedent. `flags` is the public `ImDrawFlags` enum; `axis` is the new `ImGuiAxis` enum (bound, flows into the wrappers directly).

Regen: +1 makeExtern (`Scrollbar`) into `func_32`, +1 enum across the 4 `enum.*.inc`; **no new func chunk**, EOL churn reverted. `SplitterBehavior` / `ScrollbarEx` on `ALLOWED_IMGUI`.

**Example** `internal_splitter_scrollbar.das`: a draggable two-pane splitter (drag the bar — both widths update live via the `float&` out-params), a custom scrolling row-list driven by `ScrollbarEx`'s `ImS64&` position, and `Scrollbar(axis)` drawing a child's scrollbar. Clean headless (exit 0); lint + format clean; ran windowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)