### PR TITLE
file_dialog: remember the last folder within a session

### DIFF
--- a/doc/source/tutorials/file_dialog.rst
+++ b/doc/source/tutorials/file_dialog.rst
@@ -83,6 +83,8 @@ Public API
    def public file_dialog_selected_path() : string      // first selection (convenience)
    def public file_dialog_current_dir() : string
    def public file_dialog_is_open() : bool
+   def public file_dialog_last_dir() : string                 // last confirmed folder this session
+   def public file_dialog_set_last_dir(dir : string) : void   // seed it (persist across runs)
    // convenience: parse a C#-style "caption|ext;ext|caption|ext|..." pipe spec
    def public file_filters(spec : string) : array<FileDialogFilter>
 
@@ -90,6 +92,12 @@ The result is polled, not pushed: ``file_dialog_draw()`` returns ``confirmed``
 exactly on the frame the user commits, ``cancelled`` on the frame they close /
 press *Escape*, and ``none`` otherwise. The accessors stay valid from the
 ``confirmed`` frame until the dialog is reopened.
+
+A blank ``start_dir`` opens the dialog at the last folder a selection was
+confirmed in this session, then the working directory. ``file_dialog_set_last_dir``
+seeds that folder (e.g. from saved app config on startup) and
+``file_dialog_last_dir`` reads it back to persist across runs; an explicit
+``start_dir`` always wins.
 
 Modes
 =====

--- a/tests/integration/test_file_dialog.das
+++ b/tests/integration/test_file_dialog.das
@@ -183,3 +183,49 @@ def test_file_dialog(t : T?) {
         }
     }
 }
+
+[test]
+def test_file_dialog_remembers_last_dir(t : T?) {
+    with_imgui_app(FILE_DIALOG_FEATURE) $(d) {
+        // Open save, navigate into a subfolder, confirm there — then REOPEN and assert the dialog lands
+        // back in that subfolder (it remembers the last confirmed folder this session) rather than the
+        // start dir. Drives the full capture-on-confirm -> reuse-on-open path over the live API.
+        var snap = wait_for_widget(d, "FDLG_WIN/BTN_SAVE", 15.0f)
+        t |> success(snap != null, "demo Save trigger renders")
+        if (snap == null) {
+            return
+        }
+        click(d, "FDLG_WIN/BTN_SAVE")
+        t |> success(wait_for_widget(d, "FILEDLG/FILE_TABLE", 10.0f) != null, "save dialog opens")
+        let p0 = widget_payload_field(snapshot(d), "FILEDLG/PATH_FIELD", "value") ?? ""
+
+        let folder = find_folder_row(d)
+        if (empty(folder)) {
+            // no clickably-visible folder at the start dir — can't exercise navigation; skip (no flake)
+            t |> success(true, "skipped — no visible folder at the start dir to navigate into")
+            return
+        }
+        let before = count_crumbs(d)
+        double_click(d, folder)
+        var entered = wait_until_sec(d, 5.0f) $(var cs) {
+            return count_crumbs_in(cs) > before
+        }
+        t |> success(entered != null, "navigated into a subfolder")
+        if (entered == null) {
+            return
+        }
+        let p1 = widget_payload_field(entered, "FILEDLG/PATH_FIELD", "value") ?? ""
+        t |> success(!empty(p1) && p1 != p0, "subfolder path differs from the start dir")
+
+        // confirm a save here — captures this folder as the remembered dir + closes the dialog
+        force_set_value(d, "FILEDLG/NAME_FIELD", JV("zzz_remember_probe"))
+        click(d, "FILEDLG/BTN_OK")
+        t |> success(wait_result(d, "zzz_remember_probe"), "save confirmed in the subfolder")
+
+        // reopen — must land in the remembered subfolder, not the original start dir
+        click(d, "FDLG_WIN/BTN_SAVE")
+        t |> success(wait_for_widget(d, "FILEDLG/FILE_TABLE", 10.0f) != null, "save dialog reopens")
+        let p2 = widget_payload_field(snapshot(d), "FILEDLG/PATH_FIELD", "value") ?? ""
+        t |> success(p2 == p1, "reopened at the remembered folder, not the start dir")
+    }
+}

