### PR TITLE
tests: proper synchronization for timing-dependent integration tests

### DIFF
--- a/tests/integration/test_collapsing_header_closable.das
+++ b/tests/integration/test_collapsing_header_closable.das
@@ -29,10 +29,11 @@ def test_collapsing_header_closable_smoke(t : T?) {
         }
         t |> success(closed != null, "closing the header hides REVEAL_BTN inside")
 
+        // Re-open must gate on actual paint, not stale registry existence:
+        // widget_exists returns true on the expunged-but-cached entry. wait_for_visible
+        // polls widget_rendered (registered AND painted this frame).
         open_widget(d, "MAIN_WIN/HEADER_CLOSE")
-        let reopened = wait_until(d, 300) $(var s) {
-            return widget_exists(s, "MAIN_WIN/HEADER_CLOSE/REVEAL_BTN")
-        }
-        t |> success(reopened != null, "imgui_open re-renders body")
+        t |> success(wait_for_visible(d, "MAIN_WIN/HEADER_CLOSE/REVEAL_BTN", 5.0f) != null,
+                     "imgui_open re-renders body")
     }
 }

--- a/tests/integration/test_docking_basic.das
+++ b/tests/integration/test_docking_basic.das
@@ -71,7 +71,7 @@ def test_docking_basic(t : T?) {
 
             // Give the dockspace a couple of frames to actually dock the windows
             // (DockBuilderFinish on frame 1, ImGui applies docking on frame 2).
-            let docked = wait_for_payload_value(d, "DOCK_ROOT/EXPLORER", "docked", true, 30)
+            let docked = wait_for_payload_value(d, "DOCK_ROOT/EXPLORER", "docked", true, 300)
             t |> success(docked, "EXPLORER reports docked=true after DockBuilder finish")
 
             var snap2 = snapshot(d)
@@ -105,12 +105,12 @@ def test_docking_basic(t : T?) {
                 return
             }
             // Wait until OUTPUT is docked (initial layout finished).
-            let docked = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "docked", true, 30)
+            let docked = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "docked", true, 300)
             t |> success(docked, "OUTPUT starts docked")
 
             // Send undock command, wait for `docked` field to flip false.
             post_command(d, "imgui_undock", JV((target = "DOCK_ROOT/OUTPUT")))
-            let undocked = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "docked", false, 30)
+            let undocked = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "docked", false, 300)
             t |> success(undocked, "imgui_undock flipped OUTPUT.docked false")
         }
         reset(d)
@@ -126,7 +126,7 @@ def test_docking_basic(t : T?) {
             t |> success(open0, "OUTPUT starts open")
 
             post_command(d, "imgui_close", JV((target = "DOCK_ROOT/OUTPUT")))
-            let closed = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "open", false, 30)
+            let closed = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "open", false, 300)
             t |> success(closed, "imgui_close flipped OUTPUT.open false")
         }
         reset(d)
@@ -139,7 +139,7 @@ def test_docking_basic(t : T?) {
             }
             // First undock so the floating window's pos isn't pinned by the dock.
             post_command(d, "imgui_undock", JV((target = "DOCK_ROOT/OUTPUT")))
-            let undocked = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "docked", false, 30)
+            let undocked = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT", "docked", false, 300)
             t |> success(undocked, "OUTPUT undocked")
 
             // Set window position to a specific spot.
@@ -151,7 +151,7 @@ def test_docking_basic(t : T?) {
             // poll the whole field rather than a dotted sub-key (wait_for_payload_value
             // matches on the full field value).
             let landed = wait_for_payload_value(d, "DOCK_ROOT/OUTPUT",
-                                                "pos", float2(600.0f, 200.0f), 30)
+                                                "pos", float2(600.0f, 200.0f), 300)
             t |> success(landed, "OUTPUT.pos converged to (600,200) after imgui_set_window_pos")
         }
         reset(d)
@@ -163,7 +163,7 @@ def test_docking_basic(t : T?) {
                 return
             }
             // Wait for initial layout flag to be true.
-            let seeded = wait_for_payload_value(d, "DOCK_ROOT", "has_initial_layout", true, 30)
+            let seeded = wait_for_payload_value(d, "DOCK_ROOT", "has_initial_layout", true, 300)
             t |> success(seeded, "DOCK_ROOT.has_initial_layout=true after initial setup")
 
             // imgui_dock_reset flips it back to false; the renderer re-runs setup,
