### PR TITLE
gc: per-frame memory-pressure detection + heap pinning + with_await fix

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -49,6 +49,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|force_set|open|close|focus|await|mouse_pos|mouse_click|mouse_scroll|key_press|key_release|key_char)$%%),
         group_by_regex("Synthetic input",         mod, %regex~^(synth_mouse_move|synth_mouse_button|synth_mouse_wheel|synth_key_press|synth_key_release|synth_char|release_held_buttons|release_held_keys|get_synth_cursor|get_synth_keys|imgui_synth_tick|user_control_enabled|set_user_control_enabled|set_user_control|register_real_input_toggle|register_synth_frame_hook|register_synth_stop_hook)$%%),
         group_by_regex("Debug logging",           mod, %regex~^(log_section|log_section_on|imgui_log_section|imgui_log_drain)$%%),
+        group_by_regex("Memory debugging",         mod, %regex~^(imgui_debug_memory|imgui_reset_memory_baseline|imgui_memory_report)$%%),
         group_by_regex("Snapshot transform",      mod, %regex~^(push_snapshot_item_transform|pop_snapshot_item_transform|capture_item_bbox|capture_current_item_rect)$%%),
         group_by_regex("Await modifiers",         mod, %regex~^(AwaitModifiers|AwaitArgs|AwaitResult|with_await)$%%),
         group_by_regex("JSON serialization",      mod, %regex~^(widget_entry_jv|state_jv|to_JV|from_JV|JV|serialize).*%%),
@@ -136,6 +137,7 @@ def document_module_imgui_visual_aids() {
         group_by_regex("HUD",               mod, %regex~^(paint_key_hud|glyph_for_imgui_key|paint_hud|imgui_key_hud|imgui_focus_rect).*%%),
         group_by_regex("Cursor sprite",     mod, %regex~^(cursor_sprite|imgui_cursor_sprite)$%%),
         group_by_regex("Override hooks",    mod, %regex~^apply_synth_io_override$%%),
+        group_by_regex("Memory debugging",  mod, %regex~^imgui_memory_debug$%%),
         group_by_regex("Color utilities",   mod, %regex~^rgba$%%),
         group_by_regex("Serve / lifecycle", mod, %regex~^(imgui_visual_aids_serve|visual_aids_init|render_visual_aids|effective_).*%%),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_).*%%))

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -2,6 +2,7 @@ options gen2
 options indenting = 4
 options no_unused_block_arguments = false
 options no_unused_function_arguments = false
+options persistent_heap   // collectable heap so per-frame JsonValue churn (snapshots, payloads) is reclaimed by delete + GC, not leaked; unifies program-wide
 
 module imgui_boost_runtime shared
 
