### PR TITLE
ci: macOS runs serial + unready fast-fail + record/isolated docs (#190 follow-ups)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -216,6 +216,26 @@ jobs:
         # port 9090. With it, ports 9090/9091/9092/9093 are independent and
         # workers don't collide. Expected ~3× wall-time reduction vs sequential.
         #
+        # ISOLATED MODE IS SAFE HERE BECAUSE EVERY [test] IS HEADLESS. They all
+        # run via with_imgui_app, which spawns daslang-live under --headless: an
+        # ImGui context with a CPU font atlas, NO GLFW window / GL context. So 4
+        # parallel workers cost only CPU.
+        #
+        # RECORDINGS CANNOT RUN IN CI ON macOS. A recording drives a real windowed
+        # GL host (with_recording_app, for APNG capture), but the GitHub macOS
+        # runner has no usable OpenGL surface — glfwCreateWindow fails with
+        # "Glfw Error 65545: NSGL: Failed to find a suitable pixel format", so the
+        # host's init() panics ("can't create window") and renders nothing. (This,
+        # not a render throttle, is the root of dasImgui #190: a recording produced
+        # zero frames, so content-time gating spun until the wall-clock fallback.)
+        # Tutorial videos are therefore recorded on Windows / real hardware, never
+        # in CI. The 47 record_*.das under tests/integration are def-main driver
+        # SCRIPTS (not [test]s), so dastest skips them here regardless.
+        #
+        # If a recording-bearing [test] is ever added AND a GL-capable runner is
+        # available, it must run in a SEPARATE step WITHOUT --isolated-mode (serial,
+        # one window at a time): parallel GL windows fight for the GPU.
+        #
         # DASLIVE_HV_LOG=stderr: redirect libhv's logger to stderr so we see
         # event-loop/accept diagnostics in CI output. Env propagates to the
         # spawned daslang-live subprocess via popen_argv's inherited env.


### PR DESCRIPTION
## Summary

Follow-ups from the #190 investigation. Three things, all stemming from how the headless suite behaves on the weak GitHub macOS runner.

### 1. macOS runs the suite serially (no `--isolated-mode`)
The headless suite was occasionally erroring with **"daslang-live not ready after 30s"** (first seen as a `test_plot_getters_render` flake). Root cause: the GitHub macOS runner is only ~3 vCPU, but the suite runs `--isolated-mode-threads 4` — 4 parallel `daslang-live` hosts starve each other so hard that a host's `/status` health check takes ~10s to answer, racing the client's 10s per-request timeout. `wait_until_ready` never registers a success, burns its 30s budget, and the test errors *before its body runs*. It's not test-specific and not a logic bug — just CPU starvation.

Fix: macOS opts out of isolated mode (serial, one host at a time → no contention). ubuntu keeps isolated-4. The macOS sweep timeout is bumped to 1800s since serial is slower. Verified locally: full suite serial headless = **169/169** (198s).

### 2. Unready path fails fast (no 120s dead-wait)
The failure above was *reported* at 120s, not 30s: `with_imgui_app`'s unready branch read the child to EOF but never told it to quit, so it rode to the 120s popen watchdog before surfacing the (already-decided-at-30s) "not ready" panic. Now it posts `/shutdown` first, so the host exits once it drains and the failure surfaces promptly. The 120s cap stays as the outer safety net (not lowered, so genuinely-slow test bodies aren't killed).

### 3. Docs: recordings can't run in macOS CI (no GL)
From the same investigation (the original #190 framing): the GitHub macOS runner has no usable OpenGL surface — a windowed recording host fails `glfwCreateWindow` with `Glfw Error 65545: NSGL: Failed to find a suitable pixel format`, renders zero frames, and that zero-frame output (not a render throttle) is what made content-time gating spin. Documented in `tests.yml`, alongside why isolated mode is correctness-safe (every `[test]` is `with_imgui_app` — headless, no GL window) and the rule that any future recording-bearing `[test]` must run in a separate, non-isolated step on a GL-capable runner.

## Related
- daScript#3030 (merged): App Nap disable + recording-scoped `glfwSwapInterval(0)` + GL-backend log. Useful on real Macs; doesn't affect the CI case (no window).
- #190 itself is closed (the recording-on-macOS-CI limitation is documented; not fixable without headless GL).

Rebased on master so #191 stays intact.

Refs #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)