### PR TITLE
harness: disable imgui.ini for test spawns (--no-imgui-ini)

### DIFF
--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -77,6 +77,7 @@ require strings
 var private g_headless          : bool = false
 var private g_headless_max_frames : int = 0
 var private g_headless_max_uptime_sec : float = 0.0f
+var private g_no_ini            : bool = false
 var private g_parsed            : bool = false
 
 var private g_headless_ctx      : ImGuiContext? = null
@@ -91,6 +92,7 @@ def private ensure_parsed() {
     return if (g_parsed)
     g_parsed = true
     let args <- get_user_args()
+    g_no_ini = (find_bool_flag_raw_value(args, "--no-imgui-ini") |> unwrap_or("false")) == "true"
     let raw_headless = find_bool_flag_raw_value(args, "--headless")
     g_headless = (raw_headless |> unwrap_or("false")) == "true"
     let raw_frames = find_flag_raw_value(args, "--headless-frames")
@@ -108,6 +110,17 @@ def public harness_is_headless() : bool {
     return g_headless
 }
 
+def public harness_wants_no_ini() : bool {
+    //! True if ``--no-imgui-ini`` was on the command line (``with_imgui_app``
+    //! passes it for every test spawn). ``harness_init`` calls
+    //! ``DisableIniPersistence`` when set, so ImGui never loads or saves
+    //! imgui.ini. Apps that gate default-layout setup on ``fexist("imgui.ini")``
+    //! must also check this: with persistence off, ImGui restores nothing, so a
+    //! stale imgui.ini on disk is NOT a reason to skip building the default layout.
+    ensure_parsed()
+    return g_no_ini
+}
+
 def public harness_init(title : string; width : int = 800; height : int = 600) {
     //! Windowed: ``live_create_window`` + ``live_imgui_init`` (which also applies
     //! the daslang theme + JetBrains Mono font). Headless: ``CreateContext`` +
@@ -118,6 +131,9 @@ def public harness_init(title : string; width : int = 800; height : int = 600) {
         apply_daslang_theme()
         imgui_headless_init_fonts()
         imgui_headless_set_display_size(float(width), float(height))
+        if (g_no_ini) {
+            DisableIniPersistence()
+        }
         return
     }
     // Opt into per-monitor DPI on Windows so glfwCreateWindow scales the
@@ -127,6 +143,13 @@ def public harness_init(title : string; width : int = 800; height : int = 600) {
     glfwWindowHint(int(GLFW_SCALE_TO_MONITOR), 1)
     live_create_window(title, width, height)
     live_imgui_init(live_window)
+    // --no-imgui-ini (with_imgui_app passes it for every test spawn): null the
+    // ini AFTER live_imgui_init creates the context, BEFORE the first NewFrame,
+    // so a windowed GL test starts from the app's default layout and never
+    // reads/writes a stale imgui.ini in the spawn CWD.
+    if (g_no_ini) {
+        DisableIniPersistence()
+    }
 }
 
 def public harness_begin_frame() : bool {

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -1639,8 +1639,12 @@ def public with_imgui_app(feature_path : string;
     }
     argv |> push("--live-port={port}")
     argv |> push(app_path)
+    // App user-args follow `--`. Always disable imgui.ini: a test spawn must
+    // start from the feature's default layout and never read/write a stale
+    // imgui.ini in the spawn CWD (deterministic + no cross-test pollution).
+    argv |> push("--")
+    argv |> push("--no-imgui-ini")
     if (playwright_wants_headless()) {
-        argv |> push("--")
         argv |> push("--headless")
         // Cascade guard: harness self-exits a few seconds before the popen
         // watchdog gives up. If body panics and /shutdown is never sent


### PR DESCRIPTION
## What

Test spawns now disable ImGui's `imgui.ini` persistence so harness/GL tests are deterministic and never read or write a stale `imgui.ini` in the spawn CWD.

- `with_imgui_app` appends `-- --no-imgui-ini` to **every** spawn argv (moved the `--` separator out of the headless-only branch so it's always present).
- `harness_init` calls the existing `DisableIniPersistence()` (nulls `io.IniFilename`) when the flag is set — in **both** the headless and windowed paths, after context creation and **before** the first `NewFrame` (ImGui loads the ini on the first frame, so timing matters).
- New public `harness_wants_no_ini()` exposes the flag, so apps that gate default-layout setup on `fexist("imgui.ini")` can tell that, with persistence off, a stale ini on disk is meaningless and they must seed their default layout anyway.

Interactive runs (no flag) are untouched — they keep layout persistence.

## Why

A test that reads a leftover `imgui.ini` gets a non-default dock/window layout → nondeterministic results; a test that writes one pollutes the CWD and the next test. Disabling persistence per-spawn removes both failure modes.

## Verification

- **A/B mechanism:** same windowed feature (`dock_basic`) run headless past ImGui's 5s ini-save timer, clean CWD. Without the flag → `imgui.ini` is written. With `--no-imgui-ini` → no `imgui.ini`. Confirms the flag reaches `harness_init` and nulls `IniFilename` (same null disables both load and save).
- **Regression:** `test_io_mirror`, `test_app_dockspace`, `test_app_small_layout` pass end-to-end through the new argv (the dockspace/layout ones confirm the default layout still builds without an ini).

🤖 Generated with [Claude Code](https://claude.com/claude-code)