@@ -172,7 +172,7 @@ def test_docking_basic(t : T?) {
             // public contract: send the reset command, then verify EXPLORER is
             // still docked (i.e. the layout came back).
             post_command(d, "imgui_dock_reset", JV((target = "DOCK_ROOT")))
-            let re_docked = wait_for_payload_value(d, "DOCK_ROOT/EXPLORER", "docked", true, 30)
+            let re_docked = wait_for_payload_value(d, "DOCK_ROOT/EXPLORER", "docked", true, 300)
             t |> success(re_docked, "EXPLORER re-docks after imgui_dock_reset round-trip")
         }
     }

--- a/tests/integration/test_docking_basic.das
+++ b/tests/integration/test_docking_basic.das
@@ -7,7 +7,6 @@ require dastest/testing_boost public
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
-require math
 
 //! Phase 7 docking integration smoke. Three coverage layers:
 //!   1. Registration — `dockspace`/`dock_window` and their children appear in

--- a/tests/integration/test_drag_drop.das
+++ b/tests/integration/test_drag_drop.das
@@ -45,6 +45,11 @@ def test_drag_drop_smoke(t : T?) {
         t |> equal(resp?["ok"] ?? false, true,
                    "drag_to response.ok == true")
 
+        // Gate on the gesture fully landing (mouse released, drag coroutine
+        // drained) before the value poll — don't lean on the poll window to
+        // absorb the play on a starved render thread.
+        t |> success(wait_for_mouse_idle(d, 10.0f), "drag gesture drains before accept gate")
+
         // The drop must actually LAND: drag_drop_target.accepted ticks 0 -> 1.
         // This is the real semantic the visual demo used to be the only proof of.
         let landed = wait_for_payload_value(d, "MAIN_WIN/TARGET_DD", "accepted", 1, 300)

--- a/tests/integration/test_edit_external_vectors.das
+++ b/tests/integration/test_edit_external_vectors.das
@@ -29,10 +29,18 @@ def test_edit_external_vectors_smoke(t : T?) {
         // imgui_force_set on a float3 — write {x,y,z} and verify the snapshot
         // reports back the same components.
         force_set_value(d, "MAIN_WIN/SF3", JV((x = 0.7f, y = 0.8f, z = 0.9f)))
+        // Gate on the written component VALUES, not just field presence: SF3 already
+        // exposes a non-null float3 before the write, so a presence-only predicate
+        // passes on the pre-write snapshot and the round-trip isn't actually proven.
         let after = wait_until(d, 300) $(var s) {
             let xv = widget_payload_field(s, "MAIN_WIN/SF3", "value")
-            return xv != null && xv?["x"] != null
+            let x = xv?["x"] ?? 0.0lf
+            let y = xv?["y"] ?? 0.0lf
+            let z = xv?["z"] ?? 0.0lf
+            return (x > 0.69lf && x < 0.71lf &&
+                    y > 0.79lf && y < 0.81lf &&
+                    z > 0.89lf && z < 0.91lf)
         }
-        t |> success(after != null, "edit_slider_float3 write round-trips")
+        t |> success(after != null, "edit_slider_float3 write round-trips to (0.7, 0.8, 0.9)")
     }
 }

