### PR TITLE
prepare_recording: recognize any consumer with_*_recording_app wrapper

### DIFF
--- a/utils/prepare_recording.das
+++ b/utils/prepare_recording.das
@@ -76,8 +76,9 @@ class ScanVisitor : AstVisitor {
                         spoken = !empty(voice) ? voice : caption))
                 }
             }
-        } elif (name == "with_recording_app" || name == "with_node_editor_recording_app") {
-            // 2nd positional argument is the APNG basename
+        } elif (ends_with(name, "_recording_app")) {
+            // with_recording_app or any consumer wrapper (with_node_editor_recording_app,
+            // with_implot_recording_app, ...) — 2nd positional argument is the APNG basename
             if (length(expr.arguments) >= 2) {
                 let s = const_str(expr.arguments[1])
                 if (!empty(s)) {


### PR DESCRIPTION
`prepare_recording`'s AST scanner hard-coded `with_recording_app` / `with_node_editor_recording_app` to find a driver's APNG basename. A new consumer wrapper — `with_implot_recording_app` for **dasImguiImplot** — was therefore invisible, and prepare failed with `[prepare] no with_recording_app(...) APNG basename found`.

Fix: match by suffix, `ends_with(name, "_recording_app")`, so every present and future consumer wrapper is recognized with no per-name coupling (drops the special-case for node-editor too).

```das
} elif (ends_with(name, "_recording_app")) {
    // with_recording_app or any consumer wrapper (with_node_editor_recording_app,
    // with_implot_recording_app, ...) - 2nd positional argument is the APNG basename
```

Needed for the dasImguiImplot tutorial recordings (the first one, `line_plot`, is up as dasImguiImplot#4). Pre-push formatter + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)