### PR TITLE
imgui: default cursor + tab-select introspection + ESC-cancels-dialog

### DIFF
--- a/src/module_imgui_app.cpp
+++ b/src/module_imgui_app.cpp
@@ -74,6 +74,18 @@ DAS_MOD_API void das_imgui_set_real_input_callbacks ( bool enabled ) {
     else ImGui_ImplGlfw_RestoreCallbacks(w);
 }
 
+// Set a defined Arrow cursor on the window at init, before the first frame. The GLFW
+// backend's per-frame UpdateMouseCursor only kicks in from frame 1, and on macOS Cocoa
+// only refreshes the cursor on movement — so without this the window shows whatever
+// shape was inherited at creation until the mouse moves. One standard cursor, created
+// once; GLFW frees it at glfwTerminate.
+DAS_MOD_API void das_imgui_set_default_cursor ( GLFWwindow * window ) {
+    if ( !window ) return;
+    static GLFWcursor * arrow = nullptr;
+    if ( !arrow ) arrow = glfwCreateStandardCursor(GLFW_ARROW_CURSOR);
+    if ( arrow ) glfwSetCursor(window, arrow);
+}
+
 // making custom builtin module
 class Module_imgui_app : public Module {
     ModuleLibrary lib;
@@ -116,6 +128,9 @@ public:
         // imgui_live_core to suppress real input AT THE SOURCE when user control is off.
         addExtern<DAS_BIND_FUN(das_imgui_set_real_input_callbacks)>(*this,lib,"imgui_set_real_input_callbacks",
             SideEffects::worstDefault, "das_imgui_set_real_input_callbacks");
+        // Default Arrow cursor at init (covers the pre-first-frame / macOS no-move-refresh gap).
+        addExtern<DAS_BIND_FUN(das_imgui_set_default_cursor)>(*this,lib,"imgui_set_default_cursor",
+            SideEffects::worstDefault, "das_imgui_set_default_cursor");
         addExtern<DAS_BIND_FUN(ImGui_ImplGlfw_MouseButtonCallback)>(*this,lib,"ImGui_ImplGlfw_MouseButtonCallback",
             SideEffects::worstDefault, "ImGui_ImplGlfw_MouseButtonCallback");
         addExtern<DAS_BIND_FUN(ImGui_ImplGlfw_ScrollCallback)>(*this,lib,"ImGui_ImplGlfw_ScrollCallback",
@@ -168,6 +183,7 @@ public:
         tw << "DAS_MOD_API void das_imgui_synth_key ( int key, bool down );\n";
         tw << "DAS_MOD_API void das_imgui_synth_input_char ( uint32_t cp );\n";
         tw << "DAS_MOD_API void das_imgui_set_real_input_callbacks ( bool enabled );\n";
+        tw << "DAS_MOD_API void das_imgui_set_default_cursor ( GLFWwindow * window );\n";
         return ModuleAotType::cpp;
     }
 };

--- a/tests/integration/test_file_dialog_esc.das
+++ b/tests/integration/test_file_dialog_esc.das
@@ -5,6 +5,7 @@ options no_unused_function_arguments = false
 
 require dastest/testing_boost public
 require imgui/imgui_playwright public
+require imgui
 require daslib/json public
 require daslib/json_boost public
 require strings
@@ -15,7 +16,6 @@ require strings
 //! key over the live API), like the rest of the file_dialog suite.
 
 let FILE_DIALOG_FEATURE = "modules/dasImgui/examples/tutorial/file_dialog.das"
