### PR TITLE
playwright: recording sync primitives — record_check + wait_for_hover

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -149,7 +149,7 @@ def document_module_imgui_playwright() {
         group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
         group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|widget_click_point|widget_component_point|get_text)$%%),
         group_by_regex("Actions",           mod, %regex~^(click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
-        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_unchanged|record_check_rendered|record_check_kind_count)$%%),
+        group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_unchanged|record_check_rendered|record_check_kind_count|record_check)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|expect_value|expect_render).*%%),
         group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe)$%%),
         group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -725,6 +725,20 @@ def public record_check_kind_count(app : ImguiApp; kind_prefix : string; min_cou
     return false
 }
 
+[unused_argument(app)]
+def public record_check(app : ImguiApp; desc : string; ok : bool) : bool {
+    //! Recording-safe verifier for a condition the CALLER already evaluated — the escape hatch for
+    //! an effect the field-based record_check_* can't reach: a value nested in a payload ARRAY (a
+    //! per-series legend ``shown``), a cross-widget invariant, any composed predicate. Pass the
+    //! boolean you computed (typically a ``wait_for_*(...) != null`` gate); on false it accumulates
+    //! ``desc`` into the recording's failure ledger, surfaced as a teardown panic by
+    //! with_recording_app — same accumulate-don't-panic discipline as the rest of the family.
+    //! ``app`` is unused (the caller did the polling) but kept for call-site symmetry. Returns ``ok``.
+    if (ok) return true
+    g_record_failures |> push("record_check failed: {desc}")
+    return false
+}
+
 def private arm_voiceovers(apng_path : string) : bool {
     //! Load voiceover/<stem>.manifest.json beside apng_path. On success fill g_vo_dur, set
     //! g_vo_active, clear the collection. Returns true when armed.

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -348,6 +348,21 @@ def public wait_for_render(app : ImguiApp; widget_ident : string;
     return wait_for_visible(app, widget_ident, timeout_sec)
 }
 
+def public wait_for_hover(app : ImguiApp; widget_ident : string; expected : bool = true;
+                          timeout_sec : float = DEFAULT_FRAME_WAIT_SEC) : JsonValue? {
+    //! Poll snapshot until registered widget ``widget_ident``'s hover state (``IsItemHovered``, the
+    //! per-widget ``hover`` field) equals ``expected``. The sync gate for a reliable synthetic click:
+    //! ``move_to(point)`` then ``wait_for_hover(target)`` then ``click`` guarantees the press lands a
+    //! frame AFTER hover is established. Without it, a synthetic ``move``+``press`` can batch into one
+    //! windowed-vsync frame and the press fires before ``HoveredId`` is set — the press-before-hover
+    //! race a real continuous-hover mouse never hits (synthetic != real). Bounded by ``timeout_sec``;
+    //! returns the matching snapshot or null on timeout. ``null`` is a real failure — gate it with
+    //! ``record_check`` (recording) or ``success`` (test); never proceed to the click silently.
+    return wait_until_sec(app, timeout_sec) $(var snap) {
+        return (find_widget(snap, widget_ident)?["hover"] ?? false) == expected
+    }
+}
+
 def public wait_for_int_value(app : ImguiApp;
                               target : string;
                               field : string;


### PR DESCRIPTION
Two small `imgui_playwright` additions the dasImguiImplot legend-toggle recording needs — both close gaps the existing family couldn't.

### `record_check(app, desc, ok)` — verify a caller-computed condition
Every `record_check_*` today binds to a **scalar payload field** (`record_check_value` / `_changed` / `_unchanged`) or `widget_rendered` — none can reach a value nested in a payload **array** or a composed predicate. `record_check` lets the caller evaluate the condition (typically a `wait_for_*(...) != null` gate) and pass the boolean; on `false` it accumulates `desc` into `g_record_failures`, surfaced as the `with_recording_app` teardown panic. First user: verifying a per-series legend `shown` flag.

### `wait_for_hover(app, target, expected=true)` — sync gate for reliable synthetic clicks
A synthetic `move`+`press` can batch into **one windowed-vsync frame**, so the press fires before ImGui sets `HoveredId` and the click is silently dropped — the **press-before-hover race** a real continuous-hover mouse never hits (synthetic ≠ real; it made the legend toggle ~1/3 flaky in windowed recording, reliable only in headless's deterministic pacing). `wait_for_hover` polls the snapshot until `target`'s `hover == expected`, so the gesture pattern `move_to → wait_for_hover → click` guarantees the press lands a frame **after** hover.

**Robustness (no hang, no silent pass):** bounded by `timeout_sec` (wall-clock, via `wait_until_sec`); returns `null` on timeout, which callers turn into a loud `record_check` / `success` failure — never a silent proceed.

Both are additive (no behavior change to existing checks), `app` kept for family symmetry (`[unused_argument]`), pre-push lint clean. `record_check` added to imgui2rst's "Recording / narration" group; `wait_for_hover` already matches `wait_for_.*` in "Polling / await".

🤖 Generated with [Claude Code](https://claude.com/claude-code)