### PR TITLE
imgui: bind tree-node state machine — TreeNodeBehavior family

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -250,7 +250,14 @@ class ImguiGen : CppGenBind {
             // arg). Its lower-level sibling ScrollbarEx (ImS64* scroll out-param) and
             // SplitterBehavior (float* size1/size2 out-params) are manual C++ wrappers
             // (dasIMGUI.main.cpp) so the out-params come back through int64& / float&.
-            "ImGui::Scrollbar"
+            "ImGui::Scrollbar",
+            // Tree-node state machine. TreeNodeSetOpen imperatively sets a node's
+            // open state by ID; TreeNodeUpdateNextOpen consumes a pending
+            // SetNextItemOpen() and returns the resolved open state. Both pure
+            // ImGuiID(uint)/bool/ImGuiTreeNodeFlags(public). The lower-level
+            // TreeNodeBehavior (nullable label_end -> C++ wrapper) is in
+            // dasIMGUI.main.cpp; pairs with the already-bound TreePushOverrideID.
+            "ImGui::TreeNodeSetOpen", "ImGui::TreeNodeUpdateNextOpen"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_",

--- a/examples/features/internal_tree_node_behavior.das
+++ b/examples/features/internal_tree_node_behavior.das
@@ -1,0 +1,97 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_tree_node_behavior — the imgui_internal.h tree-node state
+//          machine the public tree_node widget is built on. Cherry-picked into the
+//          v2 binding: TreeNodeBehavior (nullable label_end -> manual C++ wrapper in
+//          dasIMGUI.main.cpp that pins it to nullptr) is the open/closed core;
+//          TreeNodeSetOpen / TreeNodeUpdateNextOpen (raw, internal_allow_func) set /
+//          resolve a node's open state by ID. Pairs with the already-bound
+//          TreePushOverrideID + tree_pop(). This is the "binding is usable" gate: it
+//          drives the real bound API at runtime, not just compiles it.
+// SHOWS:   a hand-rolled tree (TreeNodeBehavior draws the arrow + label and toggles
+//          on click — nested, with tree_pop() on open); imperative open/close of a
+//          node by ID via TreeNodeSetOpen (no click needed); and TreeNodeUpdateNextOpen
+//          reading back the resolved open state for an ID.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_tree_node_behavior.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_tree_node_behavior.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_tree_node_behavior.das
+// =============================================================================
+
+// A custom tree node from the raw primitive: TreeNodeBehavior draws the arrow +
+// label, toggles open/closed on click, and (when open, without NoTreePushOnOpen)
+// pushes a tree layer — so the caller renders children + tree_pop() on a true return.
+def private custom_tree(lbl : string; flags : ImGuiTreeNodeFlags) : bool {
+    return TreeNodeBehavior(GetID(lbl), flags, lbl)
+}
+
+[export]
+def init() {
+    harness_init("internal_tree_node_behavior - hand-rolled tree from primitives", 760, 560)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(720.0, 500.0), ImGuiCond.Always)
+    window(TN_WIN, (text = "internal_tree_node_behavior", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        // ----- 1. hand-rolled, nested tree nodes from TreeNodeBehavior -----
+        text("TreeNodeBehavior(id, flags, label): the raw open/closed state machine.")
+        text("  click an arrow to toggle — the public tree_node, assembled in user code.")
+        if (custom_tree("Fruits", ImGuiTreeNodeFlags.None)) {
+            text("- apple")
+            text("- banana")
+            if (custom_tree("Citrus", ImGuiTreeNodeFlags.None)) {
+                text("- orange")
+                text("- lemon")
+                tree_pop()
+            }
+            tree_pop()
+        }
+        if (custom_tree("Vegetables", ImGuiTreeNodeFlags.None)) {
+            text("- carrot")
+            tree_pop()
+        }
+        separator()
+
+        // ----- 2. imperative open/close by ID via TreeNodeSetOpen -----
+        text("TreeNodeSetOpen(id, open): force a node's state by ID (no click needed).")
+        if (button(BTN_OPEN, (text = "Open 'Fruits'"))) {
+            TreeNodeSetOpen(GetID("Fruits"), true)
+        }
+        same_line()
+        if (button(BTN_CLOSE, (text = "Close 'Fruits'"))) {
+            TreeNodeSetOpen(GetID("Fruits"), false)
+        }
+        separator()
+
+        // ----- 3. resolved open state by ID via TreeNodeUpdateNextOpen -----
+        text("TreeNodeUpdateNextOpen(id, flags): the resolved open state for an ID.")
+        let fruits_open = TreeNodeUpdateNextOpen(GetID("Fruits"), ImGuiTreeNodeFlags.None)
+        text("  'Fruits' resolved-open = {fruits_open}")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -57,6 +57,7 @@ namespace das {
         ImS64 avail_v, ImS64 contents_v, ImDrawFlags_ flags );
     DAS_MOD_API bool SplitterBehaviorW( const ImRect& bb, ImGuiID id, ImGuiAxis axis, float& size1, float& size2,
         float min_size1, float min_size2, float hover_extend = 0.0f, float hover_visibility_delay = 0.0f, ImU32 bg_col = 0 );
+    DAS_MOD_API bool TreeNodeBehaviorW( ImGuiID id, ImGuiTreeNodeFlags_ flags, const char* label );
     DAS_MOD_API ImColor HSV(float h, float s, float v, float a = 1.0f);
     DAS_MOD_API void ImGTB_Append ( ImGuiTextBuffer & buf, const char * txt );
     DAS_MOD_API int ImGTB_At ( ImGuiTextBuffer & buf, int32_t index );

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -46,6 +46,15 @@ void Module_dasIMGUI::initFunctions_32() {
 	makeExtern< void (*)(unsigned int) , ImGui::TreePushOverrideID , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreePushOverrideID","ImGui::TreePushOverrideID")
 		->args({"id"})
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3768:29
+	makeExtern< void (*)(unsigned int,bool) , ImGui::TreeNodeSetOpen , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreeNodeSetOpen","ImGui::TreeNodeSetOpen")
+		->args({"id","open"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3769:29
+	makeExtern< bool (*)(unsigned int,int) , ImGui::TreeNodeUpdateNextOpen , SimNode_ExtFuncCall , imguiTempFn>(lib,"TreeNodeUpdateNextOpen","ImGui::TreeNodeUpdateNextOpen")
+		->args({"id","flags"})
+		->arg_type(1,makeType<ImGuiTreeNodeFlags_>(lib))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3770:29
 	makeExtern< void (*)(ImGuiSelectionUserData) , ImGui::SetNextItemSelectionUserData , SimNode_ExtFuncCall , imguiTempFn>(lib,"SetNextItemSelectionUserData","ImGui::SetNextItemSelectionUserData")
 		->args({"selection_user_data"})

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -370,6 +370,13 @@ namespace das {
             hover_extend, hover_visibility_delay, bg_col);
     }
 
+    // imgui_internal.h TreeNodeBehavior — the tree-node open/closed state machine.
+    // label_end is pinned to nullptr ("whole string"); a daslang string can't pass
+    // the NULL these need (same class as the RenderText*W text helpers above).
+    bool TreeNodeBehaviorW( ImGuiID id, ImGuiTreeNodeFlags_ flags, const char* label ) {
+        return ImGui::TreeNodeBehavior(id, flags, label, nullptr);
+    }
+
     // ImColor
 
     ImColor HSV(float h, float s, float v, float a) {
@@ -614,6 +621,12 @@ namespace das {
                     ->arg_init(7,new ExprConstFloat(0.0f))
                     ->arg_init(8,new ExprConstFloat(0.0f))
                     ->arg_init(9,new ExprConstUInt(0));
+        // imgui_internal.h TreeNodeBehavior — wrapper pins label_end to nullptr (a das
+        // string can't express the NULL it needs). flags default ImGuiTreeNodeFlags.None.
+        addExtern<DAS_BIND_FUN(das::TreeNodeBehaviorW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "TreeNodeBehavior",
+            SideEffects::worstDefault, "das::TreeNodeBehaviorW")
+                ->args({"id","flags","label"})
+                    ->arg_init(1,new ExprConstEnumeration(0,makeType<ImGuiTreeNodeFlags_>(lib)));
         // variadic functions
         addExtern<DAS_BIND_FUN(das::Text)>(*this,lib,"Text",
             SideEffects::worstDefault,"das::Text");

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -189,7 +189,11 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Axis-aligned interactive layout primitives. Scrollbar(axis) is raw
     // (internal_allow_func); ScrollbarEx (ImS64& scroll out-param) and
     // SplitterBehavior (float& size1/size2 out-params) are manual C++ wrappers.
-    "Scrollbar", "ScrollbarEx", "SplitterBehavior"
+    "Scrollbar", "ScrollbarEx", "SplitterBehavior",
+    // Tree-node state machine. TreeNodeBehavior (label_end -> nullptr wrapper) is the
+    // open/closed core; TreeNodeSetOpen / TreeNodeUpdateNextOpen (raw) set / resolve
+    // a node's open state by ID. Pair with the already-allowed TreePushOverrideID.
+    "TreeNodeBehavior", "TreeNodeSetOpen", "TreeNodeUpdateNextOpen"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
The `imgui_internal.h` tree-node primitives the public `tree_node` widget is built on:

- **`TreeNodeBehavior`** — the open/closed state machine (draws the arrow + label, toggles on click; pushes a tree layer when open).
- **`TreeNodeSetOpen`** — force a node's open state by ID (no click).
- **`TreeNodeUpdateNextOpen`** — consume a pending `SetNextItemOpen` + return the resolved open state.

Pairs with the already-bound `TreePushOverrideID` / `tree_pop()`.

`TreeNodeSetOpen` / `TreeNodeUpdateNextOpen` are raw (`internal_allow_func`, regen) — pure `ImGuiID`(uint) / `bool` / `ImGuiTreeNodeFlags`(public). `TreeNodeBehavior` carries a nullable `label_end` (a daslang string can't express the NULL it needs — same class as the `RenderText*W` text trio), so it gets a manual C++ wrapper (`dasIMGUI.main.cpp`) pinning `label_end` to `nullptr`. All three on `ALLOWED_IMGUI`.

Regen: +2 makeExterns into `func_32` (no new chunk), EOL churn reverted.

**Example** `internal_tree_node_behavior.das`: a hand-rolled nested tree (`TreeNodeBehavior` + `tree_pop`), imperative open/close of a node by ID via `TreeNodeSetOpen`, and `TreeNodeUpdateNextOpen` reading back the resolved open state. Clean headless (exit 0); lint + format clean; ran windowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)