### PR TITLE
imgui: bind logging/capture internals + with_log guard (family)

### DIFF
--- a/bind/bind_imgui.das
+++ b/bind/bind_imgui.das
@@ -147,6 +147,9 @@ class ImguiGen : CppGenBind {
         // ImGuiAxis's tag has no trailing underscore but its values are ImGuiAxis_X /
         // ImGuiAxis_Y, so strip the full "ImGuiAxis_" prefix (default would leave "_X").
         enum_prefix |> insert("ImGuiAxis", "ImGuiAxis_")
+        // ImGuiLogType — same shape as ImGuiAxis: tag has no trailing underscore but its
+        // values are ImGuiLogType_TTY etc., so strip the full "ImGuiLogType_" prefix.
+        enum_prefix |> insert("ImGuiLogType", "ImGuiLogType_")
         // Family 1 — Render* draw helpers from imgui_internal.h. Every argument is
         // an already-bound public type (ImVec2, ImU32, ImDrawList*, ImGuiDir,
         // ImGuiMouseCursor, ImDrawFlags), so no internal struct/enum is pulled in.
@@ -273,7 +276,14 @@ class ImguiGen : CppGenBind {
             // render a custom preview for a BeginCombo opened with CustomPreview. All
             // public types. Surface = with_combo_popup / with_custom_preview_combo /
             // with_combo_preview scope guards (imgui_scope_builtin.das).
-            "ImGui::BeginComboPopup", "ImGui::BeginComboPreview", "ImGui::EndComboPreview"
+            "ImGui::BeginComboPopup", "ImGui::BeginComboPreview", "ImGui::EndComboPreview",
+            // Logging/capture — the text-capture primitives the public Log* API is
+            // built on. LogBegin(type, auto_open_depth) starts a capture to the chosen
+            // target (closed by the public LogFinish; surface = the with_log guard in
+            // imgui_scope_builtin.das). LogSetNextTextDecoration(prefix, suffix) wraps
+            // the next captured text. LogRenderedText (nullable ref_pos / text_end) is a
+            // manual C++ wrapper (dasIMGUI.main.cpp).
+            "ImGui::LogBegin", "ImGui::LogSetNextTextDecoration"
         }
         internal_allow_enum <- {
             "ImGuiItemFlags_", "ImGuiNavHighlightFlags_", "ImGuiTooltipFlags_",
@@ -289,7 +299,10 @@ class ImguiGen : CppGenBind {
             // ImGuiComboFlagsPrivate_ = the single internal combo flag CustomPreview
             // (enables BeginComboPreview). Combined into the public ImGuiComboFlags
             // inside the with_custom_preview_combo guard (imgui_scope_builtin.das).
-            "ImGuiComboFlagsPrivate_"
+            "ImGuiComboFlagsPrivate_",
+            // ImGuiLogType (None/TTY/File/Buffer/Clipboard) selects LogBegin's capture
+            // target. Plain enum, tag has no trailing underscore (prefix override below).
+            "ImGuiLogType"
         }
     }
     def is_internal : bool {

--- a/examples/features/internal_log_capture.das
+++ b/examples/features/internal_log_capture.das
@@ -1,0 +1,121 @@
+options gen2
+
+require imgui/imgui_harness
+
+// =============================================================================
+// FEATURE: internal_log_capture — the imgui_internal.h logging/capture primitives
+//          below the public Log* API. Cherry-picked into the v2 binding
+//          (bind_imgui.das internal_allow_func): LogBegin (start a capture to a
+//          chosen target) and LogSetNextTextDecoration (wrap the next captured
+//          text); LogRenderedText (nullable ref_pos / text_end) is a manual C++
+//          wrapper. The ImGuiLogType enum (None/TTY/File/Buffer/Clipboard) selects
+//          the target. Surface = the with_log scope guard (imgui_scope_builtin.das,
+//          LogBegin / LogFinish) plus the two raw calls. This is the "binding is
+//          usable" gate: it drives the real bound API at runtime.
+// SHOWS:   a small widget "report" captured to the system clipboard and read back
+//          via the already-bound GetClipboardText — proving (1) real widget text is
+//          captured, (2) LogSetNextTextDecoration prefixes a section header ("# "),
+//          and (3) LogRenderedText injects a line that appears ONLY in the capture,
+//          never in the on-screen report.
+// STANDALONE: daslang.exe modules/dasImgui/examples/features/internal_log_capture.das
+// HEADLESS:   daslang.exe modules/dasImgui/examples/features/internal_log_capture.das -- --headless --headless-frames=60
+// LIVE:       daslang-live modules/dasImgui/examples/features/internal_log_capture.das
+// =============================================================================
+
+var g_decorate = true
+var g_capture_count = 0
+var g_last_clip = ""
+var g_capture_requested = false
+
+// The report submitted each frame. When `logging` is true it runs inside a
+// with_log scope, so every widget's rendered text is captured to the target — plus
+// a decorated section header and a log-only injected line.
+def private render_report(logging : bool) {
+    text("=== Daslang Widget Report ===")
+    // single '#' (not '##') so the readback below can display it verbatim — imgui
+    // strips everything after a '##' in rendered text.
+    if (logging && g_decorate) {
+        LogSetNextTextDecoration("# ", "")
+    }
+    text("Section: Fruits")
+    text("  Apple, Banana, Cherry")
+    if (logging && g_decorate) {
+        LogSetNextTextDecoration("# ", "")
+    }
+    text("Section: Colours")
+    text("  Red, Green, Blue")
+    // log-only: never drawn in the window, only appended to the active capture.
+    if (logging) {
+        LogRenderedText("(injected via LogRenderedText - capture #{g_capture_count})")
+    }
+}
+
+[export]
+def init() {
+    harness_init("internal_log_capture - LogBegin / LogRenderedText / decoration", 700, 560)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.2
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) return
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(680.0, 540.0), ImGuiCond.Always)
+    window(LOG_WIN, (text = "internal_log_capture", closable = false,
+                     flags = ImGuiWindowFlags.None)) {
+
+        text("LogBegin / LogRenderedText / LogSetNextTextDecoration capture the rendered")
+        text("text of widgets to a target. Here: the system clipboard, then read it back.")
+        separator()
+
+        if (button(BTN_CAP, (text = "Capture report to clipboard"))) {
+            g_capture_requested = true
+        }
+        same_line()
+        if (button(BTN_DEC, (text = g_decorate ? "header decoration: ON" : "header decoration: OFF"))) {
+            g_decorate = !g_decorate
+        }
+        separator()
+
+        // The report renders every frame; this frame, wrap it in a Clipboard-type log
+        // when a capture was requested so each widget's text lands in the clipboard.
+        let capture_now = g_capture_requested
+        g_capture_requested = false
+        if (capture_now) {
+            g_capture_count++
+            with_log(ImGuiLogType.Clipboard, -1) {
+                render_report(true)
+            }
+            g_last_clip := GetClipboardText()
+        } else {
+            render_report(false)
+        }
+
+        separator()
+        text("Captures so far: {g_capture_count}. Note the '# ' header decoration and the")
+        text("injected line below — neither is part of the on-screen report above:")
+        child(CLIP_CHILD, (text = "clip", size = float2(640.0f, 200.0f),
+                           child_flags = ImGuiChildFlags.Border,
+                           window_flags = ImGuiWindowFlags.None)) {
+            text(CLIP_VIEW, (text = g_last_clip))
+        }
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/src/aot_dasIMGUI.h
+++ b/src/aot_dasIMGUI.h
@@ -60,6 +60,7 @@ namespace das {
     DAS_MOD_API bool TreeNodeBehaviorW( ImGuiID id, ImGuiTreeNodeFlags_ flags, const char* label );
     DAS_MOD_API void TextExW( const char* text, ImGuiTextFlags flags = 0 );
     DAS_MOD_API void SeparatorTextExW( ImGuiID id, const char* label, float extra_width = 0.0f );
+    DAS_MOD_API void LogRenderedTextW( const char* text );
     DAS_MOD_API ImColor HSV(float h, float s, float v, float a = 1.0f);
     DAS_MOD_API void ImGTB_Append ( ImGuiTextBuffer & buf, const char * txt );
     DAS_MOD_API int ImGTB_At ( ImGuiTextBuffer & buf, int32_t index );

--- a/src/dasIMGUI.enum.add.inc
+++ b/src/dasIMGUI.enum.add.inc
@@ -43,6 +43,7 @@ addEnumeration(new Enumeration_ImGuiComboFlagsPrivate_());
 addEnumeration(new Enumeration_ImGuiSeparatorFlags_());
 addEnumeration(new Enumeration_ImGuiTextFlags_());
 addEnumeration(new Enumeration_ImGuiTooltipFlags_());
+addEnumeration(new Enumeration_ImGuiLogType());
 addEnumeration(new Enumeration_ImGuiAxis());
 addEnumeration(new Enumeration_ImGuiNavHighlightFlags_());
 addEnumFlagOps<ImGuiWindowFlags_>(*this,lib,"ImGuiWindowFlags_");

--- a/src/dasIMGUI.enum.class.inc
+++ b/src/dasIMGUI.enum.class.inc
@@ -1111,6 +1111,21 @@ public:
 	}
 };
 
+// from imgui_internal.h:984:6
+class Enumeration_ImGuiLogType : public das::Enumeration {
+public:
+	Enumeration_ImGuiLogType() : das::Enumeration("ImGuiLogType") {
+		external = true;
+		cppName = "ImGuiLogType";
+		baseType = (das::Type) das::ToBasicType<int>::type;
+		addIEx("None", "ImGuiLogType_None", int64_t(ImGuiLogType::ImGuiLogType_None), das::LineInfo());
+		addIEx("TTY", "ImGuiLogType_TTY", int64_t(ImGuiLogType::ImGuiLogType_TTY), das::LineInfo());
+		addIEx("File", "ImGuiLogType_File", int64_t(ImGuiLogType::ImGuiLogType_File), das::LineInfo());
+		addIEx("Buffer", "ImGuiLogType_Buffer", int64_t(ImGuiLogType::ImGuiLogType_Buffer), das::LineInfo());
+		addIEx("Clipboard", "ImGuiLogType_Clipboard", int64_t(ImGuiLogType::ImGuiLogType_Clipboard), das::LineInfo());
+	}
+};
+
 // from imgui_internal.h:994:6
 class Enumeration_ImGuiAxis : public das::Enumeration {
 public:

--- a/src/dasIMGUI.enum.decl.cast.inc
+++ b/src/dasIMGUI.enum.decl.cast.inc
@@ -44,5 +44,6 @@ DAS_BIND_ENUM_CAST(ImGuiComboFlagsPrivate_);
 DAS_BIND_ENUM_CAST(ImGuiSeparatorFlags_);
 DAS_BIND_ENUM_CAST(ImGuiTextFlags_);
 DAS_BIND_ENUM_CAST(ImGuiTooltipFlags_);
+DAS_BIND_ENUM_CAST(ImGuiLogType);
 DAS_BIND_ENUM_CAST(ImGuiAxis);
 DAS_BIND_ENUM_CAST(ImGuiNavHighlightFlags_);

--- a/src/dasIMGUI.enum.decl.inc
+++ b/src/dasIMGUI.enum.decl.inc
@@ -85,6 +85,8 @@ DAS_BASE_BIND_ENUM_GEN(ImGuiTextFlags_,ImGuiTextFlags);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiTooltipFlags_,ImGuiTooltipFlags);
 
+DAS_BASE_BIND_ENUM_GEN(ImGuiLogType,ImGuiLogType);
+
 DAS_BASE_BIND_ENUM_GEN(ImGuiAxis,ImGuiAxis);
 
 DAS_BASE_BIND_ENUM_GEN(ImGuiNavHighlightFlags_,ImGuiNavHighlightFlags);

--- a/src/dasIMGUI.func_30.cpp
+++ b/src/dasIMGUI.func_30.cpp
@@ -64,6 +64,14 @@ void Module_dasIMGUI::initFunctions_30() {
 // from imgui_internal.h:3397:29
 	makeExtern< void (*)() , ImGui::PopItemFlag , SimNode_ExtFuncCall , imguiTempFn>(lib,"PopItemFlag","ImGui::PopItemFlag")
 		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3401:29
+	makeExtern< void (*)(ImGuiLogType,int) , ImGui::LogBegin , SimNode_ExtFuncCall , imguiTempFn>(lib,"LogBegin","ImGui::LogBegin")
+		->args({"type","auto_open_depth"})
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3404:29
+	makeExtern< void (*)(const char *,const char *) , ImGui::LogSetNextTextDecoration , SimNode_ExtFuncCall , imguiTempFn>(lib,"LogSetNextTextDecoration","ImGui::LogSetNextTextDecoration")
+		->args({"prefix","suffix"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3408:29
 	makeExtern< void (*)(unsigned int,int) , ImGui::OpenPopupEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"OpenPopupEx","ImGui::OpenPopupEx")
 		->args({"id","popup_flags"})
@@ -86,14 +94,6 @@ void Module_dasIMGUI::initFunctions_30() {
 	makeExtern< bool (*)(unsigned int,int) , ImGui::BeginPopupEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginPopupEx","ImGui::BeginPopupEx")
 		->args({"id","extra_flags"})
 		->arg_type(1,makeType<ImGuiWindowFlags_>(lib))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3414:29
-	makeExtern< bool (*)(int,int) , ImGui::BeginTooltipEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginTooltipEx","ImGui::BeginTooltipEx")
-		->args({"tooltip_flags","extra_window_flags"})
-		->arg_type(1,makeType<ImGuiWindowFlags_>(lib))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3415:29
-	makeExtern< bool (*)() , ImGui::BeginTooltipHidden , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginTooltipHidden","ImGui::BeginTooltipHidden")
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_31.cpp
+++ b/src/dasIMGUI.func_31.cpp
@@ -12,6 +12,14 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_31() {
+// from imgui_internal.h:3414:29
+	makeExtern< bool (*)(int,int) , ImGui::BeginTooltipEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginTooltipEx","ImGui::BeginTooltipEx")
+		->args({"tooltip_flags","extra_window_flags"})
+		->arg_type(1,makeType<ImGuiWindowFlags_>(lib))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3415:29
+	makeExtern< bool (*)() , ImGui::BeginTooltipHidden , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginTooltipHidden","ImGui::BeginTooltipHidden")
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3425:29
 	makeExtern< bool (*)(const char *,const char *,bool) , ImGui::BeginMenuEx , SimNode_ExtFuncCall , imguiTempFn>(lib,"BeginMenuEx","ImGui::BeginMenuEx")
 		->args({"label","icon","enabled"})
@@ -93,16 +101,6 @@ void Module_dasIMGUI::initFunctions_31() {
 	makeExtern< void (*)(ImVec2,float,int,unsigned int,unsigned int,unsigned int) , ImGui::RenderMouseCursor , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderMouseCursor","ImGui::RenderMouseCursor")
 		->args({"pos","scale","mouse_cursor","col_fill","col_border","col_shadow"})
 		->arg_type(2,makeType<ImGuiMouseCursor_>(lib))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3732:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,int,float) , ImGui::RenderArrow , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrow","ImGui::RenderArrow")
-		->args({"draw_list","pos","col","dir","scale"})
-		->arg_type(3,makeType<ImGuiDir_>(lib))
-		->arg_init(4,new ExprConstFloat(1))
-		->addToModule(*this, SideEffects::worstDefault);
-// from imgui_internal.h:3733:29
-	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int) , ImGui::RenderBullet , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderBullet","ImGui::RenderBullet")
-		->args({"draw_list","pos","col"})
 		->addToModule(*this, SideEffects::worstDefault);
 }
 }

--- a/src/dasIMGUI.func_32.cpp
+++ b/src/dasIMGUI.func_32.cpp
@@ -12,6 +12,16 @@
 namespace das {
 #include "dasIMGUI.func.aot.decl.inc"
 void Module_dasIMGUI::initFunctions_32() {
+// from imgui_internal.h:3732:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,int,float) , ImGui::RenderArrow , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderArrow","ImGui::RenderArrow")
+		->args({"draw_list","pos","col","dir","scale"})
+		->arg_type(3,makeType<ImGuiDir_>(lib))
+		->arg_init(4,new ExprConstFloat(1))
+		->addToModule(*this, SideEffects::worstDefault);
+// from imgui_internal.h:3733:29
+	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int) , ImGui::RenderBullet , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderBullet","ImGui::RenderBullet")
+		->args({"draw_list","pos","col"})
+		->addToModule(*this, SideEffects::worstDefault);
 // from imgui_internal.h:3734:29
 	makeExtern< void (*)(ImDrawList *,ImVec2,unsigned int,float) , ImGui::RenderCheckMark , SimNode_ExtFuncCall , imguiTempFn>(lib,"RenderCheckMark","ImGui::RenderCheckMark")
 		->args({"draw_list","pos","col","sz"})

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -388,6 +388,16 @@ namespace das {
         ImGui::SeparatorTextEx(id, label, nullptr, extra_width);
     }
 
+    // imgui_internal.h LogRenderedText — inject text into the active log (the primitive
+    // widgets call to capture their own rendered text). ref_pos is pinned to nullptr:
+    // its only effect is position-driven newline insertion keyed off a widget's screen
+    // Y (the internal widget path); from das, embed '\n' in `text` for line breaks — the
+    // splitter turns it into real newlines + tree indentation. text_end -> nullptr like
+    // TextEx (a daslang string can't express the NULL).
+    void LogRenderedTextW( const char* text ) {
+        ImGui::LogRenderedText(nullptr, text, nullptr);
+    }
+
     // ImColor
 
     ImColor HSV(float h, float s, float v, float a) {
@@ -648,6 +658,11 @@ namespace das {
             SideEffects::worstDefault, "das::SeparatorTextExW")
                 ->args({"id","label","extra_width"})
                     ->arg_init(2,new ExprConstFloat(0.0f));
+        // imgui_internal.h LogRenderedText — manual log injection; ref_pos / text_end
+        // pinned to nullptr (embed '\n' in text for line breaks).
+        addExtern<DAS_BIND_FUN(das::LogRenderedTextW), SimNode_ExtFuncCall, imguiTempFn>(*this, lib, "LogRenderedText",
+            SideEffects::worstDefault, "das::LogRenderedTextW")
+                ->args({"text"});
         // variadic functions
         addExtern<DAS_BIND_FUN(das::Text)>(*this,lib,"Text",
             SideEffects::worstDefault,"das::Text");

--- a/widgets/imgui_lint.das
+++ b/widgets/imgui_lint.das
@@ -198,7 +198,12 @@ let private ALLOWED_IMGUI : table<string> <- {
     // separator with axis/span flags + thickness; TextEx (text_end -> nullptr wrapper,
     // ImGuiTextFlags-as-int) and SeparatorTextEx (label_end -> nullptr wrapper) are
     // the manual C++ wrappers.
-    "SeparatorEx", "TextEx", "SeparatorTextEx"
+    "SeparatorEx", "TextEx", "SeparatorTextEx",
+    // Logging/capture. LogSetNextTextDecoration wraps the next captured text (raw);
+    // LogRenderedText (ref_pos / text_end -> nullptr wrapper) injects text into the active
+    // log. LogBegin is guard-only (with_log, imgui_scope_builtin.das). GetClipboardText
+    // reads back a Clipboard-type capture — a host-agnostic IO query.
+    "LogSetNextTextDecoration", "LogRenderedText", "GetClipboardText"
 }
 
 class ImguiLintVisitor : AstVisitor {

--- a/widgets/imgui_scope_builtin.das
+++ b/widgets/imgui_scope_builtin.das
@@ -183,3 +183,14 @@ def public with_combo_preview(blk : block) : bool {
     }
     return opened
 }
+
+def public with_log(log_type : ImGuiLogType; auto_open_depth : int; blk : block) {
+    //! `LogBegin(log_type, auto_open_depth)` / `LogFinish()`. Captures the rendered text
+    //! of every widget submitted in ``blk`` (plus any manual ``LogRenderedText``) to the
+    //! chosen target — ``ImGuiLogType.TTY`` / ``File`` / ``Clipboard`` / ``Buffer``.
+    //! ``auto_open_depth`` is the tree depth to auto-expand (-1 = the default).
+    //! Do NOT nest: LogBegin asserts that logging is not already active.
+    LogBegin(log_type, auto_open_depth)
+    invoke(blk)
+    LogFinish()
+}


### PR DESCRIPTION
The imgui_internal.h **logging/capture** primitives below the public `Log*` API — the last family in the internal-binding sweep.

## Bound

| Symbol | How | Surface |
|---|---|---|
| `LogBegin(ImGuiLogType, int)` | regen (`internal_allow_func`) | `with_log` guard |
| `LogSetNextTextDecoration(prefix, suffix)` | regen | raw (`ALLOWED_IMGUI`) |
| `LogRenderedText(ref_pos*, text, text_end*)` | manual C++ wrapper | raw (`ALLOWED_IMGUI`) |
| `ImGuiLogType` enum (None/TTY/File/Buffer/Clipboard) | `internal_allow_enum` + `enum_prefix` override | das enum |

`ImGuiLogType`'s tag has no trailing underscore (like `ImGuiAxis`), so it gets an `enum_prefix` override and binds as a plain das enum (`ImGuiLogType.Clipboard`).

## Surface

- **`with_log(log_type, auto_open_depth) { ... }`** (imgui_scope_builtin.das) — `LogBegin` / the public `LogFinish`. Enforces the begin/end pairing (`LogBegin` asserts logging isn't already active — do not nest).
- **`LogSetNextTextDecoration`** / **`LogRenderedText`** — raw at root.
- **`GetClipboardText`** added to `ALLOWED_IMGUI` (host-agnostic IO query) so a `Clipboard`-type capture can be read back.

## Two judgment calls (please object if you disagree)

1. **`LogToBuffer` dropped.** It's redundant with `with_log(ImGuiLogType.Buffer, depth)` and dead without a `g.LogBuffer` reader — `LogFinish` clears the buffer, and there's no bound accessor. Binding it would be bind-but-useless. (We discussed this; recording it here for the reviewer.)
2. **`LogRenderedText` `ref_pos` pinned to `nullptr`.** `ref_pos` only drives position-keyed newline insertion off a widget's screen-Y (the internal widget path). For manual injection from das you embed `\n` in the text — the splitter turns it into real newlines + tree indentation, which is strictly more control. `text_end` is pinned to `nullptr` like `TextEx` (a das string can't express the NULL). So no practical functionality is lost; happy to add a `LogRenderedTextAt(ref_pos, text)` variant if you want the position-aware mode.

## Regen

Clean **+2 makeExterns** with a benign func_30→31→32 boundary relocation cascade; the 5-value `ImGuiLogType` enum across the 4 `enum.*.inc`; EOL churn reverted.

## Example

`internal_log_capture.das` — a widget "report" captured to the **system clipboard** and read back via `GetClipboardText`, proving: (1) real widget text is captured, (2) `LogSetNextTextDecoration` prefixes a section header (`# `), and (3) `LogRenderedText` injects a line that appears **only** in the capture, never in the on-screen report. Clean headless (exit 0); lint + format clean; confirmed windowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)