-let KEY_ESCAPE : int = 526   // ImGuiKey.Escape (Tab=512, Enter=525, Escape=526)
 
 [test]
 def test_file_dialog_esc(t : T?) {
@@ -31,7 +31,7 @@ def test_file_dialog_esc(t : T?) {
                      "open dialog renders the file table")
 
         // ESC cancels — no name/path field is focused on open, so the modal must close itself.
-        key_tap(d, KEY_ESCAPE)
+        key_tap(d, int(ImGuiKey.Escape))
         t |> success(wait_until_sec(d, 5.0f) $(var s) {
                 return find(widget_payload_field(s, "FDLG_WIN/RESULT", "value") ?? "", "cancelled") >= 0
             } != null,

--- a/tests/integration/test_file_dialog_esc.das
+++ b/tests/integration/test_file_dialog_esc.das
@@ -1,0 +1,44 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+require strings
+
+//! Integration smoke: ESC cancels the file dialog. Opens the dialog (no field focused),
+//! presses Escape, and asserts the demo's RESULT echoes "cancelled" — the keyboard
+//! equivalent of the Cancel button — and that the dialog closes. Headless-safe (synthetic
+//! key over the live API), like the rest of the file_dialog suite.
+
+let FILE_DIALOG_FEATURE = "modules/dasImgui/examples/tutorial/file_dialog.das"
+let KEY_ESCAPE : int = 526   // ImGuiKey.Escape (Tab=512, Enter=525, Escape=526)
+
+[test]
+def test_file_dialog_esc(t : T?) {
+    with_imgui_app(FILE_DIALOG_FEATURE) $(d) {
+        var snap = wait_for_widget(d, "FDLG_WIN/BTN_OPEN", 15.0f)
+        t |> success(snap != null, "demo window + Open trigger render")
+        if (snap == null) {
+            return
+        }
+
+        click(d, "FDLG_WIN/BTN_OPEN")
+        t |> success(wait_for_widget(d, "FILEDLG/FILE_TABLE", 10.0f) != null,
+                     "open dialog renders the file table")
+
+        // ESC cancels — no name/path field is focused on open, so the modal must close itself.
+        key_tap(d, KEY_ESCAPE)
+        t |> success(wait_until_sec(d, 5.0f) $(var s) {
+                return find(widget_payload_field(s, "FDLG_WIN/RESULT", "value") ?? "", "cancelled") >= 0
+            } != null,
+            "ESC returns the cancelled result")
+        t |> success(wait_until_sec(d, 5.0f) $(var s) {
+                return !widget_rendered(s, "FILEDLG/FILE_TABLE")
+            } != null,
+            "ESC closes the dialog (table stops rendering)")
+    }
+}

--- a/tests/integration/test_tab_select.das
+++ b/tests/integration/test_tab_select.das
@@ -1,0 +1,53 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for `imgui_select` + tab-select introspection (`TabItemState.selected`).
+//! The containers_layout fixture has a tab_bar (MAIN_TABS) with SETTINGS / AUDIO / ABOUT tabs;
+//! SETTINGS is active by default (its PHYSICS_TREE child renders). `imgui_select(AUDIO_TAB)`
+//! activates Audio — AUDIO_TAB.selected flips true, SETTINGS_TAB.selected false, and the
+//! settings-tab child stops rendering. `selected` is snapshot-visible (the TabItemState struct
+//! is reflected into the widget payload). Headless-safe (drives the dialog over the live API).
+
+let FEATURE = "modules/dasImgui/examples/features/containers_layout.das"
+
+def private is_selected(var snap : JsonValue?; tab : string) : bool {
+    return widget_payload_field(snap, tab, "selected") ?? false
+}
+
+[test]
+def test_tab_select_smoke(t : T?) {
+    with_imgui_app(FEATURE) $(d) {
+        var snap = wait_for_render(d, "LAYOUT_WIN/MAIN_TABS/SETTINGS_TAB/PHYSICS_TREE/GRAVITY", 15.0f)
+        t |> success(snap != null, "settings-tab child renders initially (SETTINGS active)")
+        if (snap == null) {
+            return
+        }
+
+        // `selected` is exposed in the snapshot payload (TabItemState reflected).
+        t |> success(is_selected(snap, "LAYOUT_WIN/MAIN_TABS/SETTINGS_TAB"),
+                     "SETTINGS_TAB.selected == true initially")
+        t |> success(!is_selected(snap, "LAYOUT_WIN/MAIN_TABS/AUDIO_TAB"),
+                     "AUDIO_TAB.selected == false initially")
+
+        // Activate the Audio tab from automation.
+        select_widget(d, "LAYOUT_WIN/MAIN_TABS/AUDIO_TAB")
+        let became = wait_until_sec(d, 5.0f) $(var s) {
+            return is_selected(s, "LAYOUT_WIN/MAIN_TABS/AUDIO_TAB")
+        }
+        t |> success(became != null, "AUDIO_TAB.selected == true after imgui_select")
+
+        // The previously-active tab deselects and its child stops rendering.
+        var s2 = snapshot(d)
+        t |> success(!is_selected(s2, "LAYOUT_WIN/MAIN_TABS/SETTINGS_TAB"),
+                     "SETTINGS_TAB.selected == false after select")
+        t |> success(!widget_rendered(s2, "LAYOUT_WIN/MAIN_TABS/SETTINGS_TAB/PHYSICS_TREE/GRAVITY"),
+                     "settings-tab child stops rendering once Audio is active")
+    }
+}

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -46,7 +46,7 @@ def document_module_imgui_boost_runtime() {
         group_by_regex("Path machinery",          mod, %regex~^(container_path_push|container_path_pop|widget_path_key|container_path_key|active_widget_path)$%%),
         group_by_regex("Coroutines",              mod, %regex~^(advance_coroutines|spawn_coroutine)$%%),
         group_by_regex("Window control",          mod, %regex~^imgui_(dock|undock|dock_reset|raise|set_window_pos|set_window_size)$%%),
-        group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|force_set|open|close|focus|await|mouse_pos|mouse_click|mouse_scroll|key_press|key_release|key_char)$%%),
+        group_by_regex("Live commands",           mod, %regex~^imgui_(snapshot|click|force_set|open|close|select|focus|await|mouse_pos|mouse_click|mouse_scroll|key_press|key_release|key_char)$%%),
         group_by_regex("Synthetic input",         mod, %regex~^(synth_mouse_move|synth_mouse_button|synth_mouse_wheel|synth_key_press|synth_key_release|synth_char|release_held_buttons|release_held_keys|get_synth_cursor|get_synth_keys|imgui_synth_tick|user_control_enabled|set_user_control_enabled|set_user_control|register_real_input_toggle|register_synth_frame_hook|register_synth_stop_hook)$%%),
         group_by_regex("Debug logging",           mod, %regex~^(log_section|log_section_on|imgui_log_section|imgui_log_drain)$%%),
         group_by_regex("Memory debugging",         mod, %regex~^(imgui_debug_memory|imgui_reset_memory_baseline|imgui_memory_report)$%%),

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -150,7 +150,7 @@ def document_module_imgui_playwright() {
     var groups <- array<DocGroup>(
         group_by_regex("App lifecycle",     mod, %regex~^(with_imgui_app|launch_imgui_app|shutdown|with_recording_app).*%%),
         group_by_regex("Locators / queries", mod, %regex~^(find_widget|widget_exists|widget_payload_field|widget_rendered|widget_click_point|widget_component_point|get_text)$%%),
-        group_by_regex("Actions",           mod, %regex~^(click|double_click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
+        group_by_regex("Actions",           mod, %regex~^(click|double_click|click_at|right_click|type_text|key_tap|force_set_value|force_set_verified|drag|drag_along|drag_to|focus|open_widget|close_widget|select_widget|reload|reset|move_to|reset_cursor_pos|resize_window)$%%),
         group_by_regex("Recording / narration", mod, %regex~^(say|say_begin|say_hash|hold_through_voice|drag_through_voice|type_into_voice|combo_pick_voice|toggle_tree_voice|close_button_voice|click_render_voice|menu_pick_voice|record_check_value|record_check_changed|record_check_unchanged|record_check_rendered|record_check_kind_count|record_check)$%%),
         group_by_regex("Content-time gating", mod, %regex~^(wait_content_frames|hold_content|record_frame_count|hold_remainder_content)$%%),
         group_by_regex("Snapshots",         mod, %regex~^(snapshot|log_snapshot|expect_value|expect_render).*%%),

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -513,6 +513,8 @@ struct TabItemState {
     @optional flags : ImGuiTabItemFlags       //! per-call ImGuiTabItemFlags
     @optional pending_open : bool             //! imgui_open queued; applied next frame
     @optional pending_close : bool            //! imgui_close queued; applied next frame
+    @optional pending_select : bool           //! imgui_select queued; applied next frame (SetSelected)
+    @optional selected : bool                 //! observed: is this the active tab this frame (snapshot-visible)
 }
 
 struct TooltipState {
@@ -2187,6 +2189,17 @@ def imgui_close(input : JsonValue?) : JsonValue? {
     //! Live-command: close the container named by ``input["target"]`` (window/popup/tree_node/collapsing_header/tab_item).
     let r = dispatch_or_err("close", input)
     if (r._is_ok) dispatch_post_command_hooks("close", r._value)
+    return with_await(input, r)
+}
+
+[live_command(description = "Select (activate) a tab_item in a tab_bar ('target' name)")]
+def imgui_select(input : JsonValue?) : JsonValue? {
+    //! Live-command: activate the ``tab_item`` named by ``input["target"]`` — the automation
+    //! counterpart of clicking a tab in a ``tab_bar`` (ImGui owns active-tab selection, so an
+    //! inactive tab can't be reached by ``imgui_click``). Routes through ImGuiTabItemFlags.SetSelected
+    //! on the next frame. The selected tab records ``state.selected = true`` for snapshot consumers.
+    let r = dispatch_or_err("select", input)
+    if (r._is_ok) dispatch_post_command_hooks("select", r._value)
     return with_await(input, r)
 }
 

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -502,6 +502,12 @@ def tab_item(var state : TabItemState; text : string; closable : bool;
         state.open = false
         state.pending_close = false
     }
+    // imgui_select queues activation: pass SetSelected for one frame, then clear.
+    var eff_flags = flags
+    if (state.pending_select) {
+        eff_flags |= ImGuiTabItemFlags.SetSelected
+        state.pending_select = false
+    }
     state.flags = flags
     if (!closable || state.open) {
         var p_open : bool? = null
@@ -510,7 +516,8 @@ def tab_item(var state : TabItemState; text : string; closable : bool;
                 p_open = addr(state.open)
             }
         }
-        let im_open = BeginTabItem(text, p_open, flags)
+        let im_open = BeginTabItem(text, p_open, eff_flags)
+        state.selected = im_open   // observable active-tab state (snapshot-visible)
         //! Same rationale as ``menu()``: the tab strip header is the
         //! ``IsItem*`` target right after BeginTabItem. Inside the body
         //! ``last item`` shifts to per-widget items and EndTabItem pops it.
@@ -806,6 +813,8 @@ def _tab_item_dispatch(var state : TabItemState; action : string; payload : stri
         state.pending_open = true
     } elif (action == "close") {
         state.pending_close = true
+    } elif (action == "select") {
+        state.pending_select = true
     }
 }
 

--- a/widgets/imgui_file_dialog.das
+++ b/widgets/imgui_file_dialog.das
@@ -660,7 +660,13 @@ def public file_dialog_draw() : FileDialogResult {
         // Backspace goes up a directory when no text field is being edited ---
         let sub_open = OVERWRITE.open || NEWDIR.open
         if (!sub_open) {
-            if (IsKeyPressed(ImGuiKey.Enter, false) || IsKeyPressed(ImGuiKey.KeypadEnter, false)) {
+            if (IsKeyPressed(ImGuiKey.Escape, false)) {
+                // ESC cancels the dialog (explicit — a focused name/path field would otherwise
+                // eat the keystroke and the modal wouldn't auto-close). Mirrors the Cancel button.
+                FILEDLG.pending_close = true
+                g_fd.open = false
+                result = FileDialogResult.cancelled
+            } elif (IsKeyPressed(ImGuiKey.Enter, false) || IsKeyPressed(ImGuiKey.KeypadEnter, false)) {
                 if (was_path_focused) {
                     let p = normalize(PATH_FIELD.value)
                     if (stat(p).is_dir) {

--- a/widgets/imgui_live.das
+++ b/widgets/imgui_live.das
@@ -113,6 +113,11 @@ def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#versi
     io.FontGlobalScale = font_global
     ImGui_ImplGlfw_InitForOpenGL(window, true)
     ImGui_ImplOpenGL3_Init(glsl_version)
+    // Give the window a defined cursor from the instant it appears — the backend's
+    // per-frame UpdateMouseCursor only takes over from frame 1, and macOS won't
+    // refresh an inherited cursor until the mouse moves. Per-widget SetMouseCursor
+    // and the backend's resize/hand cursors still apply from the first frame on.
+    imgui_set_default_cursor(window)
     return live_imgui_ctx
 }
 

--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -610,6 +610,12 @@ def public close_widget(app : ImguiApp; target : string) : JsonValue? {
     return send_imgui_command(app.transport, "imgui_close", JV((target = target)))
 }
 
+def public select_widget(app : ImguiApp; target : string) : JsonValue? {
+    //! Activate ``target`` tab_item (``imgui_select`` verb) — the automation counterpart of clicking a tab
+    //! (ImGui owns active-tab selection, so an inactive tab can't be reached by ``click``).
+    return send_imgui_command(app.transport, "imgui_select", JV((target = target)))
+}
+
 def public drag(app : ImguiApp; target : string;
                 dx : float; dy : float;
                 steps : int = 4; button : int = 0) : JsonValue? {


### PR DESCRIPTION
Three small UI fixes, each with a headless integration test where one is automatable.

### 1. Default Arrow cursor at window init
The GLFW backend's per-frame `UpdateMouseCursor` only runs from frame 1, and on macOS Cocoa only refreshes the cursor on mouse movement — so a freshly created window shows whatever shape it inherited until the pointer moves. `das_imgui_set_default_cursor` sets one shared Arrow cursor (created once, freed at `glfwTerminate`) on the window; the live harness calls it from `live_imgui_init` right after backend init. *(No automated test — window-init / platform-visual; verified manually.)*

### 2. Tab-select introspection + `imgui_select` live command
`TabItemState` gains `selected` (observed active-tab state, snapshot-visible) and `pending_select` (queued activation). The `imgui_select` live command activates a `tab_item` by name — the automation counterpart of clicking a tab, since ImGui owns active-tab selection and an inactive tab can't be reached via `imgui_click`. The playwright layer gains `select_widget(app, target)`. Covered by `tests/integration/test_tab_select.das`.

### 3. ESC cancels the file dialog
A focused name/path field eats the keystroke, so the modal didn't auto-close on Escape. An explicit `IsKeyPressed(Escape)` handler mirrors the Cancel button. Covered by `tests/integration/test_file_dialog_esc.das`.

### Verification
- `cmake --build _build` (the C++ cursor change relinks `imguiApp.shared_module`).
- Full headless integration suite green: **176/176 passed** (`dastest ... --test modules/dasImgui/tests/integration --headless`), including the two new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)