### PR TITLE
wrap_tab_bar: a multi-row, wrapping tab bar container

### DIFF
--- a/examples/tutorial/wrap_tab_bar.das
+++ b/examples/tutorial/wrap_tab_bar.das
@@ -1,20 +1,6 @@
 options gen2
 
-require daslib/safe_addr
-require imgui
-require imgui_app
-require opengl/opengl_boost
-require live/glfw_live
-require live/live_api
-require live/live_commands
-require live/live_vars
-require live_host
-require imgui/imgui_live
-require imgui/imgui_boost_runtime
-require imgui/imgui_boost_v2
-require imgui/imgui_widgets_builtin
-require imgui/imgui_containers_builtin
-require imgui/imgui_visual_aids
+require imgui/imgui_harness
 
 // =============================================================================
 // TUTORIAL: wrap_tab_bar / wrap_tab_item — a multi-row, WRAPPING tab bar.
@@ -45,76 +31,57 @@ require imgui/imgui_visual_aids
 
 [export]
 def init() {
-    live_create_window("dasImgui wrap_tab_bar tutorial", 520, 560)
-    live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    io.FontGlobalScale = 1.4
+    harness_init("wrap_tab_bar tutorial", 380, 520)
 }
 
 [export]
 def update() {
-    if (!live_begin_frame()) return
-    begin_frame()
+    if (!harness_begin_frame()) {
+        return
+    }
+    harness_new_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
-    ImGui_ImplGlfw_NewFrame()
-    apply_synth_io_override()
-    NewFrame()
-
-    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
     // deliberately narrow so the eight headers wrap onto multiple rows
-    SetNextWindowSize(ImVec2(360.0f, 500.0f), ImGuiCond.Always)
-    window(WTB_WIN, (text = "wrap_tab_bar tutorial", closable = false,
-                     flags = ImGuiWindowFlags.None)) {
-
-        text("Eight categories in a narrow panel — the native TabBar would")
-        text("ellipsize or scroll; wrap_tab_bar flows them onto rows.")
+    SetNextWindowSize(ImVec2(340.0f, 480.0f), ImGuiCond.FirstUseEver)
+    window(WTB_WIN, (text = "wrap_tab_bar tutorial", closable = false, flags = ImGuiWindowFlags.None)) {
+        text(WTB_LEAD, (text = "Eight categories in a narrow panel - the native"))
+        text(WTB_LEAD2, (text = "TabBar would ellipsize/scroll; wrap_tab_bar flows them."))
         separator()
 
         wrap_tab_bar(WTB_BAR) {
             wrap_tab_item("physics") {
-                text(WTB_B0, (text = "physics — gravity, restitution, drag"))
+                text(WTB_B0, (text = "physics - gravity, restitution, drag"))
             }
             wrap_tab_item("camera") {
-                text(WTB_B1, (text = "camera — zoom, follow, lookahead"))
+                text(WTB_B1, (text = "camera - zoom, follow, lookahead"))
             }
             wrap_tab_item("lava") {
-                text(WTB_B2, (text = "lava — speed, scale, warp, crust"))
+                text(WTB_B2, (text = "lava - speed, scale, warp, crust"))
             }
             wrap_tab_item("cinders") {
-                text(WTB_B3, (text = "cinders — brightness, density, rise"))
+                text(WTB_B3, (text = "cinders - brightness, density, rise"))
             }
             wrap_tab_item("audio") {
-                text(WTB_B4, (text = "audio — master gain, music, sfx"))
+                text(WTB_B4, (text = "audio - master gain, music, sfx"))
             }
             wrap_tab_item("lighting") {
-                text(WTB_B5, (text = "lighting — ambient, noise, scale"))
+                text(WTB_B5, (text = "lighting - ambient, noise, scale"))
             }
             wrap_tab_item("grid") {
-                text(WTB_B6, (text = "grid — size, angle, snap step"))
+                text(WTB_B6, (text = "grid - size, angle, snap step"))
             }
             wrap_tab_item("misc") {
-                text(WTB_B7, (text = "misc — everything else"))
+                text(WTB_B7, (text = "misc - everything else"))
             }
         }
     }
 
-    end_of_frame()
-    Render()
-    var w, h : int
-    live_get_framebuffer_size(w, h)
-    glViewport(0, 0, w, h)
-    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
-    glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
-
-    live_end_frame()
+    harness_end_frame()
 }
 
 [export]
 def shutdown() {
-    live_imgui_shutdown()
-    live_destroy_window()
+    harness_shutdown()
 }
 
 [export]

--- a/examples/tutorial/wrap_tab_bar.das
+++ b/examples/tutorial/wrap_tab_bar.das
@@ -1,0 +1,127 @@
+options gen2
+
+require daslib/safe_addr
+require imgui
+require imgui_app
+require opengl/opengl_boost
+require live/glfw_live
+require live/live_api
+require live/live_commands
+require live/live_vars
+require live_host
+require imgui/imgui_live
+require imgui/imgui_boost_runtime
+require imgui/imgui_boost_v2
+require imgui/imgui_widgets_builtin
+require imgui/imgui_containers_builtin
+require imgui/imgui_visual_aids
+
+// =============================================================================
+// TUTORIAL: wrap_tab_bar / wrap_tab_item — a multi-row, WRAPPING tab bar.
+//
+//   wrap_tab_bar(WTB_BAR) {
+//       wrap_tab_item("physics") { <body> }
+//       wrap_tab_item("camera")  { <body> }
+//       ...
+//   }
+//
+// ImGui's native `tab_bar` shrinks/ellipsizes or scrolls its headers when they
+// overflow the width; `wrap_tab_bar` instead wraps them onto as many rows as
+// needed and shows only the active tab's body. The active tab is an INDEX
+// (like `combo`) — `imgui_force_set {"value":N}` selects tab N. Because the
+// body renders after the whole header strip, the strip is laid out from the
+// labels seen on the PREVIOUS frame: a changed label set appears one frame late
+// (never visible for a stable list). Keep tab declaration order stable.
+//
+// The narrow window below forces the headers to wrap across rows.
+//
+// STANDALONE: daslang.exe modules/dasImgui/examples/tutorial/wrap_tab_bar.das
+// LIVE:       daslang-live modules/dasImgui/examples/tutorial/wrap_tab_bar.das
+//
+// DRIVE (when running live) — select the "lava" tab (index 2):
+//   curl -X POST -d '{"name":"imgui_force_set","args":{"target":"WTB_WIN/WTB_BAR","value":2}}' \
+//        localhost:9090/command
+// =============================================================================
+
+[export]
+def init() {
+    live_create_window("dasImgui wrap_tab_bar tutorial", 520, 560)
+    live_imgui_init(live_window)
+    var io & = unsafe(GetIO())
+    io.FontGlobalScale = 1.4
+}
+
+[export]
+def update() {
+    if (!live_begin_frame()) return
+    begin_frame()
+
+    ImGui_ImplOpenGL3_NewFrame()
+    ImGui_ImplGlfw_NewFrame()
+    apply_synth_io_override()
+    NewFrame()
+
+    SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond.Always)
+    // deliberately narrow so the eight headers wrap onto multiple rows
+    SetNextWindowSize(ImVec2(360.0f, 500.0f), ImGuiCond.Always)
+    window(WTB_WIN, (text = "wrap_tab_bar tutorial", closable = false,
+                     flags = ImGuiWindowFlags.None)) {
+
+        text("Eight categories in a narrow panel — the native TabBar would")
+        text("ellipsize or scroll; wrap_tab_bar flows them onto rows.")
+        separator()
+
+        wrap_tab_bar(WTB_BAR) {
+            wrap_tab_item("physics") {
+                text(WTB_B0, (text = "physics — gravity, restitution, drag"))
+            }
+            wrap_tab_item("camera") {
+                text(WTB_B1, (text = "camera — zoom, follow, lookahead"))
+            }
+            wrap_tab_item("lava") {
+                text(WTB_B2, (text = "lava — speed, scale, warp, crust"))
+            }
+            wrap_tab_item("cinders") {
+                text(WTB_B3, (text = "cinders — brightness, density, rise"))
+            }
+            wrap_tab_item("audio") {
+                text(WTB_B4, (text = "audio — master gain, music, sfx"))
+            }
+            wrap_tab_item("lighting") {
+                text(WTB_B5, (text = "lighting — ambient, noise, scale"))
+            }
+            wrap_tab_item("grid") {
+                text(WTB_B6, (text = "grid — size, angle, snap step"))
+            }
+            wrap_tab_item("misc") {
+                text(WTB_B7, (text = "misc — everything else"))
+            }
+        }
+    }
+
+    end_of_frame()
+    Render()
+    var w, h : int
+    live_get_framebuffer_size(w, h)
+    glViewport(0, 0, w, h)
+    glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
+    glClear(GL_COLOR_BUFFER_BIT)
+    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+
+    live_end_frame()
+}
+
+[export]
+def shutdown() {
+    live_imgui_shutdown()
+    live_destroy_window()
+}
+
+[export]
+def main() {
+    init()
+    while (!exit_requested()) {
+        update()
+    }
+    shutdown()
+}