--- a/tests/integration/test_edit_tab_item.das
+++ b/tests/integration/test_edit_tab_item.das
@@ -19,7 +19,7 @@ let FEATURE = "modules/dasImgui/examples/features/edit_tab_item.das"
 [test]
 def test_edit_tab_item_smoke(t : T?) {
     with_imgui_app(FEATURE) $(d) {
-        var snap = wait_for_widget(d, "MAIN_WIN/BAR/TAB_A", 15.0f)
+        var snap = wait_for_render(d, "MAIN_WIN/BAR/TAB_A", 15.0f)
         t |> success(snap != null, "TAB_A registers")
         if (snap == null) return
 

--- a/tests/integration/test_focus_control.das
+++ b/tests/integration/test_focus_control.das
@@ -33,14 +33,14 @@ def test_focus_control_smoke(t : T?) {
         // Click REFOCUS_EMAIL -> set_keyboard_focus_here(0) before EMAIL_INPUT
         // -> EMAIL_INPUT.focus becomes true next frame.
         click(d, "MAIN_WIN/REFOCUS_EMAIL")
-        let email_focused = wait_until(d, 120) $(var s) {
+        let email_focused = wait_until(d, 300) $(var s) {
             return s?["globals"]?["MAIN_WIN/EMAIL_INPUT"]?["focus"] ?? false
         }
         t |> success(email_focused != null, "EMAIL_INPUT.focus == true after REFOCUS_EMAIL click")
 
         // Now flip back: click REFOCUS_NAME -> NAME_INPUT focus.
         click(d, "MAIN_WIN/REFOCUS_NAME")
-        let name_focused = wait_until(d, 120) $(var s) {
+        let name_focused = wait_until(d, 300) $(var s) {
             return s?["globals"]?["MAIN_WIN/NAME_INPUT"]?["focus"] ?? false
         }
         t |> success(name_focused != null, "NAME_INPUT.focus == true after REFOCUS_NAME click")

--- a/tests/integration/test_glfw_synth_keys.das
+++ b/tests/integration/test_glfw_synth_keys.das
@@ -7,7 +7,6 @@ require dastest/testing_boost public
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
-require math
 
 //! GLFW-side synthetic keyboard driver — end-to-end gates.
 //!
@@ -30,14 +29,14 @@ def test_key_press_release_held_count(t : T?) {
 
         // GLFW_KEY_LEFT_SHIFT == 340.
         post_command(d, "key_press", JV((keycode = 340)))
-        let pressed = wait_until(d, 180) $(var snap) {
+        let pressed = wait_until(d, 180) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return (s?["held_count"] ?? 0) >= 1
         }
         t |> success(pressed != null, "key_status.held_count >= 1 after Shift press")
 
         post_command(d, "key_release", JV((keycode = 340)))
-        let released = wait_until(d, 180) $(var snap) {
+        let released = wait_until(d, 180) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return (s?["held_count"] ?? 1) == 0
         }
@@ -66,7 +65,7 @@ def test_key_type_lands_in_input(t : T?) {
         post_command(d, "key_type", JV((text = "Hi", per_char_ms = 30)))
 
         // Wait for the timeline to drain.
-        let done = wait_until(d, 240) $(var snap) {
+        let done = wait_until(d, 240) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return !(s?["playing"] ?? true)
         }
@@ -94,7 +93,7 @@ def test_key_chord_completes(t : T?) {
         let resp = post_command(d, "key_chord", JV((mods = ["Ctrl"], key = "A")))
         t |> equal(resp?["queued"] ?? 0, 4, "key_chord queues 4 events")
 
-        let done = wait_until(d, 240) $(var snap) {
+        let done = wait_until(d, 240) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return !(s?["playing"] ?? true) && (s?["held_count"] ?? 1) == 0
         }
@@ -119,7 +118,7 @@ def test_key_play_event_list_completes(t : T?) {
         ]
         post_command(d, "key_play", JV((events = events)))
 
-        let done = wait_until(d, 240) $(var snap) {
+        let done = wait_until(d, 240) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return !(s?["playing"] ?? true) && (s?["held_count"] ?? 1) == 0
         }
@@ -138,7 +137,7 @@ def test_key_stop_aborts(t : T?) {
 
         // Start a long-duration type, then stop it mid-flight.
         post_command(d, "key_type", JV((text = "the quick brown fox", per_char_ms = 500)))
-        let started = wait_until(d, 60) $(var snap) {
+        let started = wait_until(d, 60) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return s?["playing"] ?? false
         }
@@ -149,7 +148,7 @@ def test_key_stop_aborts(t : T?) {
 
         // Gate the stop taking effect (it may clear across a frame boundary)
         // rather than reading key_status synchronously.
-        let halted = wait_until(d, 60) $(var snap) {
+        let halted = wait_until(d, 60) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return !(s?["playing"] ?? true)
         }
@@ -202,7 +201,7 @@ def test_key_stop_releases_held_modifiers(t : T?) {
 
         // GLFW_KEY_LEFT_CONTROL == 341.
         post_command(d, "key_press", JV((keycode = 341)))
-        let pressed = wait_until(d, 180) $(var snap) {
+        let pressed = wait_until(d, 180) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return (s?["held_count"] ?? 0) >= 1
         }
@@ -211,7 +210,7 @@ def test_key_stop_releases_held_modifiers(t : T?) {
         let stopped = post_command(d, "key_stop", null)
         t |> equal(stopped?["released"] ?? -1, 1, "key_stop.released == 1")
 
-        let cleared = wait_until(d, 180) $(var snap) {
+        let cleared = wait_until(d, 180) $(var _snap) {
             let s = post_command(d, "key_status", null)
             return (s?["held_count"] ?? 1) == 0
         }

--- a/tests/integration/test_glfw_synth_keys.das
+++ b/tests/integration/test_glfw_synth_keys.das
@@ -57,7 +57,7 @@ def test_key_type_lands_in_input(t : T?) {
         // via playwright. Same pattern as `test_imgui_type_text_buffer_fills`,
         // which goes through `type_text` (which calls focus internally).
         focus(d, "MAIN_WIN/NAME_INPUT")
-        let focused = wait_until(d, 120) $(var snap) {
+        let focused = wait_until(d, 300) $(var snap) {
             return snap?["globals"]?["MAIN_WIN/NAME_INPUT"]?["focus"] ?? false
         }
         t |> success(focused != null, "NAME_INPUT receives keyboard focus")

--- a/tests/integration/test_glfw_synth_keys.das
+++ b/tests/integration/test_glfw_synth_keys.das
@@ -147,8 +147,13 @@ def test_key_stop_aborts(t : T?) {
         let stopped = post_command(d, "key_stop", null)
         t |> equal(stopped?["stopped"] ?? false, true, "key_stop reports stopped=true")
 
-        let halted = post_command(d, "key_status", null)
-        t |> equal(halted?["playing"] ?? true, false, "key_status.playing == false after stop")
+        // Gate the stop taking effect (it may clear across a frame boundary)
+        // rather than reading key_status synchronously.
+        let halted = wait_until(d, 60) $(var snap) {
+            let s = post_command(d, "key_status", null)
+            return !(s?["playing"] ?? true)
+        }
+        t |> success(halted != null, "key_status.playing == false after stop")
     }
 }
 

--- a/tests/integration/test_glfw_synth_mouse.das
+++ b/tests/integration/test_glfw_synth_mouse.das
@@ -160,8 +160,13 @@ def test_mouse_stop_aborts(t : T?) {
         let stopped = post_command(d, "mouse_stop", null)
         t |> equal(stopped?["stopped"] ?? false, true, "mouse_stop reports stopped=true")
 
-        let halted = post_command(d, "mouse_status", null)
-        t |> equal(halted?["playing"] ?? true, false, "mouse_status.playing == false after stop")
+        // Gate the stop taking effect (it may clear across a frame boundary)
+        // rather than reading mouse_status synchronously.
+        let halted = wait_until(d, 60) $(var snap) {
+            let s = post_command(d, "mouse_status", null)
+            return !(s?["playing"] ?? true)
+        }
+        t |> success(halted != null, "mouse_status.playing == false after stop")
     }
 }
 
@@ -181,11 +186,16 @@ def test_synth_cursor_ownership_sticky(t : T?) {
         }
         let s0 = post_command(d, "mouse_status", null)
         t |> equal(s0?["cursor_owned"] ?? true, false, "cursor_owned starts false")
-        // Single synth event flips ownership.
+        // Single synth event flips ownership. Gate on cursor_owned converging
+        // rather than reading mouse_status synchronously after the one-shot.
         post_command(d, "mouse_pos", JV((x = 100.0f, y = 100.0f)))
+        let owned = wait_until(d, 60) $(var snap) {
+            let s = post_command(d, "mouse_status", null)
+            return s?["cursor_owned"] ?? false
+        }
+        t |> success(owned != null, "cursor_owned flips true after mouse_pos")
         let s1 = post_command(d, "mouse_status", null)
-        t |> equal(s1?["cursor_owned"] ?? false, true,  "cursor_owned flips true after mouse_pos")
-        t |> equal(s1?["playing"]      ?? true,  false, "mouse_status.playing is false (mouse_pos is one-shot)")
+        t |> equal(s1?["playing"] ?? true, false, "mouse_status.playing is false (mouse_pos is one-shot)")
         // Run a short timeline, wait for drain, ownership stays.
         var events <- [
             JV((t_ms = 0,  kind = "move", x = 50.0f,  y = 50.0f)),

--- a/tests/integration/test_glfw_synth_mouse.das
+++ b/tests/integration/test_glfw_synth_mouse.das
@@ -88,7 +88,7 @@ def test_mouse_move_to_animates(t : T?) {
         // Wide window — under suite load a single slow frame can advance the
         // timeline a lot, but anywhere strictly between start and end proves
         // the tick is interpolating rather than snapping straight to the end.
-        let midflight = wait_until(d, 180) $(var snap) {
+        let midflight = wait_until(d, 180) $(var _snap) {
             let s = post_command(d, "mouse_status", null)
             let mx = s?["cursor_x"] ?? -1.0f
             return mx > 55.0f && mx < 345.0f
@@ -96,7 +96,7 @@ def test_mouse_move_to_animates(t : T?) {
         t |> success(midflight != null, "cursor passes through mid-flight x")
 
         // Wait until playback completes and cursor lands on the endpoint.
-        let landed = wait_until(d, 300) $(var snap) {
+        let landed = wait_until(d, 300) $(var _snap) {
             let s = post_command(d, "mouse_status", null)
             let playing = s?["playing"] ?? true
             let mx = s?["cursor_x"] ?? -1.0f
@@ -127,7 +127,7 @@ def test_mouse_play_event_list_completes(t : T?) {
         post_command(d, "mouse_play", JV((events = events)))
 
         // Convergence: playing flips to false and cursor lands on the last move waypoint.
-        let done = wait_until(d, 300) $(var snap) {
+        let done = wait_until(d, 300) $(var _snap) {
             let s = post_command(d, "mouse_status", null)
             let playing = s?["playing"] ?? true
             let mx = s?["cursor_x"] ?? -1.0f
@@ -151,7 +151,7 @@ def test_mouse_stop_aborts(t : T?) {
         post_command(d, "mouse_pos", JV((x = 50.0f, y = 50.0f)))
         post_command(d, "mouse_move_to", JV((x = 400.0f, y = 300.0f, duration_ms = 5000)))
         // After kickoff, mouse_status reports playing=true.
-        let started = wait_until(d, 60) $(var snap) {
+        let started = wait_until(d, 60) $(var _snap) {
             let s = post_command(d, "mouse_status", null)
             return s?["playing"] ?? false
         }
@@ -162,7 +162,7 @@ def test_mouse_stop_aborts(t : T?) {
 
         // Gate the stop taking effect (it may clear across a frame boundary)
         // rather than reading mouse_status synchronously.
-        let halted = wait_until(d, 60) $(var snap) {
+        let halted = wait_until(d, 60) $(var _snap) {
             let s = post_command(d, "mouse_status", null)
             return !(s?["playing"] ?? true)
         }
@@ -189,7 +189,7 @@ def test_synth_cursor_ownership_sticky(t : T?) {
         // Single synth event flips ownership. Gate on cursor_owned converging
         // rather than reading mouse_status synchronously after the one-shot.
         post_command(d, "mouse_pos", JV((x = 100.0f, y = 100.0f)))
-        let owned = wait_until(d, 60) $(var snap) {
+        let owned = wait_until(d, 60) $(var _snap) {
             let s = post_command(d, "mouse_status", null)
             return s?["cursor_owned"] ?? false
         }
@@ -202,7 +202,7 @@ def test_synth_cursor_ownership_sticky(t : T?) {
             JV((t_ms = 80, kind = "move", x = 200.0f, y = 200.0f))
         ]
         post_command(d, "mouse_play", JV((events = events)))
-        let drained = wait_until(d, 240) $(var snap) {
+        let drained = wait_until(d, 240) $(var _snap) {
             let s = post_command(d, "mouse_status", null)
             return !(s?["playing"] ?? true)
         }

--- a/tests/integration/test_imgui_synth_ctrl_shortcuts.das
+++ b/tests/integration/test_imgui_synth_ctrl_shortcuts.das
@@ -126,6 +126,11 @@ def test_imgui_synth_ctrl_shortcuts(t : T?) {
             }
             t |> success(typed != null, "NAME_INPUT.value == \"abc\" before chord")
 
+            // The value showing "abc" proves the chars landed, but the key_type
+            // timeline's final per-char delay may still be ticking; let it reach
+            // idle before the chord so the chord events don't interleave its tail.
+            t |> success(wait_for_key_idle(d, 4.0f), "key_type timeline idle before chord")
+
             // Select-all chord: Cmd+A on macOS, Ctrl+A everywhere else.
             if (macos) {
                 post_command(d, "imgui_key_chord", JV((mods = ["Super"], key = "A")))

--- a/tests/integration/test_imgui_synth_ctrl_shortcuts.das
+++ b/tests/integration/test_imgui_synth_ctrl_shortcuts.das
@@ -8,7 +8,6 @@ require imgui public
 require imgui/imgui_playwright public
 require daslib/json public
 require daslib/json_boost public
-require math
 
 //! ImGui-bypass synth driver — Ctrl-shortcut routing after a synth click.
 //!

--- a/tests/integration/test_indexed_dynamic.das
+++ b/tests/integration/test_indexed_dynamic.das
@@ -78,10 +78,10 @@ def test_indexed_dynamic_add_remove(t : T?) {
 
         // ADD again → key 1 re-appears with fresh defaults (value=0.5).
         click(d, "DYN_WIN/ADD_CH")
-        t |> success(wait_for_widget(d, "DYN_WIN/CHANNEL_VOL[1]", 5.0f) != null,
-                     "re-ADD restores CHANNEL_VOL[1]")
-        var snap_re = snapshot(d)
-        t |> equal(widget_payload_field(snap_re, "DYN_WIN/CHANNEL_VOL[1]", "value") ?? -1.0f,
-                   0.5f, "re-added [1].value is fresh default 0.5, not the prior 0.91")
+        // Gate on the converged fresh-default value directly: existence-only
+        // wait_for_widget can return before the first painted frame carries 0.5,
+        // racing the snapshot read against the re-added entry's default.
+        t |> success(wait_for_payload_value(d, "DYN_WIN/CHANNEL_VOL[1]", "value", 0.5f, 300),
+                     "re-added [1].value is fresh default 0.5, not the prior 0.91")
     }
 }

--- a/tests/integration/test_inputs_color.das
+++ b/tests/integration/test_inputs_color.das
@@ -53,8 +53,13 @@ def test_inputs_color_smoke(t : T?) {
         t |> success(wait_for_int_value(d, "MAIN_WIN/PALETTE_RED", "click_count", red_count_before + 1, 300),
                      "imgui_click bumps PALETTE_RED.click_count")
 
+        // Two clicks must NOT race: a second imgui_click coroutine posted while the
+        // first's release is still in flight replaces it, under-counting to 1. Gate
+        // on mouse-idle between (and after) so both press+release pairs fully land.
         click(d, "MAIN_WIN/PALETTE_GREEN")
+        t |> success(wait_for_mouse_idle(d, 10.0f), "first PALETTE_GREEN click drains before second")
         click(d, "MAIN_WIN/PALETTE_GREEN")
+        t |> success(wait_for_mouse_idle(d, 10.0f), "second PALETTE_GREEN click drains before count")
         t |> success(wait_for_int_value(d, "MAIN_WIN/PALETTE_GREEN", "click_count", 2, 300),
                      "two imgui_clicks accumulate on PALETTE_GREEN.click_count")
 

--- a/tests/integration/test_io_synth_drag.das
+++ b/tests/integration/test_io_synth_drag.das
@@ -56,6 +56,10 @@ def test_imgui_drag_value_changes(t : T?) {
         t |> equal(drag_resp?["value"] ?? "", "MAIN_WIN/DEMO_SLIDER",
                    "drag response.value = target ident (Result wire)")
 
+        // Gate the play to completion before polling value, instead of leaning
+        // on the 5s poll window to absorb the drag timeline.
+        t |> success(wait_for_mouse_idle(d, 10.0f), "drag timeline drains before value gate")
+
         // Gate 4: after the drag completes (mouse released), the slider
         // value should have moved away from 0. End-to-end proof that L1
         // mouse-down → moves → mouse-up reached the widget and drove its

--- a/tests/integration/test_layout_helpers.das
+++ b/tests/integration/test_layout_helpers.das
@@ -148,6 +148,10 @@ def test_layout_helpers(t : T?) {
             let resp = drag(d, HANDLE, 80.0f, 0.0f, 8)
             t |> equal(resp?["ok"] ?? false, true, "drag(HANDLE, +80) hit the handle")
 
+            // Gate the drag play to completion before polling value/geometry,
+            // so the snapshot below reads a fully-landed gesture.
+            t |> success(wait_for_mouse_idle(d, 10.0f), "drag drains before value/geometry read")
+
             let moved = wait_until(d, 300) $(snap) => (find_widget(snap, "LAYOUT_WIN/SPLIT_VERT/SPLIT_MAIN")?["payload"]?["value"] ?? 0.0f) > v0 + 0.02f
             t |> success(moved != null, "synth drag raised SPLIT_MAIN.value above baseline {v0}")
 

--- a/tests/integration/test_plot_getter.das
+++ b/tests/integration/test_plot_getter.das
@@ -28,7 +28,7 @@ let PLOT_GETTER_FEATURE = "modules/dasImgui/examples/features/plot_getter.das"
 [test]
 def test_plot_getters_render(t : T?) {
     with_imgui_app(PLOT_GETTER_FEATURE) $(d) {
-        var snap0 = wait_for_widget(d, "MAIN_WIN/SINE_PLOT", 15.0f)
+        var snap0 = wait_for_render(d, "MAIN_WIN/SINE_PLOT", 15.0f)
         t |> success(snap0 != null, "SINE_PLOT registers (snapshot reachable)")
         if (snap0 == null) return
         t |> equal(snap0?["globals"]?["MAIN_WIN/SINE_PLOT"]?["kind"] ?? "", "plot_lines_getter",
@@ -36,7 +36,7 @@ def test_plot_getters_render(t : T?) {
         t |> equal(snap0?["globals"]?["MAIN_WIN/SINE_PLOT"]?["payload"]?["samples"] ?? -1, 64,
                    "SINE_PLOT.payload.samples = 64")
 
-        var snap1 = wait_for_widget(d, "MAIN_WIN/BARS_PLOT", 15.0f)
+        var snap1 = wait_for_render(d, "MAIN_WIN/BARS_PLOT", 15.0f)
         t |> success(snap1 != null, "BARS_PLOT reachable")
         if (snap1 == null) return
         t |> equal(snap1?["globals"]?["MAIN_WIN/BARS_PLOT"]?["kind"] ?? "", "plot_histogram_getter",

--- a/tests/integration/test_popup_window.das
+++ b/tests/integration/test_popup_window.das
@@ -44,11 +44,10 @@ def test_popup_window(t : T?) {
             // popup_window brackets the body on the next frame, so PICK_APPLE
             // appears in the snapshot at the scoped path.
             click(d, "MAIN_WIN/via_button/OPEN_BTN")
-            // wait for path EXISTENCE — widget_rendered's `?? true` falsely
-            // passes when the indexed-path doesn't exist (popup still closed).
-            var snap_open = wait_until(d, 300) $(var snap) {
-                return widget_exists(snap, "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE")
-            }
+            // Popups are re-showable, so gate on actual paint — wait_for_visible is
+            // exists AND rendered-this-frame. (widget_rendered now requires existence,
+            // so it no longer false-passes for an absent path.)
+            var snap_open = wait_for_visible(d, "MAIN_WIN/via_button/BTN_POPUP/PICK_APPLE", 5.0f)
             t |> success(snap_open != null,
                          "click OPEN_BTN opens BTN_POPUP body (PICK_APPLE visible)")
         }

--- a/tests/integration/test_scroll_here_y.das
+++ b/tests/integration/test_scroll_here_y.das
@@ -38,7 +38,7 @@ def test_scroll_here_y_smoke(t : T?) {
 
         // Click JUMP_MIDDLE -> set_scroll_here_y(0.5) after row 100 -> scroll snaps.
         click(d, "MAIN_WIN/JUMP_MIDDLE")
-        let scrolled = wait_until(d, 120) $(var s) {
+        let scrolled = wait_until(d, 300) $(var s) {
             let y = s?["globals"]?["MAIN_WIN/SCROLL_AREA"]?["payload"]?["scroll"]?["y"] ?? 0.0f
             return y >= 1000.0f
         }
@@ -47,7 +47,7 @@ def test_scroll_here_y_smoke(t : T?) {
 
         // JUMP_TOP returns to top.
         click(d, "MAIN_WIN/JUMP_TOP")
-        let back_to_top = wait_until(d, 120) $(var s) {
+        let back_to_top = wait_until(d, 300) $(var s) {
             let y = s?["globals"]?["MAIN_WIN/SCROLL_AREA"]?["payload"]?["scroll"]?["y"] ?? 1.0f
             return y == 0.0f
         }

--- a/tests/integration/test_snapshot_transform.das
+++ b/tests/integration/test_snapshot_transform.das
@@ -27,7 +27,7 @@ def private near(a : float; b : float; tol : float) : bool {
 [test]
 def test_snapshot_transform(t : T?) {
     with_imgui_app(FEATURE) $(d) {
-        var snap = wait_for_widget(d, "MAIN_WIN/XFORM_BTN", 15.0f)
+        var snap = wait_for_visible(d, "MAIN_WIN/XFORM_BTN", 15.0f)
         t |> success(snap != null, "snapshot returned with the transformed button registered")
         if (snap == null) return
 

--- a/tests/integration/test_snapshot_unrendered.das
+++ b/tests/integration/test_snapshot_unrendered.das
@@ -24,7 +24,7 @@ let SNAPSHOT_UNRENDERED_FEATURE = "modules/dasImgui/examples/features/snapshot_u
 [test]
 def test_unrendered_widget_visible(t : T?) {
     with_imgui_app(SNAPSHOT_UNRENDERED_FEATURE) $(d) {
-        var snap = wait_for_widget(d, "MAIN_WIN/VISIBLE_VAL", 15.0f)
+        var snap = wait_for_visible(d, "MAIN_WIN/VISIBLE_VAL", 15.0f)
         t |> success(snap != null, "VISIBLE_VAL appears in registry")
         if (snap == null) return
 

--- a/tests/integration/test_triggers.das
+++ b/tests/integration/test_triggers.das
@@ -51,7 +51,11 @@ def test_triggers_smoke(t : T?) {
                      "imgui_force_set picks DIFFICULTY=2 (Hard)")
 
         // ----- Snapshot envelope — required common fields per widget -----
-        var snap_final = snapshot(d)
+        // QUICK_SAVE.bbox is per-frame; gate on the menu_item being painted so the
+        // snapshot carries its geometry instead of reading a bare snapshot that may
+        // land on a frame before the menu bar painted.
+        var snap_final = wait_for_visible(d, "MAIN_WIN/QUICK_SAVE", 5.0f)
+        t |> success(snap_final != null, "QUICK_SAVE painted")
         var menu = find_widget(snap_final, "MAIN_WIN/QUICK_SAVE")
         t |> equal(menu?["kind"] ?? "", "menu_item", "QUICK_SAVE.kind == 'menu_item'")
         t |> success(menu?["hex_id"] != null, "QUICK_SAVE.hex_id present")

--- a/tests/integration/test_user_control.das
+++ b/tests/integration/test_user_control.das
@@ -34,7 +34,7 @@ def test_user_control_toggle(t : T?) {
 
         // Frames keep advancing cleanly while disabled (the per-frame detach +
         // ClearEventsQueue path runs without crashing or wedging).
-        t |> success(wait_for_widget(d, "MAIN_WIN/DEMO_BTN", 5.0f) != null,
+        t |> success(wait_for_render(d, "MAIN_WIN/DEMO_BTN", 5.0f) != null,
                      "still rendering while control disabled")
 
         // Re-enable: subsequent ticks reattach the callbacks.


### PR DESCRIPTION
## Why

A full audit of all 131 integration tests, prompted by the slow-node flakiness/crash surfaced in #118 (re-enabling `windows-latest` exposed timing-dependent failures). The audit classified every test:

- **robust:** 99
- **timing_dependent:** 20
- **not_applicable** (lint/compile/unit, no live host): 11

The 20 timing-dependent tests relied on the value-poll window *incidentally* absorbing a coroutine play, on `wait_for_widget` (registry existence) where paint was actually required, or on short (30/120-frame) timeouts that give only ~5–20 polls at the 100 ms cadence. Each races on a loaded CI node. This PR replaces those with explicit synchronization gates.

## What

Three sync batches + one isolated lint-cleanup commit:

**A — short-timeout bumps + double-click gate** (high-severity, slow-node)
- `test_docking_basic`: all 7 DockBuilder/layout convergence gates `30 → 300` frames.
- `test_inputs_color`: two back-to-back `click(PALETTE_GREEN)` had no idle gate — the 2nd `imgui_click` coroutine replaced the 1st's in-flight release, under-counting `click_count` to 1. Now gated with `wait_for_mouse_idle` between/after. **Real correctness bug, not just a tight ceiling.**
- `test_focus_control`, `test_scroll_here_y`, `test_glfw_synth_keys`: focus/scroll gates `120 → 300`.

**B — gate on paint, not registry existence**
- `wait_for_widget → wait_for_render`/`wait_for_visible` where bbox/payload/`rendered` is read off the gate snapshot: `test_edit_tab_item`, `test_plot_getter` (×2), `test_snapshot_transform`, `test_snapshot_unrendered`, `test_user_control`.
- value/paint-gate upgrades: `test_indexed_dynamic` (collapse existence-gate + snapshot + equal into one `wait_for_payload_value` on the fresh default), `test_collapsing_header_closable` (re-open → `wait_for_visible`; the close-side absence gate stays `widget_exists`).

**C — gate coroutine plays + strengthen predicates**
- `wait_for_mouse_idle` after drag, before the value poll: `test_drag_drop`, `test_io_synth_drag`, `test_layout_helpers`.
- `wait_for_key_idle` after `key_type`, before the select-all chord: `test_imgui_synth_ctrl_shortcuts`.
- `key_stop`/`mouse_stop`/`mouse_pos` status reads wrapped in a short convergence poll: `test_glfw_synth_keys`, `test_glfw_synth_mouse`.
- predicate/paint correctness: `test_edit_external_vectors` (gate on the written 0.7/0.8/0.9 values, not mere field presence — the old predicate passed pre-write), `test_popup_window` (re-showable popup body → `wait_for_visible`; drop outdated comment), `test_triggers` (`QUICK_SAVE.bbox` → `wait_for_visible`).

**Lint cleanup** (isolated 4th commit) — touching these files brought them into the lint gate's changed-set, surfacing pre-existing warnings: dropped 3 genuinely-unused `require math` (STYLE030) and underscore-prefixed the `wait_until` snapshot arg in blocks that poll via `post_command` and never read it (LINT013). No sync-logic change.

## Not in this PR (deferred — design call)

The audit also found **harness-level "workflow timing bug" candidates** that match the #118 suspicion — these are *not* per-test and need a design decision, so they're held for a separate change:
- `with_recording_app` fixed port 9090 vs `with_imgui_app` per-worker offset (Windows shared-loopback cross-test bleed if `--worker-index` ever fails to forward under isolated mode).
- Shared 30 s ready/reset timeout under Defender + 5-module-per-spawn load (plausibly the actual `windows-latest` fastfail cause).

The deferred **synchronous playwright command channel** would structurally obviate Batch C / the input-coroutine class; Batches A/B are server-state convergence gates a sync *input* channel doesn't observe, so they're worth shipping now regardless.

## Verification

- Lint gate (`utils/lint/main.das` on all changed files): **20 files, 0 issues**.
- `das-fmt --verify`: **20 files verified**.
- `compile_check` clean on all 20.
- Full local integration-suite run deferred — CI is the regression gate for the gate-convergence semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)