### PR TITLE
binder: detect fixed-array args via isArray(), not dim.size()

### DIFF
--- a/src/cb_dasIMGUI.h
+++ b/src/cb_dasIMGUI.h
@@ -161,7 +161,7 @@ struct imguiTempFn {
 
         bool anyString = false;
         for ( auto &arg : fn->arguments ) {
-            if ( arg->type->constant && arg->type->ref && arg->type->dim.size() == 0 ) {
+            if ( arg->type->constant && arg->type->ref && !arg->type->isArray() ) {
                 if ( arg->type->baseType == Type::tFloat2 || arg->type->baseType == Type::tFloat4 ) {
                     arg->type->ref = false;
                 }

--- a/src/dasIMGUI.main.cpp
+++ b/src/dasIMGUI.main.cpp
@@ -820,7 +820,7 @@ namespace das {
         for ( auto & pfn : this->functions.each() ) {
             bool anyString = false;
             for ( auto & arg : pfn->arguments ) {
-                if ( arg->type->constant && arg->type->ref && arg->type->dim.size()==0 ) {
+                if ( arg->type->constant && arg->type->ref && !arg->type->isArray() ) {
                     if ( arg->type->baseType==Type::tFloat2 || arg->type->baseType==Type::tFloat4 ) {
                         arg->type->ref = false;
                     }


### PR DESCRIPTION
daslang PR GaijinEntertainment/daScript#3095 replaces `TypeDecl`'s flattened `dim`/`dimExpr` vectors with a structural `Type::tFixedArray` — the `dim` member is gone, so the two `arg->type->dim.size() == 0` reads in the ImVec2/ImVec4 const&→by-value fixup stop compiling.

`isArray()` means "is a fixed-size array" in **both worlds** (`dim.size() != 0` on current daslang master, `baseType == tFixedArray` after the rework), so `!arg->type->isArray()` compiles and behaves identically against both.

**Merge order:** this is mergeable ahead of the daslang PR — this repo's CI builds against current daslang master and is unaffected. Merging it unblocks daScript#3095's `extended_checks`, which does `daspkg install dasImgui --branch master` and currently fails with `cb_dasIMGUI.h:164: no member named 'dim' in 'das::TypeDecl'`.

Verified locally: module builds clean against the rework branch (junctioned tree, full `_build` rebuild + daslang startup smoke loading the rebuilt `.shared_module`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)