### PR TITLE
harness: add wait_cond — bare wall-clock condition poll

### DIFF
--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -154,7 +154,7 @@ def document_module_imgui_playwright() {
         group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_unchanged|record_check_rendered|record_check_kind_count|record_check)$%%),
         group_by_regex("Content-time gating", mod, %regex~^(wait_content_frames|hold_content|record_frame_count|hold_remainder_content)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|log_snapshot|expect_value|expect_render).*%%),
-        group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|await_quiescent|await_probe|set_auto_dump_on_timeout|auto_dump_on_timeout_enabled)$%%),
+        group_by_regex("Polling / await",   mod, %regex~^(wait_until.*|wait_for_.*|wait_cond|await_quiescent|await_probe|set_auto_dump_on_timeout|auto_dump_on_timeout_enabled)$%%),
         group_by_regex("Pause control",     mod, %regex~^(pause|unpause|with_paused)$%%),
         group_by_regex("Transport plumbing", mod, %regex~^(post_command|send_imgui_command|receive_imgui_command).*%%),
         hide_group(group_by_regex("Internal", mod, %regex~^(_|priv_|dasimgui_module_root).*%%))

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -344,6 +344,25 @@ def public wait_until_sec(app : ImguiApp;
     return null
 }
 
+def public wait_cond(app : ImguiApp;
+                     timeout_sec : float;
+                     pred : block<() : bool>) : bool {
+    //! Bare wall-clock condition poll — no snapshot, no widget coupling. Polls ``pred()`` until it
+    //! returns true, up to ``timeout_sec`` real seconds; returns true on match, false on timeout.
+    //! The ``cmd_*`` sibling of ``wait_until_sec``: for state gated on a command round-trip (sim
+    //! tick, camera mode, scene count) rather than a widget snapshot field. Replaces the hand-rolled
+    //! ``for (_ in range(N)) { if (cond) break }`` busy-poll, which bounds by frame count with no
+    //! sleep and so expires prematurely against the multi-kHz headless server (see ``wait_until``).
+    let start = ref_time_ticks()
+    let timeout_usec = int(timeout_sec * 1000000.0f)
+    while (get_time_usec(start) < timeout_usec) {
+        if (invoke(pred)) return true
+        sleep(FRAME_POLL_INTERVAL_MS)
+    }
+    dump_on_timeout(app, "wait_cond ({timeout_sec}s)")
+    return false
+}
+
 def public wait_until(app : ImguiApp;
                       max_frames : int;
                       pred : block<(var snap : JsonValue?) : bool>) : JsonValue? {


### PR DESCRIPTION
## What

Adds `wait_cond(app, timeout_sec, block<() : bool>) : bool` to the imgui_playwright harness — a bare wall-clock condition poll with no snapshot or widget coupling. Polls `pred()` until it returns true or the timeout elapses.

It's the `cmd_*` sibling of `wait_until_sec`: for test state gated on a command round-trip (a sim tick, a camera mode, a scene count) rather than a widget snapshot field.

## Why

The idiomatic deterministic wait for snapshot fields is already `wait_until_sec` / `wait_for_*`, but command-gated state had no equivalent — tests hand-rolled:

```
var ok = false
for (_ in range(N)) { if (cond) { ok = true; break } }
```

That bounds by **frame count with no sleep**, so under headless (where the server advances frames at multi-kHz with no vsync) `N` iterations is an unpredictable, often-too-short real-time window — the condition simply hasn't flipped yet. This is the same premature-expiry footgun `wait_until`'s docstring already calls out. `wait_cond` bounds by real seconds and polls with `FRAME_POLL_INTERVAL_MS` between tries, reusing the existing `dump_on_timeout` path.

Purely additive — no existing call sites change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)