@@ -818,6 +819,7 @@ def begin_frame() {
     //! Per-frame reset: bumps the frame counter and clears the per-frame registry, ``hex_id``\ →bbox map, and container path.
     //! Call before rendering widgets; L1 coroutines advance separately via :ref:`advance_coroutines <function-imgui_boost_runtime_advance_coroutines>`.
     g_frame++
+    sample_memory()
     g_registry |> clear()
     g_id_to_bbox |> clear()
     g_rendered_this_frame |> clear()
@@ -830,6 +832,76 @@ def begin_frame() {
     // later frame and corrupt unrelated widget bboxes. Reset like the other per-frame state.
     if (!empty(g_item_xform_stack)) {
         g_item_xform_stack |> clear()
+    }
+}
+
+// ===== Memory / GC-pressure tracking (opt-in) =====
+//
+// Mirrors strudel_player's heap-delta tracking: sample the heap once per frame
+// (from begin_frame), hold a baseline + running max, log periodically while
+// enabled, and emit a final delta line at teardown. Off by default — one bool
+// test per frame when off.
+
+var private g_debug_memory : bool = false
+var private g_mem_baseline_set : bool = false
+var private g_mem_heap_baseline : uint64 = 0ul
+var private g_mem_str_baseline : uint64 = 0ul
+var private g_mem_heap_max : uint64 = 0ul
+var private g_mem_str_max : uint64 = 0ul
+var private g_mem_frame_count : int = 0
+
+//! Frames between periodic memory logs while ``imgui_debug_memory`` is on (0 disables the periodic line; the teardown report still fires). ~2s at 60fps.
+var public imgui_mem_log_interval : int = 120
+
+def public imgui_reset_memory_baseline() {
+    //! Snapshot current heap + string-heap usage as the leak-tracking baseline. Call after
+    //! one-time setup (window/fonts/first frame) so only steady-state growth is measured.
+    g_mem_heap_baseline = heap_bytes_allocated()
+    g_mem_str_baseline = string_heap_bytes_allocated()
+    g_mem_heap_max = g_mem_heap_baseline
+    g_mem_str_max = g_mem_str_baseline
+    g_mem_frame_count = 0
+    g_mem_baseline_set = true
+}
+
+def public imgui_debug_memory(enabled : bool) {
+    //! Toggle per-frame heap / string-heap GC-pressure logging. Enabling (re)sets the baseline,
+    //! so a steadily-growing heap surfaces as the per-frame ``+delta`` climbing instead of flat.
+    g_debug_memory = enabled
+    if (enabled) {
+        imgui_reset_memory_baseline()
+    }
+}
+
+def public imgui_memory_report() {
+    //! Emit a final heap / string-heap delta-vs-baseline line, plus a WARNING if either grew past
+    //! 64kb (a steady per-frame leak / GC-pressure smell). Called at teardown by with_imgui_app /
+    //! with_recording_app; safe to call by hand. No-op until a baseline has been taken.
+    return if (!g_mem_baseline_set)
+    let heap_now = heap_bytes_allocated()
+    let str_now = string_heap_bytes_allocated()
+    let dheap = int64(heap_now) - int64(g_mem_heap_baseline)
+    let dstr = int64(str_now) - int64(g_mem_str_baseline)
+    to_log(LOG_INFO, "imgui mem: heap {heap_now/1024ul}kb (peak {g_mem_heap_max/1024ul}kb, delta {dheap}), str {str_now/1024ul}kb (peak {g_mem_str_max/1024ul}kb, delta {dstr})\n")
+    if (dheap > 65536l || dstr > 65536l) {
+        to_log(LOG_WARNING, "imgui mem: WARNING growth since baseline — heap +{dheap} str +{dstr} bytes (per-frame leak / GC pressure)\n")
+    }
+}
+
+def private sample_memory() {
+    return if (!g_debug_memory)
+    if (!g_mem_baseline_set) {
+        imgui_reset_memory_baseline()
+    }
+    let heap_cur = heap_bytes_allocated()
+    let str_cur = string_heap_bytes_allocated()
+    g_mem_heap_max = max(g_mem_heap_max, heap_cur)
+    g_mem_str_max = max(g_mem_str_max, str_cur)
+    g_mem_frame_count++
+    if (imgui_mem_log_interval > 0 && g_mem_frame_count % imgui_mem_log_interval == 0) {
+        let dheap = int64(heap_cur) - int64(g_mem_heap_baseline)
+        let dstr = int64(str_cur) - int64(g_mem_str_baseline)
+        to_log(LOG_INFO, "imgui mem [frame {g_frame}]: heap {heap_cur/1024ul}kb (max {g_mem_heap_max/1024ul}kb, +{dheap}), str {str_cur/1024ul}kb (max {g_mem_str_max/1024ul}kb, +{dstr})\n")
     }
 }
 
@@ -1392,20 +1464,18 @@ def private with_await(input : JsonValue?; payload : auto(P)) : JsonValue? {
     let mods = from_JV(input?["await"], default<AwaitModifiers>)
     var jv = JV(payload)
     if (mods.fire_and_forget) return jv
-    var tab : table<string; JsonValue?>
-    if (jv != null && (jv.value is _object)) {
-        for (k, v in keys(jv.value as _object), values(jv.value as _object)) {
-            tab[k] = v
+    // Add the await modifiers directly onto the result object (was: copy every
+    // field into a fresh table and return that, which orphaned `jv` every call).
+    if (jv != null && jv.value is _object) {
+        if (mods.await_frames >= 0) {
+            jv |> update("await_frames", JV(mods.await_frames))
         }
+        if (!empty(mods.await_until)) {
+            jv |> update("await_until", JV(mods.await_until))
+        }
+        jv |> update("timeout_sec", JV(mods.timeout_sec))
     }
-    if (mods.await_frames >= 0) {
-        tab["await_frames"] = JV(mods.await_frames)
-    }
-    if (!empty(mods.await_until)) {
-        tab["await_until"] = JV(mods.await_until)
-    }
-    tab["timeout_sec"] = JV(mods.timeout_sec)
-    return JV(tab)
+    return jv
 }
 
 // ===== [live_command] handlers =====

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -7,6 +7,7 @@ options _allow_imgui_legacy = true
 // imgui_live backends — its own compile passes need to skip its own lint.
 // Same pattern as `_allow_imgui_legacy = true` on widgets/imgui_lint.das.
 options _allow_glfw_calls = true
+options persistent_heap   // collectable heap so per-frame JsonValue churn is reclaimed; unifies program-wide
 
 module imgui_harness shared public
 
@@ -207,6 +208,9 @@ def public harness_end_frame() {
 def public harness_shutdown() {
     //! Windowed: ``live_imgui_shutdown`` + ``live_destroy_window``.
     //! Headless: ``DestroyContext`` (the harness owns the ctx in headless mode).
+    // Final GC-pressure summary (no-op unless imgui_debug_memory was enabled). Runs
+    // before context teardown so the numbers reflect the steady-state app, not cleanup.
+    imgui_memory_report()
     if (harness_is_headless()) {
         if (g_headless_ctx != null) {
             DestroyContext(g_headless_ctx)

--- a/widgets/imgui_visual_aids.das
+++ b/widgets/imgui_visual_aids.das
@@ -868,3 +868,15 @@ def imgui_focus_rect(input : JsonValue?) : JsonValue? {
     focus_rect_enabled = args.enabled
     return JV((ok = true, enabled = args.enabled))
 }
+
+struct MemDebugArgs {
+    @optional enabled : bool = true
+}
+
+[live_command(description="Toggle per-frame heap/string-heap GC-pressure logging. Enabling resets the baseline; a periodic line prints while on and a final delta line at teardown. Arg: enabled.")]
+def imgui_memory_debug(input : JsonValue?) : JsonValue? {
+    //! ``[live_command]`` toggle for :ref:`imgui_debug_memory <function-imgui_boost_runtime_imgui_debug_memory_bool>` — per-frame GC-pressure logging. Arg: ``enabled``.
+    let args = from_JV(input, type<MemDebugArgs>)
+    imgui_boost_runtime::imgui_debug_memory(args.enabled)
+    return JV((ok = true, enabled = args.enabled))
+}


### PR DESCRIPTION
Adds an opt-in tool to *see* per-frame GC pressure in imgui apps, pins the collectable heap, and fixes one per-command leak. Pairs with the daslang json PR (GaijinEntertainment/daScript#3034), which does the heavy lifting (frees dispatched snapshot trees, `?[]` sentinel) — `with_await` here uses the new `update()` from that PR, so **merge #3034 first**.

## Detection mode (`imgui_boost_runtime`)
Ported from `strudel_player`'s heap-delta tracking:
- `imgui_debug_memory(enabled)` / `imgui_reset_memory_baseline()` / `imgui_memory_report()` — baseline + running max + a periodic per-frame line of heap / string-heap usage, gated behind a flag. **Off by default — one bool test per frame when off.**
- `sample_memory()` runs once per frame from `begin_frame()` (the universal per-frame reset); a teardown summary fires from `harness_shutdown()`, with a WARNING if heap or string-heap grew past 64 kb since baseline.
- `imgui_memory_debug` live-command (in `imgui_visual_aids`, the debug-toggle home) so the recorder / MCP can flip it remotely.

## `with_await` leak fix
Rewritten to add the await modifiers onto the result object **in place** via the new `update()`, instead of copying every field into a fresh table and returning that — which orphaned the original `JV(payload)` wrapper on every await-wrapped command.

## Heap pinning
`options persistent_heap` on `imgui_boost_runtime` + `imgui_harness` (collectable heap so per-frame JsonValue churn is reclaimed by `delete` + GC; runtime options unify program-wide).

## Verification
- Live `buttons.das` run with `imgui_memory_debug` on: the steady heap held **flat at ~0x21 kb across 5500+ frames**, including the heavy `imgui_snapshot` dispatches at frames 2779/4856 — `max` briefly ticked to 0x26 kb on a snapshot then the steady heap returned, i.e. the ~40-widget tree is built and freed (the formerly-leaking path).
- Full integration suite: 171 passed headless; the 13 GLFW-backend synth tests (which need a real window) confirmed passing windowed — **no regression**.
- All changed files lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)