### PR TITLE
harness: add imgui_raise — select a docked window's tab from automation

### DIFF
--- a/doc/source/tutorials/docking.rst
+++ b/doc/source/tutorials/docking.rst
@@ -158,7 +158,7 @@ through the reload, and the dock state lives inside that context).
 Driving from outside
 ====================
 
-Four live commands cover the docking surface. Targets are path-qualified
+Several live commands cover the docking surface. Targets are path-qualified
 — the dockspace pushes its name onto the path, so panel targets are
 ``DOCK_ROOT/<name>``:
 
@@ -182,12 +182,20 @@ Four live commands cover the docking surface. Targets are path-qualified
    curl -X POST -d '{"name":"imgui_close","args":{"target":"DOCK_ROOT/OUTPUT"}}' \
         localhost:9090/command
 
+   # Raise a panel to the front of its dock node — selects its tab when stacked
+   curl -X POST -d '{"name":"imgui_raise","args":{"target":"DOCK_ROOT/OUTPUT"}}' \
+        localhost:9090/command
+
 ``imgui_dock`` is the inverse of ``imgui_undock`` — it takes a ``value`` of
 type ``uint`` (a dock-node id from a prior ``DockBuilder*`` call) and
 re-docks the panel into that node. ``imgui_set_window_pos`` is the
 companion you'll usually pair with ``imgui_undock``, since a freshly
 undocked window picks its position from ``imgui.ini`` (or ``(0,0)`` if
-the window has never floated).
+the window has never floated). ``imgui_raise`` brings a panel to the front
+of its dock node — when several panels share a node (so they render as a tab
+strip) it selects that panel's tab; it's the automation counterpart of
+clicking a tab, which a real click can't reach (the dock node's tab bar is
+ImGui-internal, not a registered widget).
 
 Next steps
 ==========

--- a/examples/features/dock_basic.das
+++ b/examples/features/dock_basic.das
@@ -56,7 +56,8 @@ def setup_default_layout(dock_id : uint) {
     DockBuilderSplitNode(bottom_id, ImGuiDir.Left, 0.55f, bl_id, br_id)
     DockBuilderDockWindow("Explorer",   left_id)
     DockBuilderDockWindow("Source",     top_id)
-    DockBuilderDockWindow("Output",     bl_id)
+    DockBuilderDockWindow("Console",    bl_id)   // Console + Output share bl_id -> they tab; Output docked
+    DockBuilderDockWindow("Output",     bl_id)   // last => Output is the front tab initially
     DockBuilderDockWindow("Properties", br_id)
     DockBuilderFinish(dock_id)
 }
