### PR TITLE
imgui: bind combo dropdown internals + custom-preview rail (family)

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -141,6 +141,9 @@ class ImguiGen : CppGenBind {
         // enum name. Override the strip-prefix so they bind as ImGuiButtonFlagsPrivate.Repeat
         // etc. (else enum_entry_name leaves the full `ImGuiButtonFlags_Repeat`).
         enum_prefix |> insert("ImGuiButtonFlagsPrivate_", "ImGuiButtonFlags")
+        // ImGuiComboFlagsPrivate_'s one value is ImGuiComboFlags_CustomPreview (carries
+        // the public ImGuiComboFlags_ prefix) — strip it so it binds as CustomPreview.
+        enum_prefix |> insert("ImGuiComboFlagsPrivate_", "ImGuiComboFlags")
         // ImGuiAxis's tag has no trailing underscore but its values are ImGuiAxis_X /
         // ImGuiAxis_Y, so strip the full "ImGuiAxis_" prefix (default would leave "_X").
         enum_prefix |> insert("ImGuiAxis", "ImGuiAxis_")
@@ -262,7 +265,14 @@ class ImguiGen : CppGenBind {
             // ImGuiSeparatorFlags is internal -> the flags arg binds as int. Its
             // siblings TextEx / SeparatorTextEx carry a nullable text_end / label_end
             // and are manual C++ wrappers (dasIMGUI.main.cpp).
-            "ImGui::SeparatorEx"
+            "ImGui::SeparatorEx",
+            // Combo internals — the low-level combo dropdown the public combo is
+            // built on. BeginComboPopup(popup_id, bb, flags) opens the dropdown for a
+            // self-managed box (pairs with EndPopup); BeginComboPreview / EndComboPreview
+            // render a custom preview for a BeginCombo opened with CustomPreview. All
+            // public types. Surface = with_combo_popup / with_custom_preview_combo /
+            // with_combo_preview scope guards (imgui_scope_builtin.das).
+            "ImGui::BeginComboPopup", "ImGui::BeginComboPreview", "ImGui::EndComboPreview"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_",
@@ -274,7 +284,11 @@ class ImguiGen : CppGenBind {
             // (Horizontal / Vertical / SpanAllColumns); TextEx takes ImGuiTextFlags
             // (NoWidthForLargeClippedText). Both internal -> args bind as int (cast
             // int(ImGuiSeparatorFlags.Vertical) at the call site, like ItemHoverable).
-            "ImGuiSeparatorFlags_", "ImGuiTextFlags_"
+            "ImGuiSeparatorFlags_", "ImGuiTextFlags_",
+            // ImGuiComboFlagsPrivate_ = the single internal combo flag CustomPreview
+            // (enables BeginComboPreview). Combined into the public ImGuiComboFlags
+            // inside the with_custom_preview_combo guard (imgui_scope_builtin.das).
+            "ImGuiComboFlagsPrivate_"
         }
     }
     def is_internal : bool {

--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -268,7 +268,8 @@ class ImguiGen : CppGenBind {
             "ImGui::SeparatorEx",
             // Combo internals — the low-level combo dropdown the public combo is
             // built on. BeginComboPopup(popup_id, bb, flags) opens the dropdown for a
-            // self-managed box (pairs with EndPopup); BeginComboPreview / EndComboPreview
+            // self-managed box (closes with EndCombo, NOT EndPopup — it bumps
+            // g.BeginComboDepth and only EndCombo unwinds it); BeginComboPreview / EndComboPreview
             // render a custom preview for a BeginCombo opened with CustomPreview. All
             // public types. Surface = with_combo_popup / with_custom_preview_combo /
             // with_combo_preview scope guards (imgui_scope_builtin.das).

--- a/examples/features/internal_combo.das
+++ b/examples/features/internal_combo.das
@@ -52,25 +52,40 @@ def update() {
     window(CMB_WIN, (text = "internal_combo", closable = false,
                      flags = ImGuiWindowFlags.None)) {
 
-        // ----- 1. low-level custom combo via BeginComboPopup -----
-        text("BeginComboPopup(popup_id, bb, flags): the low-level dropdown, built by hand.")
-        let cid = GetID("ll_combo")
-        if (button(LL_BOX, (text = "Fruit: {fruit_name(g_fruit)}   (click to open)"))) {
-            OpenPopupEx(cid, ImGuiPopupFlags.None)
-        }
-        // the box's rect positions the popup below it
-        let mn = GetItemRectMin()
-        let mx = GetItemRectMax()
-        let bb = float4(mn.x, mn.y, mx.x, mx.y)
-        with_combo_popup(cid, bb, ImGuiComboFlags.None) {
-            if (selectable_label(LL_A, "Apple", g_fruit == 0)) {
-                g_fruit = 0
+        // ----- 1. low-level custom combo: a box from ItemAdd + ButtonBehavior, its
+        //          dropdown from BeginComboPopup — exactly how the public combo is built.
+        //          The box id is stable; the current value is drawn into the box (so
+        //          changing the selection never shifts the box's id). -----
+        text("BeginComboPopup(popup_id, bb, flags): the low-level dropdown, built by hand")
+        text("  on ItemAdd + ButtonBehavior + the popup, exactly like the public combo.")
+        let box_id = GetID("ll_combo")
+        let popup_id = GetID("ll_combo_popup")
+        let bp = GetCursorScreenPos()
+        let box_bb = float4(bp.x, bp.y, bp.x + 240.0, bp.y + 32.0)
+        ItemSize(box_bb)
+        if (ItemAdd(box_bb, box_id)) {
+            var hovered = false
+            var held = false
+            let pressed = ButtonBehavior(box_bb, box_id, hovered, held, ImGuiButtonFlags.None)
+            // open only on a fresh press while closed (the public combo's own guard)
+            if (pressed && !IsPopupOpen(popup_id, ImGuiPopupFlags.None)) {
+                OpenPopupEx(popup_id, ImGuiPopupFlags.None)
             }
-            if (selectable_label(LL_B, "Banana", g_fruit == 1)) {
-                g_fruit = 1
+            let frame = held ? rgba(40u, 60u, 100u, 255u) : (hovered ? rgba(74u, 104u, 154u, 255u) : rgba(55u, 80u, 120u, 255u))
+            with_window_drawlist() $(var dl) {
+                dl |> add_rect_filled(ImVec2(box_bb.x, box_bb.y), ImVec2(box_bb.z, box_bb.w), frame, 3.0, ImDrawFlags.None)
+                dl |> add_text(ImVec2(box_bb.x + 8.0, box_bb.y + 7.0), rgba(235u, 240u, 250u, 255u), "Fruit: {fruit_name(g_fruit)}   v")
             }
-            if (selectable_label(LL_C, "Cherry", g_fruit == 2)) {
-                g_fruit = 2
+            with_combo_popup(popup_id, box_bb, ImGuiComboFlags.None) {
+                if (selectable_label(LL_A, "Apple", g_fruit == 0)) {
+                    g_fruit = 0
+                }
+                if (selectable_label(LL_B, "Banana", g_fruit == 1)) {
+                    g_fruit = 1
+                }
+                if (selectable_label(LL_C, "Cherry", g_fruit == 2)) {
+                    g_fruit = 2
+                }
             }
         }
         separator()

--- a/examples/features/internal_combo.das
+++ b/examples/features/internal_combo.das
@@ -1,0 +1,121 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_combo — the imgui_internal.h combo-dropdown primitives below
+//          the public combo widget. Cherry-picked into the v2 binding
+//          (bind_imgui.das internal_allow_func): BeginComboPopup (the low-level
+//          dropdown the public combo is built on), BeginComboPreview /
+//          EndComboPreview (custom-preview rendering for a CustomPreview combo). All
+//          public types. Surface = three scope guards in imgui_scope_builtin.das:
+//          with_combo_popup, with_custom_preview_combo (the enabling rail over the
+//          public BeginCombo+CustomPreview), and with_combo_preview. This is the
+//          "binding is usable" gate: it drives the real bound API at runtime.
+// SHOWS:   a fully hand-rolled combo (a box button + OpenPopupEx + with_combo_popup
+//          over the box's rect, items as selectables); and a custom-preview combo
+//          whose CLOSED-state preview is custom-drawn (a colour swatch + name) via
+//          with_custom_preview_combo + with_combo_preview.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_combo.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_combo.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_combo.das
+// =============================================================================
+
+var g_fruit = 0
+var g_color = 0
+
+def private fruit_name(i : int) : string {
+    return i == 0 ? "Apple" : (i == 1 ? "Banana" : "Cherry")
+}
+
+def private color_name(i : int) : string {
+    return i == 0 ? "Red" : (i == 1 ? "Green" : "Blue")
+}
+
+def private color_swatch(i : int) : uint {
+    return i == 0 ? rgba(220u, 70u, 70u, 255u) : (i == 1 ? rgba(70u, 200u, 90u, 255u) : rgba(80u, 120u, 230u, 255u))
+}
+
+[export]
+def init() {
+    harness_init("internal_combo - BeginComboPopup / custom-preview combo", 760, 520)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.25
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(720.0, 480.0), ImGuiCond.Always)
+    window(CMB_WIN, (text = "internal_combo", closable = false,
+                     flags = ImGuiWindowFlags.None)) {
+
+        // ----- 1. low-level custom combo via BeginComboPopup -----
+        text("BeginComboPopup(popup_id, bb, flags): the low-level dropdown, built by hand.")
+        let cid = GetID("ll_combo")
+        if (button(LL_BOX, (text = "Fruit: {fruit_name(g_fruit)}   (click to open)"))) {
+            OpenPopupEx(cid, ImGuiPopupFlags.None)
+        }
+        // the box's rect positions the popup below it
+        let mn = GetItemRectMin()
+        let mx = GetItemRectMax()
+        let bb = float4(mn.x, mn.y, mx.x, mx.y)
+        with_combo_popup(cid, bb, ImGuiComboFlags.None) {
+            if (selectable_label(LL_A, "Apple", g_fruit == 0)) {
+                g_fruit = 0
+            }
+            if (selectable_label(LL_B, "Banana", g_fruit == 1)) {
+                g_fruit = 1
+            }
+            if (selectable_label(LL_C, "Cherry", g_fruit == 2)) {
+                g_fruit = 2
+            }
+        }
+        separator()
+
+        // ----- 2. custom-preview combo: the closed preview is custom-drawn -----
+        text("Custom-preview combo: BeginCombo(CustomPreview) + BeginComboPreview —")
+        text("  the closed-state preview is a hand-drawn colour swatch + name.")
+        let cp_open = with_custom_preview_combo("##color_combo", ImGuiComboFlags.None) {
+            if (selectable_label(CP_R, "Red", g_color == 0)) {
+                g_color = 0
+            }
+            if (selectable_label(CP_G, "Green", g_color == 1)) {
+                g_color = 1
+            }
+            if (selectable_label(CP_B, "Blue", g_color == 2)) {
+                g_color = 2
+            }
+        }
+        // the custom preview (drawn into the combo's preview box regardless of open state)
+        with_combo_preview() {
+            let p = GetCursorScreenPos()
+            with_window_drawlist() $(var dl) {
+                dl |> add_rect_filled(ImVec2(p.x, p.y), ImVec2(p.x + 16.0, p.y + 16.0),
+                                      color_swatch(g_color), 2.0, ImDrawFlags.None)
+            }
+            dummy(SW, ImVec2(20.0, 16.0))
+            same_line()
+            text("{color_name(g_color)}")
+        }
+        text("selected colour = {color_name(g_color)}   (dropdown open = {cp_open})")
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -39,6 +39,7 @@ addEnumeration(new Enumeration_ImFontAtlasFlags_());
 addEnumeration(new Enumeration_ImGuiViewportFlags_());
 addEnumeration(new Enumeration_ImGuiItemFlags_());
 addEnumeration(new Enumeration_ImGuiButtonFlagsPrivate_());
+addEnumeration(new Enumeration_ImGuiComboFlagsPrivate_());
 addEnumeration(new Enumeration_ImGuiSeparatorFlags_());
 addEnumeration(new Enumeration_ImGuiTextFlags_());
 addEnumeration(new Enumeration_ImGuiTooltipFlags_());

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1062,6 +1062,17 @@ public:
 	}
 };
 
+// from imgui_internal.h:913:6
+class Enumeration_ImGuiComboFlagsPrivate_ : public das::Enumeration {
+public:
+	Enumeration_ImGuiComboFlagsPrivate_() : das::Enumeration("ImGuiComboFlagsPrivate") {
+		external = true;
+		cppName = "ImGuiComboFlagsPrivate_";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("CustomPreview", "ImGuiComboFlags_CustomPreview", int64_t(ImGuiComboFlagsPrivate_::ImGuiComboFlags_CustomPreview), das::LineInfo());
+	}
+};
+
 // from imgui_internal.h:946:6
 class Enumeration_ImGuiSeparatorFlags_ : public das::Enumeration {
 public:

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -40,6 +40,7 @@ DAS_BIND_ENUM_CAST(ImFontAtlasFlags_);
 DAS_BIND_ENUM_CAST(ImGuiViewportFlags_);
 DAS_BIND_ENUM_CAST(ImGuiItemFlags_);
 DAS_BIND_ENUM_CAST(ImGuiButtonFlagsPrivate_);
+DAS_BIND_ENUM_CAST(ImGuiComboFlagsPrivate_);
 DAS_BIND_ENUM_CAST(ImGuiSeparatorFlags_);
 DAS_BIND_ENUM_CAST(ImGuiTextFlags_);
 DAS_BIND_ENUM_CAST(ImGuiTooltipFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -77,6 +77,8 @@ DAS_BASE_BIND_ENUM_GEN(ImGuiItemFlags_,ImGuiItemFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiButtonFlagsPrivate_,ImGuiButtonFlagsPrivate);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiComboFlagsPrivate_,ImGuiComboFlagsPrivate);
+
 DAS_BASE_BIND_ENUM_GEN(ImGuiSeparatorFlags_,ImGuiSeparatorFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiTextFlags_,ImGuiTextFlags);

--- a/src/dasIMGUI.func_31.cpp
+++ b/src/dasIMGUI.func_31.cpp
@@ -24,6 +24,17 @@ void Module_dasIMGUI::initFunctions_31() {
 		->arg_init(3,new ExprConstBool(false))
 		->arg_init(4,new ExprConstBool(true))
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3429:29
+	makeExtern< bool (*)(unsigned int,const ImRect &,int) , ImGui::BeginComboPopup , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginComboPopup","ImGui::BeginComboPopup")
+		->args({"popup_id","bb","flags"})
+		->arg_type(2,makeType<ImGuiComboFlags_>(lib))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3430:29
+	makeExtern< bool (*)() , ImGui::BeginComboPreview , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginComboPreview","ImGui::BeginComboPreview")
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3431:29
+	makeExtern< void (*)() , ImGui::EndComboPreview , SimNode_ExtFuncCall , imguiTempFn>(lib,"EndComboPreview","ImGui::EndComboPreview")
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3455:29
 	makeExtern< void (*)() , ImGui::FocusItem , SimNode_ExtFuncCall , imguiTempFn>(lib,"FocusItem","ImGui::FocusItem")
 		->addToModule(*this, SideEffects::worstDefault);
@@ -92,19 +103,6 @@ void Module_dasIMGUI::initFunctions_31() {
 // from imgui_internal.h:3733:29
 	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int) , ImGui::RenderBullet , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderBullet","ImGui::RenderBullet")
 		->args({"draw_list","pos","col"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3734:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,float) , ImGui::RenderCheckMark , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderCheckMark","ImGui::RenderCheckMark")
-		->args({"draw_list","pos","col","sz"})
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3735:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,ImVec2,int,unsigned int) , ImGui::RenderArrowPointingAt , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowPointingAt","ImGui::RenderArrowPointingAt")
-		->args({"draw_list","pos","half_sz","direction","col"})
-		->arg_type(3,makeType<ImGuiDir_>(lib))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3736:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,float,unsigned int) , ImGui::RenderArrowDockMenu , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowDockMenu","ImGui::RenderArrowDockMenu")
-		->args({"draw_list","p_min","sz","col"})
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -12,6 +12,19 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_32() {
+// from imgui_internal.h:3734:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,float) , ImGui::RenderCheckMark , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderCheckMark","ImGui::RenderCheckMark")
+		->args({"draw_list","pos","col","sz"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3735:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,ImVec2,int,unsigned int) , ImGui::RenderArrowPointingAt , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowPointingAt","ImGui::RenderArrowPointingAt")
+		->args({"draw_list","pos","half_sz","direction","col"})
+		->arg_type(3,makeType<ImGuiDir_>(lib))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3736:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,float,unsigned int) , ImGui::RenderArrowDockMenu , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrowDockMenu","ImGui::RenderArrowDockMenu")
+		->args({"draw_list","p_min","sz","col"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3737:29
 	makeExtern< void (*)(ImDrawList *,const ImRect &,unsigned int,float,float,float) , ImGui::RenderRectFilledRangeH , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderRectFilledRangeH","ImGui::RenderRectFilledRangeH")
 		->args({"draw_list","rect","col","x_start_norm","x_end_norm","rounding"})

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -138,3 +138,45 @@ def public with_menu_ex(lbl : string; icon : string; enabled : bool; blk : block
     }
     return opened
 }
+
+def public with_combo_popup(popup_id : uint; bb : float4; flags : ImGuiComboFlags; blk : block) : bool {
+    //! `BeginComboPopup(popup_id, bb, flags)` / `EndPopup()` — only-on-true. The
+    //! low-level combo dropdown the public `combo` is built on: open the popup first
+    //! (``OpenPopupEx(popup_id)``), pass the combo box's rect as ``bb``, and render the
+    //! selectable items in ``blk``. Returns whether the dropdown is open.
+    let opened = BeginComboPopup(popup_id, bb, flags)
+    if (opened) {
+        invoke(blk)
+        EndPopup()
+    }
+    return opened
+}
+
+def public with_custom_preview_combo(str_id : string; flags : ImGuiComboFlags; blk : block) : bool {
+    //! `BeginCombo(str_id, "", flags + CustomPreview)` / `EndCombo()` — only-on-true.
+    //! Opens a combo whose closed-state preview is custom-drawn — pair it with a
+    //! ``with_combo_preview`` block immediately after. ``blk`` renders the dropdown
+    //! items (selectables). Returns whether the dropdown is open.
+    // CustomPreview is the lone internal ImGuiComboFlagsPrivate flag; fold it into the
+    // public flags by value (the two are distinct das enums over one int flag set).
+    let cflags = unsafe(reinterpret<ImGuiComboFlags>(int(flags) | int(ImGuiComboFlagsPrivate.CustomPreview)))
+    let opened = BeginCombo(str_id, "", cflags)
+    if (opened) {
+        invoke(blk)
+        EndCombo()
+    }
+    return opened
+}
+
+def public with_combo_preview(blk : block) : bool {
+    //! `BeginComboPreview()` / `EndComboPreview()` — only-on-true. Renders the custom
+    //! preview content (``blk``) into the preview box of a combo opened with
+    //! ``with_custom_preview_combo``. Call it immediately after that combo's block.
+    //! Returns whether the preview began.
+    let opened = BeginComboPreview()
+    if (opened) {
+        invoke(blk)
+        EndComboPreview()
+    }
+    return opened
+}

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -140,14 +140,17 @@ def public with_menu_ex(lbl : string; icon : string; enabled : bool; blk : block
 }
 
 def public with_combo_popup(popup_id : uint; bb : float4; flags : ImGuiComboFlags; blk : block) : bool {
-    //! `BeginComboPopup(popup_id, bb, flags)` / `EndPopup()` — only-on-true. The
+    //! `BeginComboPopup(popup_id, bb, flags)` / `EndCombo()` — only-on-true. The
     //! low-level combo dropdown the public `combo` is built on: open the popup first
     //! (``OpenPopupEx(popup_id)``), pass the combo box's rect as ``bb``, and render the
     //! selectable items in ``blk``. Returns whether the dropdown is open.
+    // NB: close with EndCombo, NOT EndPopup — BeginComboPopup increments
+    // g.BeginComboDepth and only EndCombo decrements it (EndPopup would leak the
+    // depth, corrupting the recycled ##Combo_NN popup window on the next open).
     let opened = BeginComboPopup(popup_id, bb, flags)
     if (opened) {
         invoke(blk)
-        EndPopup()
+        EndCombo()
     }
     return opened
 }


### PR DESCRIPTION
The `imgui_internal.h` combo-dropdown primitives below the public combo widget, **plus the v2 rail that makes the custom-preview path usable** (building the missing rail in the same PR).

Bound via `internal_allow_func` (regen): **`BeginComboPopup`** (the low-level dropdown the public combo is built on), **`BeginComboPreview`** / **`EndComboPreview`** (custom-preview rendering). All public types. Also bound the lone internal **`ImGuiComboFlagsPrivate_`** enum (its only value, `CustomPreview = 1<<20`, enables `BeginComboPreview`) with an `enum_prefix` override — its value carries the public `ImGuiComboFlags_` prefix, exactly like `ImGuiButtonFlagsPrivate`.

Surface = **three scope guards** in `imgui_scope_builtin.das` (the established Begin/End pair pattern, like `with_popup_ex` — not raw `ALLOWED_IMGUI`; that module isn't linted as root):

- **`with_combo_popup(popup_id, bb, flags)`** / `EndPopup` — the fully hand-rolled combo path (`OpenPopupEx` + the box's rect + selectables in the block).
- **`with_custom_preview_combo(str_id, flags)`** — the enabling **rail** over the public `BeginCombo` + `CustomPreview` (folds the internal `CustomPreview` flag into the public flags by value) / `EndCombo`.
- **`with_combo_preview()`** / `EndComboPreview` — the custom-preview block. `BeginComboPreview` asserts unless called right after that combo, so the two guards pair in sequence.

Regen: +3 makeExterns (benign `func_31`↔`func_32` boundary relocation, net +3) + the 1-value enum across the 4 `enum.*.inc`; **no new func chunk**, EOL churn reverted. No `ALLOWED_IMGUI` / `imgui2rst` entries (`scope_builtin` is neither linted-as-root nor a documented module).

**Example** `internal_combo.das`: a fully hand-rolled fruit combo (`BeginComboPopup`) and a colour combo whose closed-state preview is a custom-drawn swatch + name (the custom-preview rail). Clean headless (exit 0); lint + format clean; ran windowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)