--- a/widgets/imgui_file_dialog.das
+++ b/widgets/imgui_file_dialog.das
@@ -94,6 +94,7 @@ struct private DialogState {
 }
 
 var private g_fd : DialogState = DialogState()
+var private g_last_dir : string   //!< dir of the last confirmed selection — reused as the default start_dir within a session (app may persist it via file_dialog_last_dir / file_dialog_set_last_dir)
 
 let private COL_NAME = 1u
 let private COL_SIZE = 2u
@@ -382,6 +383,7 @@ def private confirm_single(path : string) : FileDialogResult {
     g_fd.result |> push(path)
     FILEDLG.pending_close = true
     g_fd.open = false
+    g_last_dir = g_fd.cur_dir   // remember the folder so the next open starts here, not at cwd
     return FileDialogResult.confirmed
 }
 
@@ -389,6 +391,7 @@ def private confirm_multi(var paths : array<string>) : FileDialogResult {
     g_fd.result <- paths
     FILEDLG.pending_close = true
     g_fd.open = false
+    g_last_dir = g_fd.cur_dir
     return FileDialogResult.confirmed
 }
 
@@ -441,7 +444,9 @@ def public file_dialog_open(cfg : FileDialogConfig) {
     g_fd.filter_labels <- [for (f in cfg.filters); f.caption]
     g_fd.filter_idx = 0
     FILTER_COMBO.value = empty(cfg.filters) ? -1 : 0
-    g_fd.start_dir = normalize(empty(cfg.start_dir) ? getcwd() : cfg.start_dir)
+    // start at the explicit start_dir, else the last folder used this session, else cwd
+    let fallback = empty(g_last_dir) ? getcwd() : g_last_dir
+    g_fd.start_dir = normalize(empty(cfg.start_dir) ? fallback : cfg.start_dir)
     g_fd.cur_dir = g_fd.start_dir
     g_fd.selection |> clear()
     g_fd.result |> clear()
@@ -466,6 +471,19 @@ def public file_dialog_open(cfg : FileDialogConfig) {
     rebuild_view()
     rebuild_crumbs()
     FILEDLG.pending_open = true
+}
+
+//! The folder of the last confirmed selection this session ("" if none yet). Persist
+//! it to app config on exit, then restore via file_dialog_set_last_dir on startup to
+//! make the dialog reopen at the user's last folder across runs.
+def public file_dialog_last_dir() : string {
+    return g_last_dir
+}
+
+//! Seed the remembered start folder (e.g. from saved app config on startup). An empty
+//! string clears it (back to cwd-default).
+def public file_dialog_set_last_dir(dir : string) {
+    g_last_dir = empty(dir) ? "" : normalize(dir)
 }
 
 //! Render the modal if open and return this frame's result. Call every frame.


### PR DESCRIPTION
## What

The native `imgui_file_dialog` reopened at `getcwd()` every time, so repeated open/save trips kept restarting at the working directory instead of where the user last was.

This captures the folder of each **confirmed** selection into a module-global and reuses it as the default `start_dir` on the next open. An explicit `cfg.start_dir` still wins; an empty one (the common case) now falls back to the remembered folder, then cwd.

Adds `file_dialog_last_dir()` / `file_dialog_set_last_dir()` so an app can persist the last folder to its own config and restore it on startup (cross-run memory), while the in-session memory works with no app wiring.

## Test

`test_file_dialog_remembers_last_dir`, added to the existing headless dialog suite: opens save, navigates into a subfolder, confirms a save there, reopens — and asserts the dialog reopens in that subfolder rather than the start dir. Drives the full capture-on-confirm → reuse-on-open path over the live API (headless, like the rest of the suite), reusing the suite's folder-row / crumb-count helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)