### PR TITLE
imgui_file_dialog: native, drivable New/Open/Save file dialog

### DIFF
--- a/.das_module
+++ b/.das_module
@@ -62,6 +62,9 @@ def initialize(project_path : string) {
     register_native_path("imgui", "imgui_docking_builtin", "{project_path}/widgets/imgui_docking_builtin.das")
     // Tables — data_table container + table_setup_*/table_next_*/table_set_column_index pass-throughs.
     register_native_path("imgui", "imgui_table_builtin", "{project_path}/widgets/imgui_table_builtin.das")
+    // File dialog — reusable native New/Open/Save (popup_modal + data_table + selectable_label +
+    // input_text + combo), fully playwright-drivable; no raw-ImGui C++ dependency.
+    register_native_path("imgui", "imgui_file_dialog", "{project_path}/widgets/imgui_file_dialog.das")
     // Window-size constraints — lambda-bearing overload (3-arg SetNextWindowSizeConstraints).
     register_native_path("imgui", "imgui_window_constraints_builtin", "{project_path}/widgets/imgui_window_constraints_builtin.das")
     // Drawlist rail — with_window_drawlist / with_foreground_drawlist /

--- a/doc/source/tutorials/file_dialog.rst
+++ b/doc/source/tutorials/file_dialog.rst
@@ -133,7 +133,7 @@ operate the dialog by id:
      - sort via header click
    * - File row *i*
      - ``FILEDLG/FILE_TABLE/ROW[i]``
-     - ``imgui_click``
+     - ``imgui_click`` (select) · ``double_click`` (enter dir / open file)
    * - Filename field
      - ``FILEDLG/NAME_FIELD``
      - ``imgui_force_set {"value": "name"}``

--- a/doc/source/tutorials/file_dialog.rst
+++ b/doc/source/tutorials/file_dialog.rst
@@ -1,0 +1,162 @@
+.. _tutorial_file_dialog:
+
+#######################
+file_dialog
+#######################
+
+A native, reusable **New / Open / Save** file dialog, built entirely from the
+boost DSL and living in ``imgui/imgui_file_dialog``. Because it is composed from
+boost widgets (``popup_modal`` / ``data_table`` / ``selectable_label`` /
+``input_text`` / ``combo`` / ``button``) rather than a bound C++ file-dialog
+library, **every element registers on the snapshot registry** — the whole dialog
+is :ref:`imgui_playwright <tutorial_driving_outside>`-drivable (a bound C++
+dialog renders raw ImGui and would be invisible to it).
+
+It mirrors the core UX of a desktop file picker: a clickable directory
+breadcrumb plus ``..``, a sortable Name / Size / Type table, an extension-filter
+dropdown, multi-select in open mode, a filename field in save / create mode, and
+an overwrite-confirm step.
+
+Source: ``examples/tutorial/file_dialog.das``.
+
+************
+Walkthrough
+************
+
+The dialog is **immediate-mode** — there are no stored callbacks (daslang blocks
+can't be stored across frames). The flow is three calls:
+
+1. a trigger (button / menu item) calls ``file_dialog_open(cfg)`` with a mode,
+   a start directory and a list of extension filters;
+2. ``file_dialog_draw()`` is called **every frame**, at the top level of
+   ``update()`` (outside any window, so the registry path stays a clean
+   ``FILEDLG/...``). It renders the modal when open and returns this frame's
+   ``FileDialogResult``;
+3. on ``confirmed``, the chosen path(s) are read with
+   ``file_dialog_selection()`` / ``file_dialog_selected_path()``.
+
+.. literalinclude:: ../../../examples/tutorial/file_dialog.das
+   :language: das
+   :linenos:
+
+Requires
+========
+
+One module on top of the harness:
+
+* ``imgui/imgui_file_dialog`` — the dialog component. It pulls in
+  ``imgui_table_builtin`` (the sortable ``data_table``),
+  ``imgui_widgets_builtin`` and ``imgui_containers_builtin`` (the leaf widgets +
+  ``popup_modal``), and ``daslib/fio`` (directory listing) transitively.
+
+Public API
+==========
+
+.. code-block:: das
+
+   enum FileDialogResult { none; confirmed; cancelled }
+   enum FileDialogMode   { open; save; create }   // 'new' is a reserved keyword
+
+   struct FileDialogFilter { caption : string; ext : string }  // ext without the dot; "" = all
+   struct FileDialogConfig {
+       title : string = "Select File"
+       start_dir : string = ""                   // "" => current working directory
+       filters : array<FileDialogFilter>         // empty => all files
+       mode : FileDialogMode = FileDialogMode.open
+       max_selection : int = 1                   // open mode; 0 = unlimited
+   }
+
+   def public file_dialog_open(cfg : FileDialogConfig) : void
+   def public file_dialog_draw() : FileDialogResult
+   def public file_dialog_selection() : array<string>   // confirmed absolute path(s)
+   def public file_dialog_selected_path() : string      // first selection (convenience)
+   def public file_dialog_current_dir() : string
+   def public file_dialog_is_open() : bool
+
+The result is polled, not pushed: ``file_dialog_draw()`` returns ``confirmed``
+exactly on the frame the user commits, ``cancelled`` on the frame they close /
+press *Escape*, and ``none`` otherwise. The accessors stay valid from the
+``confirmed`` frame until the dialog is reopened.
+
+Modes
+=====
+
+* **open** — pick one or more existing files. Selection follows the usual
+  modifiers: plain click selects, **Ctrl+click** toggles, **Shift+click** selects
+  a range, clamped to ``max_selection`` (``0`` = unlimited). Double-clicking a
+  file confirms it; double-clicking a directory enters it.
+* **save** / **create** — type a name in the filename field (clicking a row fills
+  it). The active filter's extension is appended if missing. If the name already
+  exists, an **overwrite-confirm** sub-modal (``FILEDLG/OVERWRITE``) gates the
+  commit. (``create`` is the "New" flavor — same name-entry path; ``new`` itself
+  is a reserved keyword, hence the enum name.)
+
+Navigation and sorting
+=======================
+
+The current directory is listed with ``daslib/fio``'s ``dir`` + per-entry
+``stat`` (so directories are always shown for navigation, files are filtered by
+the active extension). A clickable breadcrumb of ancestor directories plus a
+``..`` button drive ``navigate_to``; directories always sort first.
+
+The file list is a :ref:`data_table <tutorial_data_table>` with the
+``Sortable`` flag and three ``table_setup_column`` calls tagged with stable
+``user_id`` values (``COL_NAME`` / ``COL_SIZE`` / ``COL_TYPE``). A
+``sort_specs()`` block captures the active sort key and re-orders the view
+(directories first, then the chosen column). Each row's first cell is a
+``selectable_label`` with ``SpanAllColumns | AllowDoubleClick`` so a click
+anywhere on the row selects it and a double-click enters / confirms.
+
+Drivability
+===========
+
+Every interactive element is a registry-backed boost widget, so a driver can
+operate the dialog by id:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Element
+     - Path
+     - Verb
+   * - Modal
+     - ``FILEDLG``
+     - snapshot / ``imgui_open``
+   * - Parent / breadcrumb
+     - ``FILEDLG/UP`` · ``FILEDLG/CRUMB[i]``
+     - ``imgui_click``
+   * - Filter dropdown
+     - ``FILEDLG/FILTER_COMBO``
+     - ``imgui_force_set {"value": N}``
+   * - File table
+     - ``FILEDLG/FILE_TABLE``
+     - sort via header click
+   * - File row *i*
+     - ``FILEDLG/FILE_TABLE/ROW[i]``
+     - ``imgui_click``
+   * - Filename field
+     - ``FILEDLG/NAME_FIELD``
+     - ``imgui_force_set {"value": "name"}``
+   * - OK / Cancel
+     - ``FILEDLG/BTN_OK`` · ``FILEDLG/BTN_CANCEL``
+     - ``imgui_click``
+   * - Overwrite confirm
+     - ``FILEDLG/OVERWRITE/OW_YES`` · ``.../OW_NO``
+     - ``imgui_click``
+
+Standalone vs live
+==================
+
+Same convention as the other tutorials. ``daslang.exe`` runs the demo once and
+exits at ``exit_requested()``; ``daslang-live`` keeps the window open and reloads
+on source edits.
+
+.. seealso::
+
+   Full source: :download:`examples/tutorial/file_dialog.das <../../../examples/tutorial/file_dialog.das>`
+
+   Integration test: ``tests/integration/test_file_dialog.das`` — drives the
+   dialog through ``imgui_playwright`` (open → cancel, save → type → confirm).
+
+   :ref:`data_table <tutorial_data_table>` — the sortable table the file list is
+   built on. :ref:`popup_modal <tutorial_popup_modal>` — the modal container.

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -42,6 +42,7 @@ construction.
    recording.rst
    harness_headless_mode.rst
    data_table.rst
+   file_dialog.rst
    window_size_constraints.rst
    with_tab_stop.rst
    color_button_hover.rst

--- a/examples/tutorial/file_dialog.das
+++ b/examples/tutorial/file_dialog.das
@@ -1,0 +1,95 @@
+options gen2
+
+require imgui/imgui_harness
+require imgui/imgui_file_dialog
+
+// =============================================================================
+// TUTORIAL: file_dialog — native New / Open / Save dialog (boost DSL).
+//
+// `imgui/imgui_file_dialog` is a reusable, fully `imgui_playwright`-drivable
+// file dialog built entirely from boost widgets (popup_modal + data_table +
+// selectable_label + input_text + combo + buttons) — no raw-ImGui C++ library,
+// so every element shows up in the snapshot registry.
+//
+// Immediate-mode usage:
+//   1. a trigger (button / menu) calls `file_dialog_open(cfg)` with a mode,
+//      a start directory, and a list of extension filters;
+//   2. `file_dialog_draw()` runs EVERY frame at the top level of update()
+//      (outside any window, so the registry path stays a clean `FILEDLG/...`)
+//      and returns this frame's `FileDialogResult`;
+//   3. on `confirmed`, read `file_dialog_selection()` / `file_dialog_selected_path()`.
+//
+// open mode multi-selects (Ctrl / Shift, `max_selection`); save / create modes
+// take a typed name and confirm-overwrite if it already exists.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/file_dialog.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/file_dialog.das
+// =============================================================================
+
+var private g_status = "(nothing selected yet)"
+
+def private das_filters() : array<FileDialogFilter> {
+    return <- [FileDialogFilter(caption = "daslang (*.das)", ext = "das"),
+        FileDialogFilter(caption = "All files", ext = "")]
+}
+
+[export]
+def init() {
+    harness_init("file_dialog — native New / Open / Save", 760, 560)
+}
+
+[export]
+def update() {
+    if (!harness_begin_frame()) {
+        return
+    }
+    harness_new_frame()
+
+    SetNextWindowSize(ImVec2(440.0f, 200.0f), ImGuiCond.FirstUseEver)
+    window(FDLG_WIN, (text = "file_dialog demo", closable = false, flags = ImGuiWindowFlags.None)) {
+        text(LEAD, (text = "Open the native file dialog in each mode:"))
+        if (button(BTN_OPEN, (text = "Open..."))) {
+            file_dialog_open(FileDialogConfig(title = "Open File", start_dir = "",
+                filters <- das_filters(), mode = FileDialogMode.open, max_selection = 0))
+        }
+        same_line()
+        if (button(BTN_SAVE, (text = "Save As..."))) {
+            file_dialog_open(FileDialogConfig(title = "Save File As", start_dir = "",
+                filters <- das_filters(), mode = FileDialogMode.save, max_selection = 1))
+        }
+        same_line()
+        if (button(BTN_CREATE, (text = "New..."))) {
+            file_dialog_open(FileDialogConfig(title = "New File", start_dir = "",
+                filters <- das_filters(), mode = FileDialogMode.create, max_selection = 1))
+        }
+        separator(SEP)
+        text(RESULT, (text = g_status))
+    }
+
+    // The dialog renders at the top level so its registry path is `FILEDLG/...`
+    // independent of any window. Poll the result every frame.
+    let r = file_dialog_draw()
+    if (r == FileDialogResult.confirmed) {
+        var sel <- file_dialog_selection()
+        g_status = "picked {length(sel)} file(s): {file_dialog_selected_path()}"
+        delete sel
+    } elif (r == FileDialogResult.cancelled) {
+        g_status = "cancelled"
+    }
+
+    harness_end_frame()
+}
+
+[export]
+def shutdown() {
+    harness_shutdown()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/tests/integration/test_file_dialog.das
+++ b/tests/integration/test_file_dialog.das
@@ -42,21 +42,37 @@ def private count_crumbs_in(var snap : JsonValue?) : int {
 
 def private count_crumbs(app : ImguiApp) : int => count_crumbs_in(snapshot(app))
 
-// First file row whose Type cell reads "Folder" — entry indices are contiguous
-// (0..n-1), so scan the TYPE_CELL[i] payloads on one snapshot.
-def private find_folder_row(app : ImguiApp) : string {
-    var s = snapshot(app)
+// TOPMOST rendered row (smallest bbox.y) whose Type cell == "Folder" (want_folder) or is
+// any non-folder file. Two requirements make a later click land:
+//  - widget_rendered (painted this frame), not just widget_exists (registered): a row can
+//    register a frame before it's laid out (e.g. right after a filter rescan grows the list).
+//  - topmost-by-y: a row near the table's bottom scroll-clip edge is rendered but its center
+//    can fall outside the clip and miss the click, so pick the one comfortably inside.
+// Returns "" when none is clickably visible (e.g. files sit below the fold under many dirs);
+// callers treat that as "skip" rather than fail — no flake.
+def private first_row(var snap : JsonValue?; want_folder : bool) : string {
+    var best = ""
+    var best_y = 1.0e9f
     for (i in range(400)) {
+        let row = "FILEDLG/FILE_TABLE/ROW[{i}]"
         let cell = "FILEDLG/FILE_TABLE/TYPE_CELL[{i}]"
-        if (!widget_exists(s, cell)) {
+        if (!widget_exists(snap, cell) || !widget_rendered(snap, row)) {
             continue
         }
-        if ((widget_payload_field(s, cell, "value") ?? "") == "Folder") {
-            return "FILEDLG/FILE_TABLE/ROW[{i}]"
+        let v = widget_payload_field(snap, cell, "value") ?? ""
+        if (empty(v) || (v == "Folder") != want_folder) {
+            continue
+        }
+        let y = snap?["globals"]?[row]?["bbox"]?["y"] ?? 1.0e9f
+        if (y < best_y) {
+            best_y = y
+            best = row
         }
     }
-    return ""
+    return best
 }
+
+def private find_folder_row(app : ImguiApp) : string => first_row(snapshot(app), true)
 
 [test]
 def test_file_dialog(t : T?) {
@@ -109,5 +125,32 @@ def test_file_dialog(t : T?) {
         force_set_value(d, "FILEDLG/NAME_FIELD", JV("zzz_unit_test"))
         click(d, "FILEDLG/BTN_OK")
         t |> success(wait_result(d, "zzz_unit_test"), "save confirm returns a path containing the typed name")
+
+        // --- save mode: double-clicking an EXISTING file must route through the
+        // overwrite-confirm modal, not confirm directly (regression for that gate).
+        // Needs a clickably-visible file row; files sort below all folders, so when the
+        // start dir has more folders than the table shows (e.g. a repo root) no file is
+        // visible and this sub-check skips — it covers the routing wherever a file IS
+        // visible (most dirs) without flaking where it isn't. The double_click verb +
+        // row-double-click path itself is exercised CI-wide by the open-mode folder case. ---
+        click(d, "FDLG_WIN/BTN_SAVE")
+        if (wait_for_widget(d, "FILEDLG/FILE_TABLE", 10.0f) != null) {
+            force_set_value(d, "FILEDLG/FILTER_COMBO", JV(1))   // widen to "All files"
+            var file_snap = wait_until_sec(d, 3.0f) $(var fsnap) {
+                return !empty(first_row(fsnap, false))
+            }
+            if (file_snap != null) {
+                double_click(d, first_row(file_snap, false))
+                t |> success(wait_for_widget(d, "FILEDLG/OVERWRITE/OW_YES", 5.0f) != null,
+                    "save-mode double-click on an existing file opens overwrite-confirm (not a direct save)")
+                click(d, "FILEDLG/OVERWRITE/OW_YES")
+                // confirm closed the dialog: the table stops rendering (widget_exists stays
+                // true after first render, so check rendered-this-frame, not presence).
+                let closed = wait_until_sec(d, 5.0f) $(var csnap) {
+                    return !widget_rendered(csnap, "FILEDLG/FILE_TABLE")
+                }
+                t |> success(closed != null, "overwrite-confirm Yes commits the save and closes the dialog")
+            }
+        }
     }
 }

--- a/tests/integration/test_file_dialog.das
+++ b/tests/integration/test_file_dialog.das
@@ -42,15 +42,48 @@ def private count_crumbs_in(var snap : JsonValue?) : int {
 
 def private count_crumbs(app : ImguiApp) : int => count_crumbs_in(snapshot(app))
 
-// TOPMOST rendered row (smallest bbox.y) whose Type cell == "Folder" (want_folder) or is
-// any non-folder file. Two requirements make a later click land:
-//  - widget_rendered (painted this frame), not just widget_exists (registered): a row can
-//    register a frame before it's laid out (e.g. right after a filter rescan grows the list).
-//  - topmost-by-y: a row near the table's bottom scroll-clip edge is rendered but its center
-//    can fall outside the clip and miss the click, so pick the one comfortably inside.
-// Returns "" when none is clickably visible (e.g. files sit below the fold under many dirs);
-// callers treat that as "skip" rather than fail — no flake.
+// Live-style UI dump for diagnosing failures on a slow CI box (the macOS runner is
+// dog-slow): logs the table clip rect, every rendered row's type + y-extent, the
+// NAME_FIELD value, and whether the overwrite modal is up. Called on the failure path so
+// a red CI run shows exactly what the dialog looked like instead of leaving us to guess.
+def private dump_ui_state(app : ImguiApp; note : string) {
+    var s = snapshot(app)
+    let tbl = "FILEDLG/FILE_TABLE"
+    let tr = widget_rendered(s, tbl)
+    let tbb = s?["globals"]?[tbl]?["bbox"]
+    let t_top = tbb?["y"] ?? 0.0f
+    let t_bot = tbb?["w"] ?? 0.0f
+    let owy = "FILEDLG/OVERWRITE/OW_YES"
+    let ow_present = widget_exists(s, owy)
+    let nm = widget_payload_field(s, "FILEDLG/NAME_FIELD", "value") ?? "(none)"
+    to_log(LOG_WARNING, "UI DUMP [{note}]: FILE_TABLE rendered={tr} clip_y=[{t_top}..{t_bot}] OVERWRITE_present={ow_present} NAME_FIELD='{nm}'")
+    for (i in range(80)) {
+        let row = "FILEDLG/FILE_TABLE/ROW[{i}]"
+        let cell = "FILEDLG/FILE_TABLE/TYPE_CELL[{i}]"
+        if (!widget_exists(s, cell) || !widget_rendered(s, row)) {
+            continue
+        }
+        let v = widget_payload_field(s, cell, "value") ?? ""
+        let rb = s?["globals"]?[row]?["bbox"]
+        let ry0 = rb?["y"] ?? 0.0f
+        let ry1 = rb?["w"] ?? 0.0f
+        to_log(LOG_WARNING, "  ROW[{i}] type='{v}' y=[{ry0}..{ry1}]")
+    }
+}
+
+// TOPMOST reliably-clickable row whose Type cell == "Folder" (want_folder) or is any
+// non-folder file. A row is reliably clickable only when its whole bbox sits inside the
+// table's clip rect: a row straddling the bottom scroll edge is still "rendered" but its
+// center can fall outside the clip and the click misses (this is what broke macOS CI — a
+// file row near the bottom was picked and the double-click landed nowhere). So:
+//  - widget_rendered (painted this frame), not just widget_exists (registered);
+//  - row bbox fully within FILE_TABLE's bbox (small margin), then topmost-by-y.
+// Returns "" when no matching row is fully visible (e.g. files sit below the fold under a
+// many-folder start dir); callers treat that as "skip" rather than fail — no flake.
 def private first_row(var snap : JsonValue?; want_folder : bool) : string {
+    let tbb = snap?["globals"]?["FILEDLG/FILE_TABLE"]?["bbox"]
+    let t_top = tbb?["y"] ?? 0.0f
+    let t_bot = tbb?["w"] ?? 1.0e9f
     var best = ""
     var best_y = 1.0e9f
     for (i in range(400)) {
@@ -63,9 +96,14 @@ def private first_row(var snap : JsonValue?; want_folder : bool) : string {
         if (empty(v) || (v == "Folder") != want_folder) {
             continue
         }
-        let y = snap?["globals"]?[row]?["bbox"]?["y"] ?? 1.0e9f
-        if (y < best_y) {
-            best_y = y
+        let rb = snap?["globals"]?[row]?["bbox"]
+        let ry0 = rb?["y"] ?? -1.0e9f
+        let ry1 = rb?["w"] ?? 1.0e9f
+        if (ry0 < t_top || ry1 > t_bot - 4.0f) {        // not fully inside the clip rect
+            continue
+        }
+        if (ry0 < best_y) {
+            best_y = ry0
             best = row
         }
     }
@@ -140,8 +178,13 @@ def test_file_dialog(t : T?) {
                 return !empty(first_row(fsnap, false))
             }
             if (file_snap != null) {
-                double_click(d, first_row(file_snap, false))
-                t |> success(wait_for_widget(d, "FILEDLG/OVERWRITE/OW_YES", 5.0f) != null,
+                let frow = first_row(file_snap, false)
+                double_click(d, frow)
+                let ow = wait_for_widget(d, "FILEDLG/OVERWRITE/OW_YES", 5.0f)
+                if (ow == null) {
+                    dump_ui_state(d, "no overwrite modal after save-mode double-click on {frow}")
+                }
+                t |> success(ow != null,
                     "save-mode double-click on an existing file opens overwrite-confirm (not a direct save)")
                 click(d, "FILEDLG/OVERWRITE/OW_YES")
                 // confirm closed the dialog: the table stops rendering (widget_exists stays

--- a/tests/integration/test_file_dialog.das
+++ b/tests/integration/test_file_dialog.das
@@ -42,35 +42,6 @@ def private count_crumbs_in(var snap : JsonValue?) : int {
 
 def private count_crumbs(app : ImguiApp) : int => count_crumbs_in(snapshot(app))
 
-// Live-style UI dump for diagnosing failures on a slow CI box (the macOS runner is
-// dog-slow): logs the table clip rect, every rendered row's type + y-extent, the
-// NAME_FIELD value, and whether the overwrite modal is up. Called on the failure path so
-// a red CI run shows exactly what the dialog looked like instead of leaving us to guess.
-def private dump_ui_state(app : ImguiApp; note : string) {
-    var s = snapshot(app)
-    let tbl = "FILEDLG/FILE_TABLE"
-    let tr = widget_rendered(s, tbl)
-    let tbb = s?["globals"]?[tbl]?["bbox"]
-    let t_top = tbb?["y"] ?? 0.0f
-    let t_bot = tbb?["w"] ?? 0.0f
-    let owy = "FILEDLG/OVERWRITE/OW_YES"
-    let ow_present = widget_exists(s, owy)
-    let nm = widget_payload_field(s, "FILEDLG/NAME_FIELD", "value") ?? "(none)"
-    to_log(LOG_WARNING, "UI DUMP [{note}]: FILE_TABLE rendered={tr} clip_y=[{t_top}..{t_bot}] OVERWRITE_present={ow_present} NAME_FIELD='{nm}'")
-    for (i in range(80)) {
-        let row = "FILEDLG/FILE_TABLE/ROW[{i}]"
-        let cell = "FILEDLG/FILE_TABLE/TYPE_CELL[{i}]"
-        if (!widget_exists(s, cell) || !widget_rendered(s, row)) {
-            continue
-        }
-        let v = widget_payload_field(s, cell, "value") ?? ""
-        let rb = s?["globals"]?[row]?["bbox"]
-        let ry0 = rb?["y"] ?? 0.0f
-        let ry1 = rb?["w"] ?? 0.0f
-        to_log(LOG_WARNING, "  ROW[{i}] type='{v}' y=[{ry0}..{ry1}]")
-    }
-}
-
 // TOPMOST reliably-clickable row whose Type cell == "Folder" (want_folder) or is any
 // non-folder file. A row is reliably clickable only when its whole bbox sits inside the
 // table's clip rect: a row straddling the bottom scroll edge is still "rendered" but its
@@ -182,7 +153,7 @@ def test_file_dialog(t : T?) {
                 double_click(d, frow)
                 let ow = wait_for_widget(d, "FILEDLG/OVERWRITE/OW_YES", 5.0f)
                 if (ow == null) {
-                    dump_ui_state(d, "no overwrite modal after save-mode double-click on {frow}")
+                    log_snapshot(d, "no overwrite modal after save-mode double-click on {frow}")
                 }
                 t |> success(ow != null,
                     "save-mode double-click on an existing file opens overwrite-confirm (not a direct save)")

--- a/tests/integration/test_file_dialog.das
+++ b/tests/integration/test_file_dialog.das
@@ -1,0 +1,120 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+require strings
+
+//! Integration smoke for the native `imgui_file_dialog` component, driven
+//! entirely through `imgui_playwright` (proving the dialog is registry-backed,
+//! not raw ImGui). Boots the tutorial demo, opens the dialog in open mode
+//! (asserts the breadcrumb / sortable table / OK button register), cancels,
+//! then opens save mode, types a filename, confirms, and checks the demo's
+//! result text echoes the typed name. GL + a window are required, so this is a
+//! LOCAL rail — macOS CI has no GL.
+
+let FILE_DIALOG_FEATURE = "modules/dasImgui/examples/tutorial/file_dialog.das"
+
+def private result_value(app : ImguiApp) : string {
+    var s = snapshot(app)
+    return widget_payload_field(s, "FDLG_WIN/RESULT", "value") ?? ""
+}
+
+def private wait_result(app : ImguiApp; needle : string) : bool {
+    for (_ in range(120)) {
+        if (find(result_value(app), needle) >= 0) {
+            return true
+        }
+    }
+    return false
+}
+
+def private count_crumbs(app : ImguiApp) : int {
+    var s = snapshot(app)
+    var n = 0
+    for (i in range(64)) {
+        if (!widget_exists(s, "FILEDLG/CRUMB[{i}]")) {
+            break
+        }
+        n++
+    }
+    return n
+}
+
+// First file row whose Type cell reads "Folder" — entry indices are contiguous
+// (0..n-1), so scan the TYPE_CELL[i] payloads on one snapshot.
+def private find_folder_row(app : ImguiApp) : string {
+    var s = snapshot(app)
+    for (i in range(400)) {
+        let cell = "FILEDLG/FILE_TABLE/TYPE_CELL[{i}]"
+        if (!widget_exists(s, cell)) {
+            continue
+        }
+        if ((widget_payload_field(s, cell, "value") ?? "") == "Folder") {
+            return "FILEDLG/FILE_TABLE/ROW[{i}]"
+        }
+    }
+    return ""
+}
+
+[test]
+def test_file_dialog(t : T?) {
+    with_imgui_app(FILE_DIALOG_FEATURE) $(d) {
+        // demo window + the three trigger buttons render
+        var snap = wait_for_widget(d, "FDLG_WIN/BTN_OPEN", 15.0f)
+        t |> success(snap != null, "demo window + Open trigger render")
+        if (snap == null) {
+            return
+        }
+        t |> success(widget_exists(snap, "FDLG_WIN/BTN_SAVE"), "Save As trigger present")
+        t |> success(widget_exists(snap, "FDLG_WIN/BTN_CREATE"), "New trigger present")
+
+        // --- open mode: the dialog is fully registry-backed ---
+        click(d, "FDLG_WIN/BTN_OPEN")
+        var od = wait_for_widget(d, "FILEDLG/FILE_TABLE", 10.0f)
+        t |> success(od != null, "open dialog renders the sortable file table (FILEDLG/FILE_TABLE)")
+        if (od != null) {
+            t |> success(widget_exists(od, "FILEDLG/UP"), "breadcrumb '..' button present")
+            t |> success(widget_exists(od, "FILEDLG/BTN_OK"), "OK button present")
+            t |> success(widget_exists(od, "FILEDLG/BTN_CANCEL"), "Cancel button present")
+
+            // folder double-click enters the directory — regresses the row-loop
+            // rebuild crash (navigate_to mutating entries/view mid-iteration).
+            let folder = find_folder_row(d)
+            if (!empty(folder)) {
+                let before = count_crumbs(d)
+                double_click(d, folder)
+                var entered = false
+                for (_ in range(180)) {
+                    if (count_crumbs(d) > before) {
+                        entered = true
+                        break
+                    }
+                }
+                t |> success(entered, "folder double-click enters the dir without crashing ({folder})")
+            }
+
+            // breadcrumb click navigates — regresses the crumb-loop rebuild crash.
+            // A surviving table after the click proves the body didn't throw.
+            if (widget_exists(snapshot(d), "FILEDLG/CRUMB[0]")) {
+                click(d, "FILEDLG/CRUMB[0]")
+                t |> success(wait_for_widget(d, "FILEDLG/FILE_TABLE", 5.0f) != null,
+                    "breadcrumb click navigates without crashing")
+            }
+        }
+        click(d, "FILEDLG/BTN_CANCEL")
+        t |> success(wait_result(d, "cancelled"), "Cancel returns the cancelled result")
+
+        // --- save mode: type a name + confirm, result echoes the name ---
+        click(d, "FDLG_WIN/BTN_SAVE")
+        var sd = wait_for_widget(d, "FILEDLG/NAME_FIELD", 10.0f)
+        t |> success(sd != null, "save dialog renders the filename field (FILEDLG/NAME_FIELD)")
+        force_set_value(d, "FILEDLG/NAME_FIELD", JV("zzz_unit_test"))
+        click(d, "FILEDLG/BTN_OK")
+        t |> success(wait_result(d, "zzz_unit_test"), "save confirm returns a path containing the typed name")
+    }
+}

--- a/tests/integration/test_file_dialog.das
+++ b/tests/integration/test_file_dialog.das
@@ -14,36 +14,33 @@ require strings
 //! not raw ImGui). Boots the tutorial demo, opens the dialog in open mode
 //! (asserts the breadcrumb / sortable table / OK button register), cancels,
 //! then opens save mode, types a filename, confirms, and checks the demo's
-//! result text echoes the typed name. GL + a window are required, so this is a
-//! LOCAL rail — macOS CI has no GL.
+//! result text echoes the typed name. Runs headless (no GL / no window) — it
+//! drives the dialog purely over the live API, so it runs in CI on both ubuntu
+//! and macOS via `--headless`, like the rest of the integration suite.
 
 let FILE_DIALOG_FEATURE = "modules/dasImgui/examples/tutorial/file_dialog.das"
 
-def private result_value(app : ImguiApp) : string {
-    var s = snapshot(app)
-    return widget_payload_field(s, "FDLG_WIN/RESULT", "value") ?? ""
-}
-
+// Budgeted poll (poll interval + real timeout) — never a tight busy-loop, which
+// in headless can spin to completion before the UI updates (false negative) and
+// pegs a core. wait_until_sec is the headless-safe poller (timeline-aware).
 def private wait_result(app : ImguiApp; needle : string) : bool {
-    for (_ in range(120)) {
-        if (find(result_value(app), needle) >= 0) {
-            return true
-        }
-    }
-    return false
+    return wait_until_sec(app, 5.0f) $(var snap) {
+        return find(widget_payload_field(snap, "FDLG_WIN/RESULT", "value") ?? "", needle) >= 0
+    } != null
 }
 
-def private count_crumbs(app : ImguiApp) : int {
-    var s = snapshot(app)
+def private count_crumbs_in(var snap : JsonValue?) : int {
     var n = 0
     for (i in range(64)) {
-        if (!widget_exists(s, "FILEDLG/CRUMB[{i}]")) {
+        if (!widget_exists(snap, "FILEDLG/CRUMB[{i}]")) {
             break
         }
         n++
     }
     return n
 }
+
+def private count_crumbs(app : ImguiApp) : int => count_crumbs_in(snapshot(app))
 
 // First file row whose Type cell reads "Folder" — entry indices are contiguous
 // (0..n-1), so scan the TYPE_CELL[i] payloads on one snapshot.
@@ -88,13 +85,9 @@ def test_file_dialog(t : T?) {
             if (!empty(folder)) {
                 let before = count_crumbs(d)
                 double_click(d, folder)
-                var entered = false
-                for (_ in range(180)) {
-                    if (count_crumbs(d) > before) {
-                        entered = true
-                        break
-                    }
-                }
+                let entered = wait_until_sec(d, 5.0f) $(var cs) {
+                    return count_crumbs_in(cs) > before
+                } != null
                 t |> success(entered, "folder double-click enters the dir without crashing ({folder})")
             }
 

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -150,10 +150,10 @@ def document_module_imgui_playwright() {
     var groups <- array<DocGroup>(
         group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
         group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|widget_click_point|widget_component_point|get_text)$%%),
-        group_by_regex("Actions",           mod, %regex~^(click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
+        group_by_regex("Actions",           mod, %regex~^(click|double_click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
         group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_unchanged|record_check_rendered|record_check_kind_count|record_check)$%%),
         group_by_regex("Content-time gating", mod, %regex~^(wait_content_frames|hold_content|record_frame_count|hold_remainder_content)$%%),
-        group_by_regex("Snapshots",         mod, %regex~^(snapshot|expect_value|expect_render).*%%),
+        group_by_regex("Snapshots",         mod, %regex~^(snapshot|log_snapshot|expect_value|expect_render).*%%),
         group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe)$%%),
         group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),
         group_by_regex("Transport plumbing", mod, %regex~^(post_command|send_imgui_command|receive_imgui_command).*%%),

--- a/widgets/imgui_file_dialog.das
+++ b/widgets/imgui_file_dialog.das
@@ -1,0 +1,524 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+module imgui_file_dialog shared
+
+require imgui public
+require imgui/imgui_boost_runtime public
+require imgui/imgui_boost_v2 public
+require imgui/imgui_widgets_builtin public
+require imgui/imgui_containers_builtin public
+require imgui/imgui_table_builtin public
+require daslib/fio
+require strings
+
+//! Native, reusable file dialog built entirely from the boost DSL — so every
+//! interactive element registers on the snapshot registry and the whole dialog
+//! is `imgui_playwright`-drivable (a bound C++ file dialog, rendering raw ImGui,
+//! would be invisible to it). Mirrors ImGuiFileDialog's core UX: directory
+//! navigation (clickable breadcrumb + ".."), a sortable Name/Size/Type table,
+//! an extension-filter dropdown, multi-select (open mode), a filename field
+//! (save/create), and an overwrite-confirm step.
+//!
+//! Immediate-mode: `file_dialog_open(cfg)` queues the modal, then call
+//! `file_dialog_draw()` EVERY frame (at the top level of `update()`, outside any
+//! window, so the registry path stays a clean `FILEDLG/...`). It returns the
+//! per-frame result; read the chosen path(s) with `file_dialog_selection()`.
+//! A modal is exclusive, so the widget state is a module singleton (one dialog
+//! at a time).
+
+// ===== Public types =====
+
+enum FileDialogResult {
+    none        //!< still open this frame, or not open
+    confirmed   //!< committed a valid selection this frame
+    cancelled   //!< cancelled / closed this frame
+}
+
+enum FileDialogMode {
+    open        //!< pick existing file(s) — multi-select per `max_selection`
+    save        //!< type/confirm a name; overwrite-confirm if it exists
+    create      //!< "New" — type a name (same name-entry path as save)
+}
+
+struct FileDialogFilter {
+    caption : string    //!< shown in the filter dropdown, e.g. "Levels (*.json)" (`label` is reserved in gen2)
+    ext : string        //!< extension without the dot, e.g. "json"; "" = all files
+}
+
+struct FileDialogConfig {
+    title : string = "Select File"
+    start_dir : string = ""                 //!< absolute dir to open at; "" = cwd
+    filters : array<FileDialogFilter>       //!< empty => all files
+    mode : FileDialogMode = FileDialogMode.open
+    max_selection : int = 1                 //!< open mode; 0 = unlimited
+}
+
+// ===== Internal state =====
+
+struct private Entry {
+    name : string
+    is_dir : bool
+    size : uint64
+}
+
+struct private DialogState {
+    title : string
+    cur_dir : string
+    start_dir : string
+    mode : FileDialogMode = FileDialogMode.open
+    max_selection : int = 1
+    filters : array<FileDialogFilter>
+    filter_labels : array<string>           // cached for the combo (no per-frame alloc)
+    filter_idx : int = 0
+    entries : array<Entry>                  // current dir, filtered
+    view : array<int>                       // indices into entries, sorted
+    selection : array<int>                  // selected entry indices
+    anchor : int = -1                       // shift-range anchor (entry index)
+    crumbs : array<string>                  // ancestor paths, root-first
+    result : array<string>                  // confirmed absolute path(s)
+    pending_leaf : string                   // name awaiting overwrite-confirm
+    sort_col : int = 1                       // column_user_id (COL_NAME)
+    sort_desc : bool = false
+    open : bool = false
+    error : string
+}
+
+var private g_fd : DialogState = DialogState()
+
+let private COL_NAME = 1u
+let private COL_SIZE = 2u
+let private COL_TYPE = 3u
+
+// Indexed widget-state tables (the dynamic-row / dynamic-button idiom).
+var private ROW : table<int; ClickState>
+var private SIZE_CELL : table<int; NarrativeState>
+var private TYPE_CELL : table<int; NarrativeState>
+var private CRUMB : table<int; ClickState>
+var private CRUMB_SL : table<int; EmptyMarkerState>
+
+// ===== Helpers =====
+
+def private active_ext() : string {
+    if (g_fd.filter_idx >= 0 && g_fd.filter_idx < length(g_fd.filters)) {
+        return g_fd.filters[g_fd.filter_idx].ext
+    }
+    return ""
+}
+
+// "foo.json" matches ext "json" iff it ends in exactly ".json" (the level_names
+// idiom — uses fio's replace_extension, never hand-rolled rfind/slice).
+def private has_ext(name : string; ext : string) : bool {
+    if (empty(ext)) {
+        return true
+    }
+    return replace_extension(name, "") + "." + ext == name
+}
+
+def private ensure_ext(name : string; ext : string) : string {
+    if (empty(ext) || has_ext(name, ext)) {
+        return name
+    }
+    return "{name}.{ext}"
+}
+
+// Human-readable size with one decimal. uint interpolates as hex, so the
+// tenths are computed with integer math and rendered through int (decimal).
+def private fmt_size(b : uint64) : string {
+    if (b < 1024ul) {
+        return "{int(b)} B"
+    } elif (b < 1048576ul) {
+        let t = int(b * 10ul / 1024ul)
+        return "{t / 10}.{t % 10} KB"
+    } elif (b < 1073741824ul) {
+        let t = int(b * 10ul / 1048576ul)
+        return "{t / 10}.{t % 10} MB"
+    }
+    let t = int(b * 10ul / 1073741824ul)
+    return "{t / 10}.{t % 10} GB"
+}
+
+def private is_valid_filename(name : string) : bool {
+    if (empty(name) || name == "." || name == "..") {
+        return false
+    }
+    var ok = true
+    peek_data(name) $(bytes) {
+        for (c in bytes) {
+            if (c == uint8(47) || c == uint8(92)) {     // '/' or '\' — no path separators
+                ok = false
+            }
+        }
+    }
+    return ok
+}
+
+def private scan_dir() {
+    g_fd.entries |> clear()
+    let ext = active_ext()
+    dir(g_fd.cur_dir) $(nm) {
+        if (nm == "." || nm == "..") {
+            return
+        }
+        let fs = stat(path_join(g_fd.cur_dir, nm))
+        if (!fs.is_valid) {
+            return
+        }
+        if (fs.is_dir) {
+            g_fd.entries |> push(Entry(name = nm, is_dir = true, size = 0ul))
+        } elif (has_ext(nm, ext)) {
+            g_fd.entries |> push(Entry(name = nm, is_dir = false, size = fs.size))
+        }
+    }
+}
+
+def private compare_entry(a : Entry; b : Entry) : int {
+    var ord = 0
+    if (g_fd.sort_col == int(COL_SIZE)) {
+        if (a.size < b.size) {
+            ord = -1
+        } elif (a.size > b.size) {
+            ord = 1
+        }
+    } else {
+        if (a.name < b.name) {
+            ord = -1
+        } elif (a.name > b.name) {
+            ord = 1
+        }
+    }
+    return ord
+}
+
+def private sort_view() {
+    g_fd.view |> sort() $(ia, ib) {
+        let a = g_fd.entries[ia]
+        let b = g_fd.entries[ib]
+        if (a.is_dir != b.is_dir) {
+            return a.is_dir                  // dirs first, always
+        }
+        var ord = compare_entry(a, b)
+        if (g_fd.sort_desc) {
+            ord = -ord
+        }
+        if (ord != 0) {
+            return ord < 0
+        }
+        return a.name < b.name               // stable tiebreak
+    }
+}
+
+def private rebuild_view() {
+    g_fd.view <- [for (i in range(length(g_fd.entries))); i]
+    sort_view()
+}
+
+def private rebuild_crumbs() {
+    var tmp : array<string>
+    tmp |> reserve(64)
+    var p = g_fd.cur_dir
+    for (_ in range(64)) {
+        tmp |> push(p)
+        let par = parent(p)
+        if (par == p) {
+            break
+        }
+        p = par
+    }
+    g_fd.crumbs <- [for (i in range(length(tmp))); tmp[length(tmp) - 1 - i]]
+    delete tmp
+}
+
+def private navigate_to(d : string) {
+    g_fd.cur_dir = normalize(d)
+    g_fd.selection |> clear()
+    g_fd.anchor = -1
+    g_fd.error = ""
+    scan_dir()
+    rebuild_view()
+    rebuild_crumbs()
+}
+
+def private is_selected(idx : int) : bool {
+    for (s in g_fd.selection) {
+        if (s == idx) {
+            return true
+        }
+    }
+    return false
+}
+
+def private apply_click(idx : int; ctrl : bool; shift : bool) {
+    let multi = g_fd.mode == FileDialogMode.open && g_fd.max_selection != 1
+    if (!multi || (!ctrl && !shift)) {
+        g_fd.selection |> clear()
+        g_fd.selection |> push(idx)
+        g_fd.anchor = idx
+        return
+    }
+    if (shift && g_fd.anchor >= 0) {
+        var lo = -1
+        var hi = -1
+        for (vi in range(length(g_fd.view))) {
+            if (g_fd.view[vi] == g_fd.anchor) {
+                lo = vi
+            }
+            if (g_fd.view[vi] == idx) {
+                hi = vi
+            }
+        }
+        if (lo > hi) {
+            let t = lo; lo = hi; hi = t
+        }
+        if (lo >= 0) {
+            g_fd.selection <- [for (vi in range(lo, hi + 1)); g_fd.view[vi]]
+        } else {
+            g_fd.selection |> clear()
+        }
+    } else {
+        // ctrl-toggle: drop idx if present, else add it
+        let was_sel = is_selected(idx)
+        var ns <- [for (s in g_fd.selection); s; where s != idx]
+        if (!was_sel) {
+            ns |> push(idx)
+        }
+        g_fd.selection <- ns
+        g_fd.anchor = idx
+    }
+    // clamp to max_selection (keep the most recent N)
+    if (g_fd.max_selection > 0 && length(g_fd.selection) > g_fd.max_selection) {
+        let start = length(g_fd.selection) - g_fd.max_selection
+        g_fd.selection <- [for (k in range(start, length(g_fd.selection))); g_fd.selection[k]]
+    }
+}
+
+def private name_exists(leaf : string) : bool {
+    for (e in g_fd.entries) {
+        if (!e.is_dir && e.name == leaf) {
+            return true
+        }
+    }
+    return false
+}
+
+def private confirm_single(path : string) : FileDialogResult {
+    g_fd.result |> clear()
+    g_fd.result |> push(path)
+    FILEDLG.pending_close = true
+    g_fd.open = false
+    return FileDialogResult.confirmed
+}
+
+def private confirm_multi(var paths : array<string>) : FileDialogResult {
+    g_fd.result <- paths
+    FILEDLG.pending_close = true
+    g_fd.open = false
+    return FileDialogResult.confirmed
+}
+
+def private try_confirm() : FileDialogResult {
+    g_fd.error = ""
+    if (g_fd.mode == FileDialogMode.open) {
+        var paths <- [for (s in g_fd.selection);
+            path_join(g_fd.cur_dir, g_fd.entries[s].name);
+            where !g_fd.entries[s].is_dir]
+        if (!empty(paths)) {
+            return confirm_multi(paths)
+        }
+        if (length(g_fd.selection) == 1 && g_fd.entries[g_fd.selection[0]].is_dir) {
+            navigate_to(path_join(g_fd.cur_dir, g_fd.entries[g_fd.selection[0]].name))
+            return FileDialogResult.none
+        }
+        g_fd.error = "select a file"
+        return FileDialogResult.none
+    }
+    // save / create (name mode)
+    let raw = NAME_FIELD.value
+    if (!is_valid_filename(raw)) {
+        g_fd.error = "invalid name"
+        return FileDialogResult.none
+    }
+    let leaf = ensure_ext(raw, active_ext())
+    if (name_exists(leaf)) {
+        g_fd.pending_leaf = leaf
+        OVERWRITE.pending_open = true
+        return FileDialogResult.none
+    }
+    return confirm_single(path_join(g_fd.cur_dir, leaf))
+}
+
+// ===== Public API =====
+
+//! Queue the dialog to open next frame and snapshot `start_dir`'s listing.
+def public file_dialog_open(cfg : FileDialogConfig) {
+    g_fd.title = cfg.title
+    g_fd.mode = cfg.mode
+    g_fd.max_selection = cfg.max_selection
+    g_fd.filters := cfg.filters
+    g_fd.filter_labels <- [for (f in cfg.filters); f.caption]
+    g_fd.filter_idx = 0
+    FILTER_COMBO.value = empty(cfg.filters) ? -1 : 0
+    g_fd.start_dir = normalize(empty(cfg.start_dir) ? getcwd() : cfg.start_dir)
+    g_fd.cur_dir = g_fd.start_dir
+    g_fd.selection |> clear()
+    g_fd.result |> clear()
+    g_fd.anchor = -1
+    g_fd.sort_col = int(COL_NAME)
+    g_fd.sort_desc = false
+    g_fd.error = ""
+    g_fd.open = true
+    NAME_FIELD.pending_value = ""
+    NAME_FIELD.has_pending = true
+    ROW |> clear()
+    SIZE_CELL |> clear()
+    TYPE_CELL |> clear()
+    CRUMB |> clear()
+    CRUMB_SL |> clear()
+    scan_dir()
+    rebuild_view()
+    rebuild_crumbs()
+    FILEDLG.pending_open = true
+}
+
+//! Render the modal if open and return this frame's result. Call every frame.
+def public file_dialog_draw() : FileDialogResult {
+    var result = FileDialogResult.none
+    // A row double-click navigates / confirms, both of which rebuild
+    // entries/view — deferred out of the row loop (mutating mid-iteration
+    // invalidates the loop's indices). Captured here, applied after the table.
+    var nav_to = ""
+    var confirm_path = ""
+    SetNextWindowSize(ImVec2(720.0f, 520.0f), ImGuiCond.FirstUseEver)
+    popup_modal(FILEDLG, (text = g_fd.title, closable = false, flags = ImGuiWindowFlags.None)) {
+        // --- breadcrumb / nav ---
+        if (button(UP, (text = ".."))) {
+            nav_to = parent(g_fd.cur_dir)
+        }
+        for (ci in range(length(g_fd.crumbs))) {
+            let seg = g_fd.crumbs[ci]
+            let lbl = base_name(seg)
+            same_line(CRUMB_SL[ci])
+            if (button(CRUMB[ci], (text = empty(lbl) ? seg : lbl))) {
+                nav_to = seg            // deferred: navigate_to rebuilds crumbs — can't run mid-loop
+            }
+        }
+        // --- filter ---
+        if (!empty(g_fd.filter_labels)) {
+            combo(FILTER_COMBO, (text = "##filter", items := g_fd.filter_labels))
+            if (FILTER_COMBO.value != g_fd.filter_idx && FILTER_COMBO.value >= 0) {
+                g_fd.filter_idx = FILTER_COMBO.value
+                scan_dir()
+                rebuild_view()
+            }
+        }
+        separator(NAV_SEP)
+        // --- file table ---
+        let tflags = (ImGuiTableFlags.BordersOuter | ImGuiTableFlags.RowBg |
+                      ImGuiTableFlags.Resizable | ImGuiTableFlags.ScrollY |
+                      ImGuiTableFlags.Sortable)
+        data_table(FILE_TABLE, (text = "##files", columns = 3, flags = tflags,
+                                outer_size = float2(0.0f, 340.0f), inner_width = 0.0f)) {
+            table_setup_scroll_freeze(0, 1)
+            table_setup_column("Name", ImGuiTableColumnFlags.DefaultSort | ImGuiTableColumnFlags.WidthStretch, 0.0f, COL_NAME)
+            table_setup_column("Size", ImGuiTableColumnFlags.WidthFixed, 90.0f, COL_SIZE)
+            table_setup_column("Type", ImGuiTableColumnFlags.WidthFixed, 80.0f, COL_TYPE)
+            table_headers_row()
+            sort_specs() $(specs) {
+                if (!empty(specs)) {
+                    g_fd.sort_col = int(specs[0].column_user_id)
+                    g_fd.sort_desc = specs[0].sort_direction == ImGuiSortDirection.Descending
+                }
+                sort_view()
+            }
+            for (idx in g_fd.view) {
+                let e = g_fd.entries[idx]
+                table_next_row()
+                table_set_column_index(0)
+                if (selectable_label(ROW[idx], (text = e.name, selected = is_selected(idx),
+                                                flags = ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowDoubleClick))) {
+                    if (IsMouseDoubleClicked(ImGuiMouseButton.Left)) {
+                        if (e.is_dir) {
+                            nav_to = path_join(g_fd.cur_dir, e.name)
+                        } else {
+                            confirm_path = path_join(g_fd.cur_dir, e.name)
+                        }
+                    } else {
+                        let io & = unsafe(GetIO())
+                        apply_click(idx, io.KeyCtrl, io.KeyShift)
+                        if (g_fd.mode != FileDialogMode.open && !e.is_dir) {
+                            NAME_FIELD.pending_value = e.name
+                            NAME_FIELD.has_pending = true
+                        }
+                    }
+                }
+                table_set_column_index(1)
+                text(SIZE_CELL[idx], (text = e.is_dir ? "" : fmt_size(e.size)))
+                table_set_column_index(2)
+                text(TYPE_CELL[idx], (text = e.is_dir ? "Folder" : (empty(active_ext()) ? "File" : active_ext())))
+            }
+        }
+        // Apply the deferred row action now the loop is finished (safe to rebuild).
+        if (!empty(nav_to)) {
+            navigate_to(nav_to)
+        } elif (!empty(confirm_path)) {
+            result = confirm_single(confirm_path)
+        }
+        separator(BOTTOM_SEP)
+        // --- bottom bar ---
+        if (g_fd.mode != FileDialogMode.open) {
+            input_text(NAME_FIELD, (text = "Name"))
+        }
+        if (!empty(g_fd.error)) {
+            text(ERR_LABEL, (text = g_fd.error))
+        }
+        let ok_label = (g_fd.mode == FileDialogMode.open ? "Open" :
+                        (g_fd.mode == FileDialogMode.save ? "Save" : "Create"))
+        if (button(BTN_OK, (text = ok_label))) {
+            result = try_confirm()
+        }
+        same_line()
+        if (button(BTN_CANCEL, (text = "Cancel"))) {
+            FILEDLG.pending_close = true
+            g_fd.open = false
+            result = FileDialogResult.cancelled
+        }
+        // --- overwrite-confirm (save / create) ---
+        SetNextWindowSize(ImVec2(360.0f, 0.0f), ImGuiCond.FirstUseEver)
+        popup_modal(OVERWRITE, (text = "Overwrite?", closable = false, flags = ImGuiWindowFlags.AlwaysAutoResize)) {
+            text(OW_MSG, (text = "'{g_fd.pending_leaf}' already exists. Overwrite?"))
+            separator(OW_SEP)
+            if (button(OW_YES, (text = "Overwrite"))) {
+                OVERWRITE.pending_close = true
+                result = confirm_single(path_join(g_fd.cur_dir, g_fd.pending_leaf))
+            }
+            same_line()
+            if (button(OW_NO, (text = "Cancel"))) {
+                OVERWRITE.pending_close = true
+            }
+        }
+    }
+    // ESC / external close with no committed result this frame ⇒ cancel
+    if (g_fd.open && !FILEDLG.open && result == FileDialogResult.none) {
+        g_fd.open = false
+        result = FileDialogResult.cancelled
+    }
+    return result
+}
+
+//! Confirmed absolute path(s). Valid on the `confirmed` frame and until reopened.
+def public file_dialog_selection() : array<string> {
+    var out : array<string>
+    out := g_fd.result
+    return <- out
+}
+
+//! First confirmed path (convenience for single-select callers).
+def public file_dialog_selected_path() : string {
+    return empty(g_fd.result) ? "" : g_fd.result[0]
+}
+
+def public file_dialog_current_dir() : string => g_fd.cur_dir
+
+def public file_dialog_is_open() : bool => g_fd.open

--- a/widgets/imgui_file_dialog.das
+++ b/widgets/imgui_file_dialog.das
@@ -62,6 +62,7 @@ struct private Entry {
     name : string
     is_dir : bool
     size : uint64
+    ext : string    //!< dotted extension (".das"), "" if none / dir — drives the Type cell + Type sort
 }
 
 struct private DialogState {
@@ -136,7 +137,7 @@ def private fmt_size(b : uint64) : string {
         let t = int(b * 10ul / 1048576ul)
         return "{t / 10}.{t % 10} MB"
     }
-    let t = int(b * 10ul / 1073741824ul)
+    let t = int64(b * 10ul / 1073741824ul)   // int64: the GB tier is unbounded (int32 overflows >~214 TB)
     return "{t / 10}.{t % 10} GB"
 }
 
@@ -167,9 +168,9 @@ def private scan_dir() {
             return
         }
         if (fs.is_dir) {
-            g_fd.entries |> push(Entry(name = nm, is_dir = true, size = 0ul))
+            g_fd.entries |> push(Entry(name = nm, is_dir = true, size = 0ul, ext = ""))
         } elif (has_ext(nm, ext)) {
-            g_fd.entries |> push(Entry(name = nm, is_dir = false, size = fs.size))
+            g_fd.entries |> push(Entry(name = nm, is_dir = false, size = fs.size, ext = extension(nm)))
         }
     }
 }
@@ -180,6 +181,12 @@ def private compare_entry(a : Entry; b : Entry) : int {
         if (a.size < b.size) {
             ord = -1
         } elif (a.size > b.size) {
+            ord = 1
+        }
+    } elif (g_fd.sort_col == int(COL_TYPE)) {
+        if (a.ext < b.ext) {
+            ord = -1
+        } elif (a.ext > b.ext) {
             ord = 1
         }
     } else {
@@ -409,6 +416,10 @@ def public file_dialog_draw() : FileDialogResult {
             combo(FILTER_COMBO, (text = "##filter", items := g_fd.filter_labels))
             if (FILTER_COMBO.value != g_fd.filter_idx && FILTER_COMBO.value >= 0) {
                 g_fd.filter_idx = FILTER_COMBO.value
+                // selection holds indices into `entries`; scan_dir rebuilds it, so old
+                // indices would dangle (OOB / wrong row in try_confirm). Clear them.
+                g_fd.selection |> clear()
+                g_fd.anchor = -1
                 scan_dir()
                 rebuild_view()
             }
@@ -456,7 +467,7 @@ def public file_dialog_draw() : FileDialogResult {
                 table_set_column_index(1)
                 text(SIZE_CELL[idx], (text = e.is_dir ? "" : fmt_size(e.size)))
                 table_set_column_index(2)
-                text(TYPE_CELL[idx], (text = e.is_dir ? "Folder" : (empty(active_ext()) ? "File" : active_ext())))
+                text(TYPE_CELL[idx], (text = e.is_dir ? "Folder" : (empty(e.ext) ? "File" : e.ext)))
             }
         }
         // Apply the deferred row action now the loop is finished (safe to rebuild).

--- a/widgets/imgui_file_dialog.das
+++ b/widgets/imgui_file_dialog.das
@@ -474,7 +474,16 @@ def public file_dialog_draw() : FileDialogResult {
         if (!empty(nav_to)) {
             navigate_to(nav_to)
         } elif (!empty(confirm_path)) {
-            result = confirm_single(confirm_path)
+            if (g_fd.mode == FileDialogMode.open) {
+                result = confirm_single(confirm_path)
+            } else {
+                // save/create: a double-clicked file exists by definition, so it must pass
+                // the same overwrite gate as the name+OK path instead of confirming directly.
+                g_fd.pending_leaf = base_name(confirm_path)
+                NAME_FIELD.pending_value = g_fd.pending_leaf
+                NAME_FIELD.has_pending = true
+                OVERWRITE.pending_open = true
+            }
         }
         separator(BOTTOM_SEP)
         // --- bottom bar ---

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -465,7 +465,11 @@ def public double_click(app : ImguiApp; target : string) : JsonValue? {
     //! per frame, so the two taps are guaranteed to land on distinct frames a couple of frames
     //! apart — well inside ``MouseDoubleClickTime`` at any frame rate, and never collapsed into one
     //! frame the way a wall-clock timeline can be on a slow/stalled host (which drops the double-click).
+    //! Returns ``{ok=false, error}`` when ``target`` isn't in the snapshot or isn't rendered this
+    //! frame (``widget_click_point`` would otherwise default the bbox to (0,0) and click nowhere).
     var snap = snapshot(app)
+    if (!(snap |> widget_exists(target))) return JV((ok = false, error = "double_click target unresolved: {target}"))
+    if (!(snap |> widget_rendered(target))) return JV((ok = false, error = "double_click target not rendered this frame: {target}"))
     let pos = widget_click_point(snap, target)
     var events <- [
         JV((t_ms = 0, kind = "move",   x = last_cursor_x, y = last_cursor_y)),

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -458,22 +458,25 @@ def public click(app : ImguiApp; target : string) : JsonValue? {
 }
 
 def public double_click(app : ImguiApp; target : string) : JsonValue? {
-    //! Faithful double-click on ``target``'s bbox center: two press/release taps within
-    //! ImGui's ``MouseDoubleClickTime`` (built as an ``imgui_mouse_play`` timeline) so
+    //! Faithful double-click on ``target``'s bbox center: two press/release taps so
     //! ``IsMouseDoubleClicked`` fires — e.g. enter-directory / open-file in a file dialog.
     //! Re-snapshots to resolve the center client-side (like ``drag``); the target must be rendered.
+    //! Frame-paced (``t_ms`` = frame index, like ``drag``): the host advances exactly one event
+    //! per frame, so the two taps are guaranteed to land on distinct frames a couple of frames
+    //! apart — well inside ``MouseDoubleClickTime`` at any frame rate, and never collapsed into one
+    //! frame the way a wall-clock timeline can be on a slow/stalled host (which drops the double-click).
     var snap = snapshot(app)
     let pos = widget_click_point(snap, target)
     var events <- [
-        JV((t_ms = 0,   kind = "move",   x = last_cursor_x, y = last_cursor_y)),
-        JV((t_ms = 400, kind = "move",   x = pos._0,        y = pos._1)),
-        JV((t_ms = 500, kind = "button", button = 0,        action = "press")),
-        JV((t_ms = 560, kind = "button", button = 0,        action = "release")),
-        JV((t_ms = 660, kind = "button", button = 0,        action = "press")),
-        JV((t_ms = 720, kind = "button", button = 0,        action = "release")),
-        JV((t_ms = 850, kind = "move",   x = pos._0,        y = pos._1))
+        JV((t_ms = 0, kind = "move",   x = last_cursor_x, y = last_cursor_y)),
+        JV((t_ms = 1, kind = "move",   x = pos._0,        y = pos._1)),
+        JV((t_ms = 2, kind = "button", button = 0,        action = "press")),
+        JV((t_ms = 3, kind = "button", button = 0,        action = "release")),
+        JV((t_ms = 4, kind = "button", button = 0,        action = "press")),
+        JV((t_ms = 5, kind = "button", button = 0,        action = "release")),
+        JV((t_ms = 6, kind = "move",   x = pos._0,        y = pos._1))
     ]
-    var r = post_command(app, "imgui_mouse_play", JV((events = events)))
+    var r = post_command(app, "imgui_mouse_play", JV((events = events, frame_paced = true)))
     unsafe { delete events; }
     last_cursor_x = pos._0
     last_cursor_y = pos._1

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -457,6 +457,29 @@ def public click(app : ImguiApp; target : string) : JsonValue? {
     return send_imgui_command(app.transport, "imgui_click", JV((target = target)))
 }
 
+def public double_click(app : ImguiApp; target : string) : JsonValue? {
+    //! Faithful double-click on ``target``'s bbox center: two press/release taps within
+    //! ImGui's ``MouseDoubleClickTime`` (built as an ``imgui_mouse_play`` timeline) so
+    //! ``IsMouseDoubleClicked`` fires — e.g. enter-directory / open-file in a file dialog.
+    //! Re-snapshots to resolve the center client-side (like ``drag``); the target must be rendered.
+    var snap = snapshot(app)
+    let pos = widget_click_point(snap, target)
+    var events <- [
+        JV((t_ms = 0,   kind = "move",   x = last_cursor_x, y = last_cursor_y)),
+        JV((t_ms = 400, kind = "move",   x = pos._0,        y = pos._1)),
+        JV((t_ms = 500, kind = "button", button = 0,        action = "press")),
+        JV((t_ms = 560, kind = "button", button = 0,        action = "release")),
+        JV((t_ms = 660, kind = "button", button = 0,        action = "press")),
+        JV((t_ms = 720, kind = "button", button = 0,        action = "release")),
+        JV((t_ms = 850, kind = "move",   x = pos._0,        y = pos._1))
+    ]
+    var r = post_command(app, "imgui_mouse_play", JV((events = events)))
+    unsafe { delete events; }
+    last_cursor_x = pos._0
+    last_cursor_y = pos._1
+    return r
+}
+
 def public right_click(app : ImguiApp; target : string) : JsonValue? {
     //! Synthesize a right-click on ``target`` (``imgui_click`` verb with ``button = 1``).
     //! Used by popup_context_item / popup_context_window drivers.

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -273,6 +273,33 @@ def public widget_rendered(var snap : JsonValue?; ident : string) : bool {
     return widget_exists(snap, ident) && (snap?["globals"]?[ident]?["rendered"] ?? true)
 }
 
+def public log_snapshot(app : ImguiApp; note : string = "") : void {
+    //! Dump the live UI state to the log (LOG_WARNING) — for every registered widget: its
+    //! ident, kind, ``rendered`` flag, bbox, and ``payload.value`` when present. The way to
+    //! see what a headless/CI run actually painted when you can't watch the window; pair it
+    //! with a failed assertion (dump on the failure path) so a red run is self-explaining.
+    var snap = snapshot(app)
+    let g = snap?["globals"]
+    if (g == null || !(g is _object)) {
+        to_log(LOG_WARNING, "log_snapshot [{note}]: snapshot has no widget registry")
+        return
+    }
+    let obj & = unsafe(g as _object)
+    to_log(LOG_WARNING, "log_snapshot [{note}]: {length(obj)} widgets")
+    for (k, v in keys(obj), values(obj)) {
+        let kind = v?["kind"] ?? "?"
+        let rend = v?["rendered"] ?? true
+        let bb = v?["bbox"]
+        let x = bb?["x"] ?? 0.0f
+        let y = bb?["y"] ?? 0.0f
+        let z = bb?["z"] ?? 0.0f
+        let wy = bb?["w"] ?? 0.0f
+        let val = v?["payload"]?["value"]
+        let vs = val == null ? "" : " value={val}"
+        to_log(LOG_WARNING, "  {k}  kind={kind} rendered={rend} bbox=({x},{y})-({z},{wy}){vs}")
+    }
+}
+
 // ===== Poll-until family =====
 
 def public wait_until_sec(app : ImguiApp;

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -477,6 +477,11 @@ def public double_click(app : ImguiApp; target : string) : JsonValue? {
     unsafe { delete events; }
     last_cursor_x = pos._0
     last_cursor_y = pos._1
+    // SYNC: let the two-tap timeline fully play (both releases must fire) before returning —
+    // a following command (imgui_click / a second imgui_mouse_play) would otherwise drive the
+    // synth mouse while this timeline is still in flight, stomping it: the double-click is lost
+    // and the next click lands in a corrupted mouse state. Mirrors every other mouse_play poster.
+    wait_for_mouse_idle(app)
     return r
 }
 


### PR DESCRIPTION
## What

A reusable **New / Open / Save** file dialog (`imgui/imgui_file_dialog`) built entirely from boost widgets (`popup_modal` + `data_table` + `selectable_label` + `input_text` + `combo` + buttons), so the whole dialog registers on the snapshot registry and is **`imgui_playwright`-drivable**.

## Why native, not a bound C++ dialog

A bound library like aiekick's **ImGuiFileDialog** renders raw Dear ImGui internally — invisible to the snapshot registry, so it can't be driven by `imgui_playwright` (the same limitation the bound addons have) — and it adds a heavy C++ dependency for a one-directory picker. This mirrors ImGuiFileDialog's UX natively instead.

## Features

- Directory navigation: clickable breadcrumb + `..`
- Sortable **Name / Size / Type** table (`data_table` + `sort_specs`), directories first; per-file extension in the Type column; human-readable Size (KB/MB/GB)
- Extension-filter dropdown
- Multi-select in open mode (Ctrl / Shift, clamped to `max_selection`)
- Filename field + overwrite-confirm in save / create mode (both the name+OK and double-click-existing-file paths route through it)
- Immediate-mode API: `file_dialog_open` / `file_dialog_draw` / `file_dialog_selection` (no stored callbacks — daslang blocks can't be stored). Navigation/confirm are deferred out of the row &amp; breadcrumb loops so a click never rebuilds the listing mid-iteration.

## Also

Adds a faithful, frame-paced `double_click` verb to `imgui_playwright` (two press/release taps that land on distinct frames, well within ImGui's `MouseDoubleClickTime`) — needed to drive enter-directory / open-file, and exercised by the test. It waits for the mouse timeline to drain before returning, so a following command can't stomp it.

## Files

- `widgets/imgui_file_dialog.das` — the component (routed in `.das_module`)
- `widgets/imgui_playwright.das` — `double_click` verb
- `examples/tutorial/file_dialog.das` — harness demo (all three modes)
- `doc/source/tutorials/file_dialog.rst` (+ index) — tutorial. The `.. video::` walkthrough is added separately.
- `tests/integration/test_file_dialog.das` — `imgui_playwright` smoke: open/cancel, save/type/confirm, folder double-click + breadcrumb nav, save-mode double-click overwrite-confirm.

## CI

The integration test runs **headless** (no GL, no window) in CI on both ubuntu and macOS, like the rest of the integration suite — it drives the dialog entirely over the live API. One sub-check (save-mode double-click on an existing file) needs a clickably-visible file row; files sort below all folders, so under a many-folder start dir it skips cleanly rather than flaking, and the `double_click` path itself is exercised CI-wide by the open-mode folder case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)