### PR TITLE
imgui: bind separator / low-level text primitives — SeparatorEx family

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -257,14 +257,24 @@ class ImguiGen : CppGenBind {
             // ImGuiID(uint)/bool/ImGuiTreeNodeFlags(public). The lower-level
             // TreeNodeBehavior (nullable label_end -> C++ wrapper) is in
             // dasIMGUI.main.cpp; pairs with the already-bound TreePushOverrideID.
-            "ImGui::TreeNodeSetOpen", "ImGui::TreeNodeUpdateNextOpen"
+            "ImGui::TreeNodeSetOpen", "ImGui::TreeNodeUpdateNextOpen",
+            // SeparatorEx — a separator with explicit axis/span flags + thickness.
+            // ImGuiSeparatorFlags is internal -> the flags arg binds as int. Its
+            // siblings TextEx / SeparatorTextEx carry a nullable text_end / label_end
+            // and are manual C++ wrappers (dasIMGUI.main.cpp).
+            "ImGui::SeparatorEx"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_",
             "ImGuiButtonFlagsPrivate_",
             // Axis selector (None=-1 / X=0 / Y=1) for the scrollbar / splitter
             // behavior primitives. Plain enum, tag has no trailing underscore.
-            "ImGuiAxis"
+            "ImGuiAxis",
+            // Separator / low-level text flags. SeparatorEx takes ImGuiSeparatorFlags
+            // (Horizontal / Vertical / SpanAllColumns); TextEx takes ImGuiTextFlags
+            // (NoWidthForLargeClippedText). Both internal -> args bind as int (cast
+            // int(ImGuiSeparatorFlags.Vertical) at the call site, like ItemHoverable).
+            "ImGuiSeparatorFlags_", "ImGuiTextFlags_"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_separator_text.das
+++ b/examples/features/internal_separator_text.das
@@ -1,0 +1,84 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_separator_text — the imgui_internal.h separator / low-level
+//          text primitives below the public Separator / Text API. Cherry-picked
+//          into the v2 binding: SeparatorEx (raw, internal_allow_func — its
+//          ImGuiSeparatorFlags binds as int, cast at the call site); TextEx
+//          (nullable text_end) and SeparatorTextEx (nullable label_end) are manual
+//          C++ wrappers (dasIMGUI.main.cpp) that pin the terminus to nullptr. New
+//          internal enums ImGuiSeparatorFlags (Horizontal / Vertical / SpanAllColumns)
+//          and ImGuiTextFlags (NoWidthForLargeClippedText). This is the "binding is
+//          usable" gate: it drives the real bound API at runtime.
+// SHOWS:   SeparatorEx with varying thickness + a vertical separator between
+//          same-line items; TextEx (the low-level text renderer, with / without its
+//          layout flag); and SeparatorTextEx — a separator carrying an inline label.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_separator_text.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_separator_text.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_separator_text.das
+// =============================================================================
+
+[export]
+def init() {
+    harness_init("internal_separator_text - SeparatorEx / TextEx / SeparatorTextEx", 760, 540)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(720.0, 500.0), ImGuiCond.Always)
+    window(ST_WIN, (text = "internal_separator_text", closable = false,
+                    flags = ImGuiWindowFlags.None)) {
+
+        // ----- SeparatorEx: axis + thickness -----
+        text("SeparatorEx(flags, thickness): horizontal separators of varying thickness.")
+        text("thin (1px):")
+        SeparatorEx(int(ImGuiSeparatorFlags.Horizontal), 1.0)
+        text("medium (3px):")
+        SeparatorEx(int(ImGuiSeparatorFlags.Horizontal), 3.0)
+        text("thick (6px):")
+        SeparatorEx(int(ImGuiSeparatorFlags.Horizontal), 6.0)
+        text("a vertical SeparatorEx between two same-line items:")
+        text("left")
+        same_line()
+        SeparatorEx(int(ImGuiSeparatorFlags.Vertical), 2.0)
+        same_line()
+        text("right")
+        separator()
+
+        // ----- TextEx: the low-level text renderer with layout flags -----
+        text("TextEx(text, flags): the low-level text renderer (ImGuiTextFlags).")
+        TextEx("plain TextEx, no flags")
+        TextEx("TextEx with NoWidthForLargeClippedText", int(ImGuiTextFlags.NoWidthForLargeClippedText))
+        separator()
+
+        // ----- SeparatorTextEx: a separator carrying an inline label -----
+        text("SeparatorTextEx(id, label, extra_width): a separator with an inline label.")
+        SeparatorTextEx(GetID("sec1"), "Section One", 0.0)
+        text("content under section one")
+        SeparatorTextEx(GetID("sec2"), "Section Two (extra_width 40)", 40.0)
+        text("content under section two")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -58,6 +58,8 @@ namespace das {
     DAS_MOD_API bool SplitterBehaviorW( const ImRect& bb, ImGuiID id, ImGuiAxis axis, float& size1, float& size2,
         float min_size1, float min_size2, float hover_extend = 0.0f, float hover_visibility_delay = 0.0f, ImU32 bg_col = 0 );
     DAS_MOD_API bool TreeNodeBehaviorW( ImGuiID id, ImGuiTreeNodeFlags_ flags, const char* label );
+    DAS_MOD_API void TextExW( const char* text, ImGuiTextFlags flags = 0 );
+    DAS_MOD_API void SeparatorTextExW( ImGuiID id, const char* label, float extra_width = 0.0f );
     DAS_MOD_API ImColor HSV(float h, float s, float v, float a = 1.0f);
     DAS_MOD_API void ImGTB_Append ( ImGuiTextBuffer & buf, const char * txt );
     DAS_MOD_API int ImGTB_At ( ImGuiTextBuffer & buf, int32_t index );

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -39,6 +39,8 @@ addEnumeration(new Enumeration_ImFontAtlasFlags_());
 addEnumeration(new Enumeration_ImGuiViewportFlags_());
 addEnumeration(new Enumeration_ImGuiItemFlags_());
 addEnumeration(new Enumeration_ImGuiButtonFlagsPrivate_());
+addEnumeration(new Enumeration_ImGuiSeparatorFlags_());
+addEnumeration(new Enumeration_ImGuiTextFlags_());
 addEnumeration(new Enumeration_ImGuiTooltipFlags_());
 addEnumeration(new Enumeration_ImGuiAxis());
 addEnumeration(new Enumeration_ImGuiNavHighlightFlags_());

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1062,6 +1062,32 @@ public:
 	}
 };
 
+// from imgui_internal.h:946:6
+class Enumeration_ImGuiSeparatorFlags_ : public das::Enumeration {
+public:
+	Enumeration_ImGuiSeparatorFlags_() : das::Enumeration("ImGuiSeparatorFlags") {
+		external = true;
+		cppName = "ImGuiSeparatorFlags_";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("None", "ImGuiSeparatorFlags_None", int64_t(ImGuiSeparatorFlags_::ImGuiSeparatorFlags_None), das::LineInfo());
+		addIEx("Horizontal", "ImGuiSeparatorFlags_Horizontal", int64_t(ImGuiSeparatorFlags_::ImGuiSeparatorFlags_Horizontal), das::LineInfo());
+		addIEx("Vertical", "ImGuiSeparatorFlags_Vertical", int64_t(ImGuiSeparatorFlags_::ImGuiSeparatorFlags_Vertical), das::LineInfo());
+		addIEx("SpanAllColumns", "ImGuiSeparatorFlags_SpanAllColumns", int64_t(ImGuiSeparatorFlags_::ImGuiSeparatorFlags_SpanAllColumns), das::LineInfo());
+	}
+};
+
+// from imgui_internal.h:964:6
+class Enumeration_ImGuiTextFlags_ : public das::Enumeration {
+public:
+	Enumeration_ImGuiTextFlags_() : das::Enumeration("ImGuiTextFlags") {
+		external = true;
+		cppName = "ImGuiTextFlags_";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("None", "ImGuiTextFlags_None", int64_t(ImGuiTextFlags_::ImGuiTextFlags_None), das::LineInfo());
+		addIEx("NoWidthForLargeClippedText", "ImGuiTextFlags_NoWidthForLargeClippedText", int64_t(ImGuiTextFlags_::ImGuiTextFlags_NoWidthForLargeClippedText), das::LineInfo());
+	}
+};
+
 // from imgui_internal.h:970:6
 class Enumeration_ImGuiTooltipFlags_ : public das::Enumeration {
 public:

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -40,6 +40,8 @@ DAS_BIND_ENUM_CAST(ImFontAtlasFlags_);
 DAS_BIND_ENUM_CAST(ImGuiViewportFlags_);
 DAS_BIND_ENUM_CAST(ImGuiItemFlags_);
 DAS_BIND_ENUM_CAST(ImGuiButtonFlagsPrivate_);
+DAS_BIND_ENUM_CAST(ImGuiSeparatorFlags_);
+DAS_BIND_ENUM_CAST(ImGuiTextFlags_);
 DAS_BIND_ENUM_CAST(ImGuiTooltipFlags_);
 DAS_BIND_ENUM_CAST(ImGuiAxis);
 DAS_BIND_ENUM_CAST(ImGuiNavHighlightFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -77,6 +77,10 @@ DAS_BASE_BIND_ENUM_GEN(ImGuiItemFlags_,ImGuiItemFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiButtonFlagsPrivate_,ImGuiButtonFlagsPrivate);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiSeparatorFlags_,ImGuiSeparatorFlags);
+
+DAS_BASE_BIND_ENUM_GEN(ImGuiTextFlags_,ImGuiTextFlags);
+
 DAS_BASE_BIND_ENUM_GEN(ImGuiTooltipFlags_,ImGuiTooltipFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiAxis,ImGuiAxis);

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -38,6 +38,11 @@ void Module_dasIMGUI::initFunctions_32() {
 		->arg_type(3,makeType<ImGuiButtonFlags_>(lib))
 		->arg_init(3,new ExprConstEnumeration(0,makeType<ImGuiButtonFlags_>(lib)))
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3746:29
+	makeExtern< void (*)(int,float) , ImGui::SeparatorEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"SeparatorEx","ImGui::SeparatorEx")
+		->args({"flags","thickness"})
+		->arg_init(1,new ExprConstFloat(1))
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3754:29
 	makeExtern< void (*)(ImGuiAxis) , ImGui::Scrollbar , SimNode_ExtFuncCall , imguiTempFn>(lib,"Scrollbar","ImGui::Scrollbar")
 		->args({"axis"})

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -377,6 +377,17 @@ namespace das {
         return ImGui::TreeNodeBehavior(id, flags, label, nullptr);
     }
 
+    // imgui_internal.h TextEx / SeparatorTextEx — both carry a nullable text_end /
+    // label_end (a daslang string can't express the NULL), pinned to nullptr here.
+    // ImGuiTextFlags is internal -> binds as int (cast int(ImGuiTextFlags.X)).
+    void TextExW( const char* text, ImGuiTextFlags flags ) {
+        ImGui::TextEx(text, nullptr, flags);
+    }
+
+    void SeparatorTextExW( ImGuiID id, const char* label, float extra_width ) {
+        ImGui::SeparatorTextEx(id, label, nullptr, extra_width);
+    }
+
     // ImColor
 
     ImColor HSV(float h, float s, float v, float a) {
@@ -627,6 +638,16 @@ namespace das {
             SideEffects::worstDefault, "das::TreeNodeBehaviorW")
                 ->args({"id","flags","label"})
                     ->arg_init(1,new ExprConstEnumeration(0,makeType<ImGuiTreeNodeFlags_>(lib)));
+        // imgui_internal.h TextEx / SeparatorTextEx — wrappers pin text_end / label_end
+        // to nullptr. TextEx's flags is the internal ImGuiTextFlags (int), default 0.
+        addExtern<DAS_BIND_FUN(das::TextExW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "TextEx",
+            SideEffects::worstDefault, "das::TextExW")
+                ->args({"text","flags"})
+                    ->arg_init(1,new ExprConstInt(0));
+        addExtern<DAS_BIND_FUN(das::SeparatorTextExW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "SeparatorTextEx",
+            SideEffects::worstDefault, "das::SeparatorTextExW")
+                ->args({"id","label","extra_width"})
+                    ->arg_init(2,new ExprConstFloat(0.0f));
         // variadic functions
         addExtern<DAS_BIND_FUN(das::Text)>(*this,lib,"Text",
             SideEffects::worstDefault,"das::Text");

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -193,7 +193,12 @@ let private ALLOWED_IMGUI : table<string> <- {
     // Tree-node state machine. TreeNodeBehavior (label_end -> nullptr wrapper) is the
     // open/closed core; TreeNodeSetOpen / TreeNodeUpdateNextOpen (raw) set / resolve
     // a node's open state by ID. Pair with the already-allowed TreePushOverrideID.
-    "TreeNodeBehavior", "TreeNodeSetOpen", "TreeNodeUpdateNextOpen"
+    "TreeNodeBehavior", "TreeNodeSetOpen", "TreeNodeUpdateNextOpen",
+    // Separator / low-level text. SeparatorEx (raw, ImGuiSeparatorFlags-as-int) is a
+    // separator with axis/span flags + thickness; TextEx (text_end -> nullptr wrapper,
+    // ImGuiTextFlags-as-int) and SeparatorTextEx (label_end -> nullptr wrapper) are
+    // the manual C++ wrappers.
+    "SeparatorEx", "TextEx", "SeparatorTextEx"
 }
 
 class ImguiLintVisitor : AstVisitor {


### PR DESCRIPTION
Three `imgui_internal.h` primitives below the public `Separator` / `Text` API:

- **`SeparatorEx`** — a separator with explicit axis/span flags + thickness.
- **`TextEx`** — the low-level text renderer with layout flags.
- **`SeparatorTextEx`** — a separator carrying an inline label.

`SeparatorEx` is raw (`internal_allow_func`, regen). `TextEx` and `SeparatorTextEx` carry a nullable `text_end` / `label_end` (a daslang string can't express the NULL — same class as the `RenderText*W` trio), so they get manual C++ wrappers (`dasIMGUI.main.cpp`) pinning the terminus to `nullptr`.

New internal enums **`ImGuiSeparatorFlags`** (Horizontal / Vertical / SpanAllColumns) and **`ImGuiTextFlags`** (NoWidthForLargeClippedText). Both internal, so their flag args bind **as int** — cast `int(ImGuiSeparatorFlags.Vertical)` at the call site, the established #171/#172 convention (public flag enums bind as the das enum; internal ones as int).

Regen: +1 makeExtern (`SeparatorEx`) into `func_32`, +2 enums across the 4 `enum.*.inc`; **no new func chunk**, EOL churn reverted. All three on `ALLOWED_IMGUI`.

**Example** `internal_separator_text.das`: `SeparatorEx` at three thicknesses + a vertical one between same-line items, `TextEx` with / without its flag, and two `SeparatorTextEx` labeled section dividers. Clean headless (exit 0); lint + format clean; ran windowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)