--- a/tests/integration/test_wrap_tab_bar.das
+++ b/tests/integration/test_wrap_tab_bar.das
@@ -19,7 +19,9 @@ let WRAP_FEATURE = "modules/dasImgui/examples/tutorial/wrap_tab_bar.das"
 [test]
 def test_wrap_tab_bar(t : T?) {
     with_imgui_app(WRAP_FEATURE) $(d) {
-        var snap = wait_for_widget(d, "WTB_WIN/WTB_BAR", 15.0f)
+        // 30s (not the usual 15) — the macOS CI lane runs serially on a starved
+        // runner; the host can take >15s to spawn + render its first widget frame.
+        var snap = wait_for_widget(d, "WTB_WIN/WTB_BAR", 30.0f)
         t |> success(snap != null, "wrap_tab_bar renders")
         if (snap == null) {
             return
@@ -33,7 +35,7 @@ def test_wrap_tab_bar(t : T?) {
 
         // drive: select tab 2 (lava) by index — exercises has_pending/pending_value
         force_set_value(d, "WTB_WIN/WTB_BAR", JV(2))
-        var snap2 = wait_until_sec(d, 5.0f) $(var s) {
+        var snap2 = wait_until_sec(d, 15.0f) $(var s) {
             return (widget_payload_field(s, "WTB_WIN/WTB_BAR", "value") ?? -1) == 2
         }
         t |> success(snap2 != null, "force_set selects tab 2")

--- a/tests/integration/test_wrap_tab_bar.das
+++ b/tests/integration/test_wrap_tab_bar.das
@@ -1,0 +1,46 @@
+options gen2
+options indenting = 4
+options no_unused_block_arguments = false
+options no_unused_function_arguments = false
+
+require dastest/testing_boost public
+require imgui/imgui_playwright public
+require daslib/json public
+require daslib/json_boost public
+
+//! Integration smoke for the wrapping tab bar. Opens the wrap_tab_bar tutorial,
+//! asserts tab 0 is active by default (its body renders, an inactive body does
+//! not), then force-selects tab 2 by index and asserts the active body follows.
+//! Proves the widget is both snapshot-visible (the `value` payload) and
+//! programmatically drivable — the upgrade over ImGui's native TabBar.
+
+let WRAP_FEATURE = "modules/dasImgui/examples/tutorial/wrap_tab_bar.das"
+
+[test]
+def test_wrap_tab_bar(t : T?) {
+    with_imgui_app(WRAP_FEATURE) $(d) {
+        var snap = wait_for_widget(d, "WTB_WIN/WTB_BAR", 15.0f)
+        t |> success(snap != null, "wrap_tab_bar renders")
+        if (snap == null) {
+            return
+        }
+
+        // default: first tab active, its body shown, an inactive body hidden
+        t |> success((widget_payload_field(snap, "WTB_WIN/WTB_BAR", "value") ?? -1) == 0,
+                     "tab 0 active by default")
+        t |> success(widget_rendered(snap, "WTB_WIN/WTB_BAR/WTB_B0"), "tab 0 body renders")
+        t |> success(!widget_rendered(snap, "WTB_WIN/WTB_BAR/WTB_B2"), "inactive tab 2 body hidden")
+
+        // drive: select tab 2 (lava) by index — exercises has_pending/pending_value
+        force_set_value(d, "WTB_WIN/WTB_BAR", JV(2))
+        var snap2 = wait_until_sec(d, 5.0f) $(var s) {
+            return (widget_payload_field(s, "WTB_WIN/WTB_BAR", "value") ?? -1) == 2
+        }
+        t |> success(snap2 != null, "force_set selects tab 2")
+        if (snap2 == null) {
+            return
+        }
+        t |> success(widget_rendered(snap2, "WTB_WIN/WTB_BAR/WTB_B2"), "tab 2 body renders after switch")
+        t |> success(!widget_rendered(snap2, "WTB_WIN/WTB_BAR/WTB_B0"), "tab 0 body hidden after switch")
+    }
+}

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -28,7 +28,7 @@ require imgui/imgui_widgets_builtin
 def document_module_imgui_boost_v2() {
     var mod = find_module("imgui_boost_v2")
     var groups <- array<DocGroup>(
-        group_by_regex("Container macros",       mod, %regex~^(window|child|group|tab_bar|tab_item|menu_bar|menu|popup|modal|tree_node|collapsing_header)$%%),
+        group_by_regex("Container macros",       mod, %regex~^(window|child|group|tab_bar|tab_item|wrap_tab_bar|wrap_tab_item|menu_bar|menu|popup|modal|tree_node|collapsing_header)$%%),
         group_by_regex("Widget annotation macros", mod, %regex~^(define_widget|widget|container)$%%),
         group_by_regex("ID scope macros",        mod, %regex~^(with_id|with_path)$%%),
         group_by_regex("Style scope macros",     mod, %regex~^(with_style|with_color|with_var)$%%),

--- a/utils/imgui2rst.das
+++ b/utils/imgui2rst.das
@@ -83,7 +83,7 @@ def document_module_imgui_containers_builtin() {
     var mod = find_module("imgui_containers_builtin")
     var groups <- array<DocGroup>(
         group_by_regex("Windows",       mod, %regex~^(window|child|group|child_scroll_reenter|set_window_size|viewport_center|is_mouse_pos_valid)$%%),
-        group_by_regex("Tabs",          mod, %regex~^(tab_bar|tab_item)$%%),
+        group_by_regex("Tabs",          mod, %regex~^(tab_bar|tab_item|wrap_tab_bar|wrap_tab_item)$%%),
         group_by_regex("Trees",         mod, %regex~^(tree_node|collapsing_header)$%%),
         group_by_regex("Menus",         mod, %regex~^(menu_bar|menu|menu_item)$%%),
         group_by_regex("Popups",        mod, %regex~^(popup|modal|tooltip|open_popup|open_popup_on_item_click|close_current_popup|is_popup_open)$%%),

--- a/widgets/imgui_boost_runtime.das
+++ b/widgets/imgui_boost_runtime.das
@@ -517,6 +517,18 @@ struct TabItemState {
     @optional selected : bool                 //! observed: is this the active tab this frame (snapshot-visible)
 }
 
+struct WrapTabBarState {
+    //! Backs the `wrap_tab_bar` container (the multi-row / wrapping tab bar
+    //! ImGui lacks). Active tab is an index into the tab list, like `combo`:
+    //! `imgui_force_set {"value":N}` selects tab N next frame. `labels` mirrors
+    //! the tabs seen last frame (the header strip is laid out a frame behind so
+    //! it can precede the bodies).
+    @live value : int                         //! active tab index; preserved across reload
+    @optional has_pending : bool              //! imgui_force_set queued; consumed next frame
+    @optional pending_value : int             //! next-frame index queued by imgui_force_set
+    @optional labels : array<string>          //! tab labels from the previous frame (snapshot-visible)
+}
+
 struct TooltipState {
     //! Backs both `tooltip` and `item_tooltip`. Tooltips don't persist —
     //! they're a per-frame chrome pop.

--- a/widgets/imgui_containers_builtin.das
+++ b/widgets/imgui_containers_builtin.das
@@ -559,6 +559,104 @@ def edit_tab_item(var p_open : bool? implicit; text : string;
     edit_container_open_close_finalize(widget_ident, "edit_tab_item", p_open, header_bbox)
 }
 
+// ===== Wrapping tab bar (multi-row) =====
+// ImGui's native TabBar shrinks tabs to fit (ellipsizing labels) or scrolls
+// them behind arrows; it never wraps to multiple rows. `wrap_tab_bar` /
+// `wrap_tab_item` draw the tab headers as a wrapped strip of highlighted
+// buttons (as many rows as the width needs) and render only the active tab's
+// body. The body renders AFTER the whole strip, so the strip is laid out from
+// the labels collected on the PREVIOUS frame — a label-set change appears one
+// frame late (never visible for a stable category list after frame 1).
+
+struct private WrapCtx {
+    value : int               // active tab index for this bar
+    count : int               // running declaration index of wrap_tab_item calls
+    labels : array<string>    // labels collected this frame -> state.labels
+}
+var private g_wrap : array<WrapCtx>   // bar stack (supports nesting)
+
+[widget_dispatch]
+def _wrap_tab_bar_dispatch(var state : WrapTabBarState; action : string; payload : string) {
+    if (action == "set") {
+        unsafe {
+            sscan_json_at(payload, addr(state.pending_value),
+                          *reinterpret<TypeInfo const?>(typeinfo rtti_typeinfo(type<int>)))
+        }
+        state.has_pending = true
+    }
+}
+
+def private draw_wrap_strip(var state : WrapTabBarState) {
+    let n = length(state.labels)
+    return if (n == 0)
+    state.value = clamp(state.value, 0, n - 1)
+    let pad = GetStyle().FramePadding.x
+    let spacing = GetStyle().ItemSpacing.x
+    let vis_x2 = GetWindowPos().x + GetWindowContentRegionMax().x
+    var last_x2 = 0.0f
+    for (i in range(n)) {
+        let lbl = state.labels[i]
+        if (i > 0) {
+            let bw = CalcTextSize(lbl).x + pad * 2.0f
+            if (last_x2 + spacing + bw < vis_x2) {
+                SameLine()
+            }
+        }
+        let is_active = i == state.value
+        if (is_active) {
+            PushStyleColor(ImGuiCol.Button, GetStyleColorVec4(ImGuiCol.ButtonActive))
+        }
+        if (Button(lbl, ImVec2(0.0f, 0.0f))) {
+            state.value = i
+        }
+        if (is_active) {
+            PopStyleColor(1)
+        }
+        last_x2 = GetItemRectMax().x
+    }
+    Separator()
+}
+
+[container]
+def wrap_tab_bar(var state : WrapTabBarState; blk : block) {
+    //! A multi-row, wrapping tab bar — the container ImGui's native `tab_bar`
+    //! isn't: when tabs overflow the width it shrinks/ellipsizes or scrolls,
+    //! while this one wraps the header strip onto as many rows as needed and
+    //! shows only the active tab's body. Active tab is an index;
+    //! `imgui_force_set {"value":N}` selects tab N next frame. Pair with
+    //! `wrap_tab_item`. The header strip lays out from the labels seen on the
+    //! previous frame, so a changed label set appears one frame late.
+    if (state.has_pending) {
+        state.value = state.pending_value
+        state.has_pending = false
+    }
+    draw_wrap_strip(state)
+    var ctx : WrapCtx
+    ctx.value = state.value
+    g_wrap |> emplace(ctx)
+    invoke(blk)
+    let top = length(g_wrap) - 1
+    state.labels <- g_wrap[top].labels
+    g_wrap |> resize(top)
+    pending_value_container_finalize(widget_ident, "wrap_tab_bar", state)
+}
+
+def public wrap_tab_item(text : string; blk : block) {
+    //! One tab of a `wrap_tab_bar`. Its body block renders only while this tab
+    //! is the active one. Tabs are indexed in declaration order — keep the
+    //! order stable across frames (the header strip is laid out a frame behind).
+    let top = length(g_wrap) - 1
+    return if (top < 0)
+    let idx = g_wrap[top].count
+    g_wrap[top].count = idx + 1
+    g_wrap[top].labels |> push(text)
+    if (idx == g_wrap[top].value) {
+        PushID(text)
+        invoke(blk)
+        PopID()
+    }
+}
+
 // ===== Tooltip family =====
 
 [container]


### PR DESCRIPTION
## What

`wrap_tab_bar` / `wrap_tab_item` — the multi-row, **wrapping** tab bar ImGui doesn't have. When tab headers overflow the available width, ImGui's native `TabBar` either shrinks them (ellipsizing labels to a single letter) or scrolls them behind arrows. This container instead **wraps the header strip onto as many rows as the width needs** and renders only the active tab's body.

```
wrap_tab_bar(MY_TABS) {
    wrap_tab_item("physics") { ...body... }
    wrap_tab_item("camera")  { ...body... }
    wrap_tab_item("lighting") { ...body... }
    ...
}
```

## Why

A settings / tweak panel with many categories in a narrow dock is unreadable with the native tab bar — every header collapses to `g…` `p…` `c…`. Wrapping keeps every label legible and scales to any number of categories.

## Design notes

- **Active tab is an index** (like `combo`): `imgui_force_set {"value":N}` selects tab N. The bar is snapshot-visible (`value` + `labels`) and programmatically drivable — the upgrade over the native `TabBar`, whose active tab lives only in ImGui's internal storage (so it can't be asserted or driven from a test).
- The body renders *after* the whole header strip, and daslang blocks can't be deferred, so the strip lays out from the **labels collected on the previous frame**. A changed label set appears one frame late — invisible for a stable list, and it keeps the bodies from interleaving with the header strip.
- Keep tab declaration order stable across frames.

## Included

- `WrapTabBarState` (imgui_boost_runtime) + `wrap_tab_bar` / `wrap_tab_item` + a `[widget_dispatch]` (imgui_containers_builtin).
- Tutorial example `examples/tutorial/wrap_tab_bar.das`.
- Headless integration test `tests/integration/test_wrap_tab_bar.das` — default tab active (its body renders, an inactive body does not), then force-select another tab and assert the active body follows.
- imgui2rst container-macro grouping for the two new functions.

## Verification

- Full integration suite: **177 / 177 pass** (headless).
- Lint clean on the new code; `imgui2rst` doc-gen clean (no Uncategorized symbols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)