@@ -98,6 +99,13 @@ def update() {
                              flags = ImGuiWindowFlags.None)) {
             text("> ready.")
             button(CLEAR_BTN, (text = "Clear"))
+        }
+        // Console shares Output's dock node, so the two render as a tab pair —
+        // background-tab children don't render until selected (imgui_raise / a tab click).
+        dock_window(CONSOLE, (text = "Console", closable = false,
+                              flags = ImGuiWindowFlags.None)) {
+            text("log tail")
+            button(CONSOLE_BTN, (text = "Scroll to end"))
         }
         dock_window(PROPERTIES, (text = "Properties", closable = false,
                                  flags = ImGuiWindowFlags.None)) {

--- a/tests/integration/test_docking_basic.das
+++ b/tests/integration/test_docking_basic.das
@@ -17,7 +17,9 @@ require daslib/json_boost public
 //!   3. Live commands — `imgui_undock` (window becomes floating),
 //!      `imgui_dock` (window re-docks to a target node), `imgui_dock_reset`
 //!      (state.has_initial_layout flips false → setup re-runs),
-//!      `imgui_close` on a closable dock_window flips `state.open` false.
+//!      `imgui_close` on a closable dock_window flips `state.open` false,
+//!      `imgui_raise` selects a window's tab when it's stacked (Console + Output
+//!      share one node; raising flips which one's children render).
 //!
 //! One host spawn, six subtests; `reset(d)` re-simulates the compiled program
 //! into a fresh context between subtests (no recompile) so each starts from a
@@ -173,6 +175,36 @@ def test_docking_basic(t : T?) {
             post_command(d, "imgui_dock_reset", JV((target = "DOCK_ROOT")))
             let re_docked = wait_for_payload_value(d, "DOCK_ROOT/EXPLORER", "docked", true, 300)
             t |> success(re_docked, "EXPLORER re-docks after imgui_dock_reset round-trip")
+        }
+        reset(d)
+
+        t |> run("raise") <| @(t : T?) {
+            // Console + Output share one dock node (a tab pair). A backgrounded tab's children aren't
+            // painted (registered-but-`rendered:false`), so selecting a tab is observable as its child
+            // starting to paint and the other's stopping. There's no command to click a dock node's
+            // internal tab bar, so imgui_raise is the automation rail for it. Verified both directions.
+            var snap = wait_for_widget(d, "DOCK_ROOT/CONSOLE", 15.0f)
+            if (snap == null) {
+                t |> success(false, "snapshot reachable")
+                return
+            }
+            // Output is the front tab initially (docked last); Console is backgrounded.
+            t |> success(wait_for_visible(d, "DOCK_ROOT/OUTPUT/CLEAR_BTN", 5.0f) != null,
+                         "OUTPUT starts as the front tab — CLEAR_BTN paints")
+            t |> success(!widget_rendered(snapshot(d), "DOCK_ROOT/CONSOLE/CONSOLE_BTN"),
+                         "CONSOLE starts backgrounded — its child does not paint")
+
+            // Raise Console -> it becomes the front tab; its child paints, Output's stops.
+            post_command(d, "imgui_raise", JV((target = "DOCK_ROOT/CONSOLE")))
+            t |> success(wait_for_visible(d, "DOCK_ROOT/CONSOLE/CONSOLE_BTN", 5.0f) != null,
+                         "imgui_raise CONSOLE selected its tab — CONSOLE_BTN paints")
+            t |> success(wait_cond(d, 5.0f) $() => !widget_rendered(snapshot(d), "DOCK_ROOT/OUTPUT/CLEAR_BTN"),
+                         "...and OUTPUT is backgrounded — its child stops painting")
+
+            // Raise Output back -> the tab switches the other way.
+            post_command(d, "imgui_raise", JV((target = "DOCK_ROOT/OUTPUT")))
+            t |> success(wait_for_visible(d, "DOCK_ROOT/OUTPUT/CLEAR_BTN", 5.0f) != null,
+                         "imgui_raise OUTPUT switched the tab back — CLEAR_BTN paints again")
         }
     }
 }

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -45,7 +45,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Per-frame registry",      mod, %regex~^(WidgetEntry|WidgetMeta|begin_frame|end_frame|end_of_frame|register_widget|register_focusable|register_radio_site_alias|register_handle_bbox|register_end_of_frame_hook|register_post_command_hook|lookup_widget|lookup_state_addr|clear_module_widgets|widget_registered|widget_prelude|widget_rect|with_state|id_to_path|id_to_bbox).*%%),
         group_by_regex("Path machinery",          mod, %regex~^(container_path_push|container_path_pop|widget_path_key|container_path_key|active_widget_path)$%%),
         group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
-        group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|set_window_pos|set_window_size)$%%),
+        group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|raise|set_window_pos|set_window_size)$%%),
         group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|force_set|open|close|focus|await|mouse_pos|mouse_click|mouse_scroll|key_press|key_release|key_char)$%%),
         group_by_regex("Synthetic input",         mod, %regex~^(synth_mouse_move|synth_mouse_button|synth_mouse_wheel|synth_key_press|synth_key_release|synth_char|release_held_buttons|release_held_keys|get_synth_cursor|get_synth_keys|imgui_synth_tick|user_control_enabled|set_user_control_enabled|set_user_control|register_real_input_toggle|register_synth_frame_hook|register_synth_stop_hook)$%%),
         group_by_regex("Debug logging",           mod, %regex~^(log_section|log_section_on|imgui_log_section|imgui_log_drain)$%%),

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -2214,6 +2214,14 @@ def imgui_undock(input : JsonValue?) : JsonValue? {
     return with_await(input, r)
 }
 
