### PR TITLE
imgui: render via the pure-das opengl_imgui_driver; unlink C++ imgui_impl_opengl3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,14 +97,13 @@ Two distinct frame-loop APIs:
 def update() {
     if (!live_begin_frame()) return
     begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()         //! REQUIRED for synth IO to drain
     NewFrame()
     // ... widgets ...
     end_of_frame()
     Render()
-    // ... GL clear + ImGui_ImplOpenGL3_RenderDrawData ...
+    // ... GL clear + live_imgui_render() ...
     live_end_frame()
 }
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,6 @@ SET(DAS_IMGUI_BIND_SRC
 SET(DAS_IMGUI_APP_SRC
     ${DAS_IMGUI_DIR}/src/module_imgui_app.cpp
     ${imgui_INCLUDE_DIR}/backends/imgui_impl_glfw.cpp
-    ${imgui_INCLUDE_DIR}/backends/imgui_impl_opengl3.cpp
     ${DAS_IMGUI_DIR}/gl3w/GL/gl3w.cpp
 )
 

--- a/doc/source/tutorials/boost_basics.rst
+++ b/doc/source/tutorials/boost_basics.rst
@@ -56,15 +56,15 @@ The frame loop
 
 #. ``live_begin_frame()`` — return early if the window is closing.
 #. ``begin_frame()`` — boost-side per-frame setup (registry, command dispatch).
-#. ``ImGui_ImplOpenGL3_NewFrame`` / ``ImGui_ImplGlfw_NewFrame`` /
-   ``apply_synth_io_override`` / ``NewFrame`` — the ImGui backend
-   prologue. ``apply_synth_io_override`` lets synthetic mouse/keyboard
+#. ``ImGui_ImplGlfw_NewFrame`` / ``apply_synth_io_override`` /
+   ``NewFrame`` — the ImGui input + frame prologue.
+   ``apply_synth_io_override`` lets synthetic mouse/keyboard
    events from live-commands win against the GLFW backend's per-frame
    poll (needed for tutorial recordings).
 #. The widget block (see below).
 #. ``end_of_frame()`` / ``Render()`` — boost-side bookkeeping, then ImGui
    composes the draw list.
-#. ``glViewport`` / ``glClear`` / ``ImGui_ImplOpenGL3_RenderDrawData`` — paint.
+#. ``glViewport`` / ``glClear`` / ``live_imgui_render`` — paint (pure-das GL renderer).
 #. ``live_end_frame()`` — swap buffers, advance live-reload housekeeping.
 
 The window container

--- a/doc/source/tutorials/harness_headless_mode.rst
+++ b/doc/source/tutorials/harness_headless_mode.rst
@@ -72,7 +72,7 @@ The harness exports five helpers; each branches on
 
 ``harness_begin_frame() : bool``
    * Windowed: poll GLFW events, run boost ``begin_frame``, then
-     ``ImGui_ImplOpenGL3_NewFrame`` + ``ImGui_ImplGlfw_NewFrame``.
+     ``ImGui_ImplGlfw_NewFrame`` (input).
    * Headless: feed ``ImGuiIO::DeltaTime`` from real wall-clock, run
      boost ``begin_frame``, advance the headless frame counter. If
      ``--headless-frames=N`` is set and the counter reaches ``N``, call
@@ -90,8 +90,8 @@ The harness exports five helpers; each branches on
 
 ``harness_end_frame()``
    * Windowed: boost ``end_of_frame`` + ``Render`` + viewport/clear +
-     ``ImGui_ImplOpenGL3_RenderDrawData`` + ``live_end_frame`` (swap
-     buffers).
+     ``live_imgui_render`` (pure-das GL renderer) + ``live_end_frame``
+     (swap buffers).
    * Headless: ``end_of_frame`` + ``Render``. The resulting
      ``ImDrawData`` is discarded — there is no GL backend to consume it.
 

--- a/examples/imgui_demo/main.das
+++ b/examples/imgui_demo/main.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -57,7 +55,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     NewFrame()
 
@@ -70,7 +67,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 

--- a/examples/tutorial/boost_basics.das
+++ b/examples/tutorial/boost_basics.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -38,8 +36,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui boost basics", 960, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -47,7 +45,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -77,7 +74,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/buttons.das
+++ b/examples/tutorial/buttons.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -54,8 +52,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui buttons tutorial", 800, 720)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -63,7 +61,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -140,7 +137,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/child.das
+++ b/examples/tutorial/child.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -50,8 +48,8 @@ var private SCROLL_ROW : table<int; NarrativeState>
 def init() {
     live_create_window("dasImgui child tutorial", 800, 540)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -59,7 +57,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -121,7 +118,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/collapsing_header.das
+++ b/examples/tutorial/collapsing_header.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -57,8 +55,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui collapsing_header tutorial", 760, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -66,7 +64,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -116,7 +113,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/color.das
+++ b/examples/tutorial/color.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -55,8 +53,8 @@ let REF_COLOR    : float4 = float4(0.10f, 0.55f, 0.95f, 1.0f)
 def init() {
     live_create_window("dasImgui color tutorial", 800, 700)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -64,7 +62,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -112,7 +109,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/color_button_hover.das
+++ b/examples/tutorial/color_button_hover.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -40,8 +38,8 @@ var private STATE_MESSAGE = "Hover any swatch."
 def init() {
     live_create_window("dasImgui color_button_hover tutorial", 640, 380)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -49,7 +47,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -93,7 +90,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/containers.das
+++ b/examples/tutorial/containers.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -46,8 +44,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui containers tutorial", 760, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -55,7 +53,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -138,7 +135,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/custom_widgets.das
+++ b/examples/tutorial/custom_widgets.das
@@ -7,13 +7,11 @@ options _allow_imgui_legacy = true
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -159,8 +157,8 @@ def knob(var state : VolumeKnobState; text : string) : bool {
 def init() {
     live_create_window("dasImgui custom_widgets", 800, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -168,7 +166,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -210,7 +207,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/data_table.das
+++ b/examples/tutorial/data_table.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -131,8 +129,8 @@ def init() {
     // prior session's window pos/size can't drift the framing. Tutorial-scoped on
     // purpose - not a blanket change to live_imgui_init.
     DisableIniPersistence()
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -140,7 +138,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -192,7 +189,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/display_widgets.das
+++ b/examples/tutorial/display_widgets.das
@@ -3,13 +3,11 @@ options gen2
 require math
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -43,8 +41,8 @@ var private g_phase : float = 0.0f
 def init() {
     live_create_window("dasImgui display widgets", 940, 680)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -52,7 +50,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -112,7 +109,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/docking.das
+++ b/examples/tutorial/docking.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -86,7 +84,7 @@ def init() {
     // ini from a prior run would otherwise override the seed non-deterministically).
     DisableIniPersistence()
     var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    GetStyle().FontScaleMain = 1.5
     // The single flag that turns docking on for the whole session. Without
     // this, DockSpace() / DockSpaceOverViewport() render nothing.
     io.ConfigFlags |= ImGuiConfigFlags.DockingEnable
@@ -97,7 +95,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -138,7 +135,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/drag.das
+++ b/examples/tutorial/drag.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -49,8 +47,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui drag tutorial", 760, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -58,7 +56,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -103,7 +100,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/drawlist.das
+++ b/examples/tutorial/drawlist.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -48,8 +46,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui drawlist tutorial", 1000, 800)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.2
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.2
 }
 
 [export]
@@ -57,7 +55,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -166,7 +163,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/driving_outside.das
+++ b/examples/tutorial/driving_outside.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -72,8 +70,8 @@ def init() {
     // Deterministic FirstUseEver layout for the recording: disable imgui.ini so a prior
     // session's window pos/size can't drift the framing. Tutorial-scoped on purpose.
     DisableIniPersistence()
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -81,7 +79,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -145,7 +142,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/dropdown_select.das
+++ b/examples/tutorial/dropdown_select.das
@@ -4,13 +4,11 @@ require math
 require strings
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -58,8 +56,8 @@ var private D_SHIRT_ROW : table<int; ClickState>
 def init() {
     live_create_window("dasImgui dropdown_select tutorial", 760, 640)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -67,7 +65,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -126,7 +123,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/dynamic_fonts.das
+++ b/examples/tutorial/dynamic_fonts.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -49,8 +47,8 @@ var private g_global_scale : float = 1.0f
 def init() {
     live_create_window("dasImgui dynamic_fonts tutorial", 820, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.2
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.2
 }
 
 [export]
@@ -58,7 +56,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -106,7 +103,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/edit_tab_item.das
+++ b/examples/tutorial/edit_tab_item.das
@@ -3,13 +3,11 @@ options gen2
 require daslib/safe_addr
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -58,8 +56,8 @@ var private g_tab_c_open : bool = true
 def init() {
     live_create_window("dasImgui edit_tab_item tutorial", 760, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -67,7 +65,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -121,7 +118,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/editing_external.das
+++ b/examples/tutorial/editing_external.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -67,8 +65,8 @@ def init() {
     //! the pointer, so they must stay on-screen as the recording drives each one.
     live_create_window("dasImgui editing_external", 760, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.2
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.2
 }
 
 [export]
@@ -76,7 +74,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -133,7 +130,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/flat_tooltips.das
+++ b/examples/tutorial/flat_tooltips.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -37,8 +35,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui flat tooltips", 720, 420)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -46,7 +44,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -87,7 +84,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/group.das
+++ b/examples/tutorial/group.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -44,8 +42,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui group tutorial", 720, 480)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -53,7 +51,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -123,7 +120,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/icons.das
+++ b/examples/tutorial/icons.das
@@ -57,7 +57,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -116,7 +115,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/input_numeric.das
+++ b/examples/tutorial/input_numeric.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -50,8 +48,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui input_numeric tutorial", 760, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -59,7 +57,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -105,7 +102,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/input_text.das
+++ b/examples/tutorial/input_text.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -73,8 +71,8 @@ def private completion_cb(var data : ImGuiInputTextCallbackData) : int {
 def init() {
     live_create_window("dasImgui input_text tutorial", 760, 760)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -82,7 +80,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -140,7 +137,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/item_flags.das
+++ b/examples/tutorial/item_flags.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -42,8 +40,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui item_flags tutorial", 820, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.3
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.3
 }
 
 [export]
@@ -51,7 +49,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -99,7 +96,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/layout.das
+++ b/examples/tutorial/layout.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -48,8 +46,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui layout tutorial", 1024, 720)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -57,7 +55,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -109,7 +106,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/layout_primitives.das
+++ b/examples/tutorial/layout_primitives.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -34,8 +32,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui layout primitives", 1000, 640)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -43,7 +41,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -87,7 +84,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/live_reload.das
+++ b/examples/tutorial/live_reload.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -115,8 +113,8 @@ def init() {
     live_create_window("dasImgui live_reload tutorial", 1040, 720)
     live_imgui_init(live_window)
     DisableIniPersistence()
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 
     // Re-running init resets g_session_string each reload. (Initial-value
     // assignments at module scope run once at program load, but `init` is
@@ -133,7 +131,6 @@ def update() {
 
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -178,7 +175,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     // Always match live_begin_frame with live_end_frame to keep the
     // frame pump alive on the daslang-live side.

--- a/examples/tutorial/log_capture.das
+++ b/examples/tutorial/log_capture.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -44,8 +42,8 @@ var private g_capture_requested = false
 def init() {
     live_create_window("dasImgui log_capture tutorial", 820, 600)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.3
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.3
 }
 
 [export]
@@ -53,7 +51,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -108,7 +105,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/main_menu_bar.das
+++ b/examples/tutorial/main_menu_bar.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -48,8 +46,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui main_menu_bar tutorial", 800, 480)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -57,7 +55,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -108,7 +105,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/narrative_layout_tour.das
+++ b/examples/tutorial/narrative_layout_tour.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -42,8 +40,8 @@ def init() {
     //! same story.
     live_create_window("dasImgui narrative+layout tour", 720, 480)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.15
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.15
 }
 
 [export]
@@ -51,7 +49,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -107,7 +104,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/narrative_widgets.das
+++ b/examples/tutorial/narrative_widgets.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -39,8 +37,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui narrative widgets", 760, 600)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -48,7 +46,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -92,7 +89,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/plot.das
+++ b/examples/tutorial/plot.das
@@ -3,13 +3,11 @@ options gen2
 require math
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -65,8 +63,8 @@ def fill_bars(var arr : array<float>) {
 def init() {
     live_create_window("dasImgui plot tutorial", 800, 720)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -74,7 +72,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -121,7 +118,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/popup_modal.das
+++ b/examples/tutorial/popup_modal.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -50,8 +48,8 @@ var private CONFIRM_RESULT : string = "(no answer yet)"
 def init() {
     live_create_window("dasImgui popup_modal tutorial", 720, 480)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -59,7 +57,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -130,7 +127,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/popup_window.das
+++ b/examples/tutorial/popup_window.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -43,8 +41,8 @@ var private LAST_PICK : string = "(none yet)"
 def init() {
     live_create_window("dasImgui popup_window tutorial", 760, 480)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -52,7 +50,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -103,7 +100,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/popups.das
+++ b/examples/tutorial/popups.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -55,8 +53,8 @@ var private g_win_action  : string = "(right-click empty area)"
 def init() {
     live_create_window("dasImgui popups tutorial", 760, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -64,7 +62,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -125,7 +122,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/recording.das
+++ b/examples/tutorial/recording.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -55,8 +53,8 @@ def init() {
     live_create_window("dasImgui recording tutorial", 940, 560)
     live_imgui_init(live_window)
     DisableIniPersistence()
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -64,7 +62,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -86,7 +83,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/selectable_hover.das
+++ b/examples/tutorial/selectable_hover.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -43,8 +41,8 @@ let private ROWS = fixed_array("Arrow", "TextInput", "ResizeAll", "Hand", "NotAl
 def init() {
     live_create_window("dasImgui selectable_hover tutorial", 600, 380)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -52,7 +50,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -82,7 +79,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/slider.das
+++ b/examples/tutorial/slider.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -46,8 +44,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui slider tutorial", 760, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -55,7 +53,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -109,7 +106,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/state_telemetry.das
+++ b/examples/tutorial/state_telemetry.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -55,8 +53,8 @@ def init() {
     live_create_window("dasImgui state_telemetry tutorial", 1040, 720)
     live_imgui_init(live_window)
     DisableIniPersistence()
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -64,7 +62,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -129,7 +126,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/tab_bar.das
+++ b/examples/tutorial/tab_bar.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -54,8 +52,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui tab_bar tutorial", 760, 540)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -63,7 +61,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -128,7 +125,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/texture_ref.das
+++ b/examples/tutorial/texture_ref.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -17,7 +15,6 @@ require imgui/imgui_widgets_builtin
 require imgui/imgui_containers_builtin
 require imgui/imgui_visual_aids
 require stbimage/stbimage_boost
-require daslib/fio
 require daslib/safe_addr
 
 // =============================================================================
@@ -79,8 +76,8 @@ def private texture_ref() : ImTextureRef {
 def init() {
     live_create_window("dasImgui texture_ref tutorial", 820, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.3
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.3
     // GL context is live now — decode + upload the picture once.
     upload_picture()
 }
@@ -90,7 +87,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -132,7 +128,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/toggles.das
+++ b/examples/tutorial/toggles.das
@@ -3,13 +3,11 @@ options gen2
 require math
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -47,8 +45,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui toggles tutorial", 760, 560)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 let MODE_LABELS = fixed_array("Off", "Manual", "Auto")
@@ -58,7 +56,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -97,7 +94,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/tree_image_misc.das
+++ b/examples/tutorial/tree_image_misc.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -52,8 +50,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui tree_node_ex + image tutorial", 980, 720)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -61,7 +59,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -106,7 +103,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/tree_node.das
+++ b/examples/tutorial/tree_node.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -58,8 +56,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui tree_node tutorial", 720, 540)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -67,7 +65,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -127,7 +124,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/visual_aids_tour.das
+++ b/examples/tutorial/visual_aids_tour.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -47,8 +45,8 @@ def init() {
     live_create_window("visual aids tour", 1000, 640)
     live_imgui_init(live_window)
     DisableIniPersistence()
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -56,7 +54,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -142,7 +139,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/widgets_tour.das
+++ b/examples/tutorial/widgets_tour.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -47,8 +45,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui widgets tour", 1024, 720)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -56,7 +54,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -110,7 +107,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/window_size_constraints.das
+++ b/examples/tutorial/window_size_constraints.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -68,8 +66,8 @@ def init() {
     // restoring whatever a prior session left. Tutorial-scoped on purpose — not a
     // blanket change to live_imgui_init.
     DisableIniPersistence()
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.2
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.2
 
     // Seed the three constraints once at init — daslang lambdas hold their
     // own capture state, so a single per-shape struct is enough for all
@@ -96,7 +94,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -144,7 +141,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/with_disabled.das
+++ b/examples/tutorial/with_disabled.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -41,8 +39,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui with_disabled family", 760, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -50,7 +48,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -108,7 +105,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/with_id.das
+++ b/examples/tutorial/with_id.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -55,8 +53,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui with_id tutorial", 720, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -64,7 +62,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -130,7 +127,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/with_style.das
+++ b/examples/tutorial/with_style.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -50,8 +48,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui with_style tutorial", 720, 520)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.5
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.5
 }
 
 [export]
@@ -59,7 +57,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -109,7 +106,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/examples/tutorial/with_tab_stop.das
+++ b/examples/tutorial/with_tab_stop.das
@@ -2,13 +2,11 @@ options gen2
 
 require imgui
 require imgui_app
-require glfw/glfw_boost
 require opengl/opengl_boost
 require live/glfw_live
 require live/live_api
 require live/live_commands
 require live/live_vars
-require live/opengl_live
 require live_host
 require imgui/imgui_live
 require imgui/imgui_boost_runtime
@@ -35,8 +33,8 @@ require imgui/imgui_visual_aids
 def init() {
     live_create_window("dasImgui with_tab_stop tutorial", 760, 460)
     live_imgui_init(live_window)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = 1.4
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = 1.4
 }
 
 [export]
@@ -44,7 +42,6 @@ def update() {
     if (!live_begin_frame()) return
     begin_frame()
 
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     apply_synth_io_override()
     NewFrame()
@@ -76,7 +73,7 @@ def update() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
 
     live_end_frame()
 }

--- a/skills/migration.md
+++ b/skills/migration.md
@@ -54,8 +54,8 @@ Two equivalent ways to drive a frame loop:
   (`harness_begin_frame`, `harness_new_frame`, `harness_end_frame`). Supports
   `--headless`. **Use this for new code, feature demos, tests, and most apps.**
 - **`require live/glfw_live` + `require imgui/imgui_live`** — manual frame
-  with separate `ImGui_ImplOpenGL3_NewFrame` / `ImGui_ImplGlfw_NewFrame` /
-  `NewFrame` / `Render` / `glClear` / `RenderDrawData` calls. Used by
+  with separate `ImGui_ImplGlfw_NewFrame` / `NewFrame` / `Render` / `glClear` /
+  `live_imgui_render` calls. Used by
   `examples/tutorial/*.das` so the tutorial can demonstrate the full stack.
   **Use this only when you need explicit control** over each backend call
   (custom GL clear color per frame, custom font atlas building, etc.).

--- a/src/module_imgui_app.cpp
+++ b/src/module_imgui_app.cpp
@@ -4,7 +4,6 @@
 #include <GL/gl3w.h>
 #include <GLFW/glfw3.h>
 
-#include "../imgui/backends/imgui_impl_opengl3.h"
 #include "../imgui/backends/imgui_impl_glfw.h"
 
 using namespace das;
@@ -23,11 +22,6 @@ MAKE_EXTERNAL_TYPE_FACTORY(ImDrawData,ImDrawData);
 
 DAS_MOD_API void glfw_error_callback(int error, const char* description) {
     printf("Glfw Error %d: %s\n", error, description);
-}
-
-DAS_MOD_API void das_ImGui_ImplOpenGL3_Init ( const char * version ) {
-    gl3wInit();
-    ImGui_ImplOpenGL3_Init(version);
 }
 
 // =====================================================================
@@ -139,23 +133,6 @@ public:
             SideEffects::worstDefault, "ImGui_ImplGlfw_KeyCallback");
         addExtern<DAS_BIND_FUN(ImGui_ImplGlfw_CharCallback)>(*this,lib,"ImGui_ImplGlfw_CharCallback",
             SideEffects::worstDefault, "ImGui_ImplGlfw_CharCallback");
-        // OpenGL
-        addExtern<DAS_BIND_FUN(das_ImGui_ImplOpenGL3_Init)>(*this,lib,"ImGui_ImplOpenGL3_Init",
-            SideEffects::worstDefault, "das_ImGui_ImplOpenGL3_Init");
-        addExtern<DAS_BIND_FUN(ImGui_ImplOpenGL3_Shutdown)>(*this,lib,"ImGui_ImplOpenGL3_Shutdown",
-            SideEffects::worstDefault, "ImGui_ImplOpenGL3_Shutdown");
-        addExtern<DAS_BIND_FUN(ImGui_ImplOpenGL3_NewFrame)>(*this,lib,"ImGui_ImplOpenGL3_NewFrame",
-            SideEffects::worstDefault, "ImGui_ImplOpenGL3_NewFrame");
-        addExtern<DAS_BIND_FUN(ImGui_ImplOpenGL3_RenderDrawData)>(*this,lib,"ImGui_ImplOpenGL3_RenderDrawData",
-            SideEffects::worstDefault, "ImGui_ImplOpenGL3_RenderDrawData");
-
-        // ImGui_ImplOpenGL3_CreateFontsTexture/DestroyFontsTexture are not bound —
-        // the backend creates/destroys textures automatically via the
-        // RendererHasTextures texture queue inside RenderDrawData. No das callers existed.
-        addExtern<DAS_BIND_FUN(ImGui_ImplOpenGL3_CreateDeviceObjects)>(*this,lib,"ImGui_ImplOpenGL3_CreateDeviceObjects",
-            SideEffects::worstDefault, "ImGui_ImplOpenGL3_CreateDeviceObjects");
-        addExtern<DAS_BIND_FUN(ImGui_ImplOpenGL3_DestroyDeviceObjects)>(*this,lib,"ImGui_ImplOpenGL3_DestroyDeviceObjects",
-            SideEffects::worstDefault, "ImGui_ImplOpenGL3_DestroyDeviceObjects");
 #endif
         // Synth IO bypass (imgui_live driver).
         addExtern<DAS_BIND_FUN(das_imgui_synth_mouse_pos)>(*this,lib,"imgui_synth_mouse_pos",
@@ -174,8 +151,6 @@ public:
     virtual ModuleAotType aotRequire ( TextWriter & tw ) const override {
         tw << "#include \"../modules/dasImgui/src/imgui_stub.h\"\n";
         tw << "#include <backends/imgui_impl_glfw.h>\n";
-        tw << "#include <backends/imgui_impl_opengl3.h>\n";
-        tw << "DAS_MOD_API void das_ImGui_ImplOpenGL3_Init ( const char * version );\n";
         tw << "DAS_MOD_API void das_imgui_synth_mouse_pos ( float x, float y );\n";
         tw << "DAS_MOD_API void das_imgui_synth_mouse_button ( int button, bool down );\n";
         tw << "DAS_MOD_API void das_imgui_synth_mouse_wheel ( float dx, float dy );\n";

--- a/utils/make_icon_doc.das
+++ b/utils/make_icon_doc.das
@@ -78,7 +78,6 @@ def render_icon_frame(name : string; capture_to : string) {
         return
     }
     begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
     ImGui_ImplGlfw_NewFrame()
     NewFrame()
 
@@ -103,7 +102,7 @@ def render_icon_frame(name : string; capture_to : string) {
     glViewport(0, 0, w, h)
     glClearColor(BG.x, BG.y, BG.z, BG.w)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
     // Read back BEFORE the swap: the just-rendered icon is in the back buffer.
     if (!empty(capture_to)) {
         capture_png(capture_to)

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -186,7 +186,7 @@ def public harness_begin_frame() : bool {
     }
     return false if (!live_begin_frame())
     begin_frame()
-    ImGui_ImplOpenGL3_NewFrame()
+    // (no ImGui_ImplOpenGL3_NewFrame — the das renderer builds its objects at init, nothing per-frame)
     ImGui_ImplGlfw_NewFrame()
     // Single clock: drive ImGui DeltaTime from the master clock (get_dt), so lockstep
     // recording uses the fixed step; normal mode get_dt()==wall dt (no-op). Guard >0.
@@ -227,7 +227,7 @@ def public harness_end_frame() {
     glViewport(0, 0, w, h)
     glClearColor(0.10f, 0.10f, 0.12f, 1.0f)
     glClear(GL_COLOR_BUFFER_BIT)
-    ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())
+    live_imgui_render()
     live_end_frame()
 }
 

--- a/widgets/imgui_live.das
+++ b/widgets/imgui_live.das
@@ -21,10 +21,15 @@ require strings
 require imgui/imgui_boost_runtime
 require imgui/imgui_live_core public
 require imgui/imgui_theme_daslang
+require opengl/opengl_imgui_driver public
 
 let private STORE_KEY = "__imgui_ctx"
 
 var public live_imgui_ctx : ImGuiContext?
+
+//! The pure-das GL renderer backend (replaces the C++ imgui_impl_opengl3). Held here so the windowed
+//! harness can drive it, and serialized across daslang-live reload alongside the context.
+var public live_imgui_gl : ImguiGlRenderer
 
 //! HDPI scale picked up from ``glfwGetWindowContentScale`` at init: 1.0 on a
 //! plain display, 2.0 on macOS retina, 1.25/1.5/2.0 on Windows DPI scaling.
@@ -52,7 +57,7 @@ def private ensure_scale_parsed() {
     g_scale_override = to_float(raw |> unwrap_or("0"))
 }
 
-def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#version 330") : ImGuiContext? {
+def public live_imgui_init(window : GLFWwindow?) : ImGuiContext? {
     //! Idempotent ImGui context create + backend init; safe across reload (reuses preserved ctx).
     //! Picks content scale: ``--imgui-content-scale=<float>`` override wins;
     //! otherwise queries ``glfwGetWindowContentScale``. Loads JetBrains Mono at
@@ -109,10 +114,12 @@ def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#versi
     load_daslang_font(14.0f * live_imgui_content_scale)
     apply_daslang_theme()
     ScaleAllSizes(GetStyle(), layout_scale)
-    var io & = unsafe(GetIO())
-    unsafe(GetStyle()).FontScaleMain = font_global
+    let io & = unsafe(GetIO())
+    GetStyle().FontScaleMain = font_global
     ImGui_ImplGlfw_InitForOpenGL(window, true)
-    ImGui_ImplOpenGL3_Init(glsl_version)
+    // pure-das GL renderer instead of the C++ ImGui_ImplOpenGL3_Init(glsl_version)
+    imgui_gl_set_backend_flags()
+    live_imgui_gl <- imgui_gl_create()
     // Give the window a defined cursor from the instant it appears — the backend's
     // per-frame UpdateMouseCursor only takes over from frame 1, and macOS won't
     // refresh an inherited cursor until the mouse moves. Per-widget SetMouseCursor
@@ -121,10 +128,17 @@ def public live_imgui_init(window : GLFWwindow?; glsl_version : string = "#versi
     return live_imgui_ctx
 }
 
+def public live_imgui_render() {
+    //! Drain the dynamic-texture queue and replay this frame's ImDrawData with the pure-das GL renderer
+    //! (opengl_imgui_driver). Call after ``Render()``, in place of the old C++ backend's draw step.
+    imgui_gl_update_textures(live_imgui_gl)
+    imgui_gl_render(live_imgui_gl)
+}
+
 def public live_imgui_shutdown() {
     //! Reload-aware ImGui shutdown — skips during reload so the ctx is reused, runs only on process exit. Call from your script's ``shutdown()``.
     if (live_imgui_ctx != null && !is_reload()) {
-        ImGui_ImplOpenGL3_Shutdown()
+        finalize(live_imgui_gl)
         ImGui_ImplGlfw_Shutdown()
         DestroyContext(live_imgui_ctx)
         live_imgui_ctx = null
@@ -138,6 +152,13 @@ def private save_imgui_ctx() {
     var arch = Archive(reading = false, stream = ser)
     var ptr_val = unsafe(reinterpret<uint64>(live_imgui_ctx))
     arch |> serialize(ptr_val)
+    // the GL renderer's handles are valid across reload (the GL context persists); preserve them so the
+    // post-reload frames keep using the same program/buffers/textures instead of leaking + re-creating.
+    arch |> serialize(live_imgui_gl.program)
+    arch |> serialize(live_imgui_gl.vao)
+    arch |> serialize(live_imgui_gl.vbo)
+    arch |> serialize(live_imgui_gl.ebo)
+    arch |> serialize(live_imgui_gl.textures)
     let data <- ser->extractData()
     live_store_bytes(STORE_KEY, data)
     unsafe { delete ser; }
@@ -151,6 +172,11 @@ def private restore_imgui_ctx() {
         var arch = Archive(reading = true, stream = ser)
         var ptr_val : uint64
         arch |> serialize(ptr_val)
+        arch |> serialize(live_imgui_gl.program)
+        arch |> serialize(live_imgui_gl.vao)
+        arch |> serialize(live_imgui_gl.vbo)
+        arch |> serialize(live_imgui_gl.ebo)
+        arch |> serialize(live_imgui_gl.textures)
         unsafe {
             live_imgui_ctx = reinterpret<ImGuiContext?>(ptr_val)
             delete ser


### PR DESCRIPTION
Flip the OpenGL ImGui path from the C++ `ImGui_ImplOpenGL3` backend onto the pure-das `opengl/opengl_imgui_driver` (the GL twin of dasVulkan's `vulkan_imgui_driver`). Companion to **GaijinEntertainment/daScript#3283** (the driver), which is merged — daslang master now provides `opengl/opengl_imgui_driver`.

### The flip
- **`widgets/imgui_live.das`** — create/finalize the das `ImguiGlRenderer` (`live_imgui_gl`) in `live_imgui_init`/`live_imgui_shutdown`, preserve its GL handles across daslang-live reload (handles stay valid; the GL context persists), and add **`live_imgui_render()`** — the call tutorials use in place of the old C++ draw step.
- **`widgets/imgui_harness.das`** — drive the das renderer in `harness_end_frame`; drop the per-frame `ImGui_ImplOpenGL3_NewFrame`.

### The sweep (53 tutorials / imgui_demo / utils)
- `ImGui_ImplOpenGL3_RenderDrawData(GetDrawData())` → `live_imgui_render()`, and drop the now-dead `ImGui_ImplOpenGL3_NewFrame()` line.
- No new requires needed (every file already requires `imgui/imgui_live`).

### Build — stop compiling the C++ GL backend
- `CMakeLists.txt`: drop `imgui_impl_opengl3.cpp` from the sources (kept `imgui_impl_glfw.cpp` — the input/platform backend stays).
- `src/module_imgui_app.cpp`: remove our references to it (include, the `das_ImGui_ImplOpenGL3_Init` wrapper, the 6 `addExtern`s, the AOT text). The upstream-vendored `imgui_impl_opengl3.cpp` file is left in place — we just no longer build it.

### Docs + lint
- `CLAUDE.md` + `skills/migration.md` render-loop examples and the `boost_basics` / `harness_headless_mode` tutorial RST updated to `live_imgui_render()`.
- The sweep makes the tutorials "changed", so the changed-files lint gate now covers their pre-existing boilerplate — cleaned up (drop unused `glfw/glfw_boost` + `live/opengl_live` requires, `var io` → `let io`, drop redundant `unsafe(GetStyle())` wraps). All 55 changed `.das` files lint clean (0 issues).

### Verification
- Native module rebuilt with no GL backend compiled in — links clean, no unresolved `ImGui_ImplOpenGL3` symbols.
- `imgui_harness` renders a full UI (window/text/button/checkbox/slider, font atlas, blend, clip) via the das driver with the C++ backend gone — screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)