+[live_command(description = "Raise a dock_window to the front of its dock node — selects its tab when it's stacked with others ('target' name)")]
+def imgui_raise(input : JsonValue?) : JsonValue? {
+    //! Live-command: bring the dock_window named by ``input["target"]`` to the front of its dock node — when several windows are docked into one node (so they render as a tab strip), this selects that window's tab. Routes through SetNextWindowFocus() on the next frame. The automation counterpart of clicking a tab; ``imgui_click`` can't reach a dock node's internal tab bar.
+    let r = dispatch_or_err("raise", input)
+    if (r._is_ok) dispatch_post_command_hooks("raise", r._value)
+    return with_await(input, r)
+}
+
 [live_command(description = "Clear a dockspace's DockBuilder layout so the user's setup runs again ('target' = dockspace name)")]
 def imgui_dock_reset(input : JsonValue?) : JsonValue? {
     //! Live-command: reset the dockspace named by ``input["target"]`` — clears the DockBuilder node tree and flips ``state.has_initial_layout`` back to false so the user's setup function re-runs on the next frame.

--- a/widgets/imgui_docking_builtin.das
+++ b/widgets/imgui_docking_builtin.das
@@ -53,6 +53,7 @@ struct DockWindowState {
     @optional pending_close : bool            //! imgui_close queued; applied next frame
     @optional pending_dock_to : uint = 0u     //! imgui_dock queued; SetNextWindowDockID(value) next frame
     @optional pending_undock : bool           //! imgui_undock queued; SetNextWindowDockID(0) next frame
+    @optional pending_raise : bool            //! imgui_raise queued; SetNextWindowFocus() next frame (selects the tab when docked)
     @optional pending_pos : float2            //! imgui_set_window_pos queued — pos
     @optional pending_pos_set : bool          //! gates pending_pos (so (0,0) is a valid request)
     @optional pending_size : float2           //! imgui_set_window_pos queued — size
@@ -78,7 +79,7 @@ def private dockspace_finalize(widget_ident : string; kind : string;
 }
 
 def private dock_window_finalize(widget_ident : string; var state : DockWindowState) {
-    //! dock_window finalize. State path; the per-kind [widget_dispatch] handles open/close/dock/undock/set_window_pos.
+    //! dock_window finalize. State path; the per-kind [widget_dispatch] handles open/close/dock/undock/raise/set_window_pos.
     var entry : WidgetEntry
     unsafe {
         container_finalize(widget_ident, "dock_window", entry,
@@ -109,6 +110,8 @@ def _dock_window_dispatch(var state : DockWindowState; action : string; payload 
         }
     } elif (action == "undock") {
         state.pending_undock = true
+    } elif (action == "raise") {
+        state.pending_raise = true
     } elif (action == "set_window_pos") {
         // Payload: ``{x, y[, w, h]}`` — pos always set, size optional. The one
         // place we still touch JsonValue at dispatch time; alternative would
@@ -191,6 +194,10 @@ def dock_window(var state : DockWindowState; text : string; closable : bool;
     if (state.pending_undock) {
         SetNextWindowDockID(0u, ImGuiCond.Always)
         state.pending_undock = false
+    }
+    if (state.pending_raise) {
+        SetNextWindowFocus()       // raises the tab to the front when this window is docked in a stack
+        state.pending_raise = false
     }
     if (state.pending_pos_set) {
         SetNextWindowPos(ImVec2(state.pending_pos.x, state.pending_pos.y), ImGuiCond.Always)


### PR DESCRIPTION
## Why

When several windows are docked into one node they render as a tab strip — but that tab bar is **ImGui-internal**, not a registered widget, so `imgui_click` can't reach it. There was no way for automation (or an in-app navigate-to action) to bring a backgrounded docked window to the front. This is the automation counterpart of clicking a tab.

## What

- **`imgui_raise {target:&lt;window&gt;}`** — new live command. Adds `DockWindowState.pending_raise` (mirrors `pending_dock_to`), consumed in the `dock_window` prelude via `SetNextWindowFocus()`, routed through the existing `_dock_window_dispatch` + a `live_command`. Additive; no behavior change to existing commands.
- **`dock_basic` example** gains a `Console` window stacked with `Output` (a tab pair) to demonstrate stacking + raising. `Console` is docked *before* `Output` so `Output` stays the front tab — the existing layout subtest is unaffected.
- **`test_docking_basic`** gains a `raise` subtest: verifies tab selection in **both** directions via paint-visibility (`wait_for_visible` / `widget_rendered` / `wait_cond`) — a backgrounded tab's children are registered-but-`rendered:false`, so selecting a tab is observable as its child starting to paint and the other's stopping.
- **Docking tutorial** documents the command.

## Test

`test_docking_basic` — 8/8 subtests green (registration / initial_layout / undock / close / set_window_pos / dock_reset / **raise**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)