### PR TITLE
fix(widgets): set_item_tooltip ID-stack leak + fail-fast playwright readiness

### DIFF
--- a/widgets/imgui_playwright.das
+++ b/widgets/imgui_playwright.das
@@ -31,6 +31,7 @@ let DEFAULT_RELOAD_TIMEOUT_SEC : float = 30.0f       // POST /reload to /status.
 let DEFAULT_FRAME_WAIT_SEC : float = 10.0f           // upper bound on "first frame to render the named widget"
 
 let READY_POLL_INTERVAL_MS : uint = 100u             // ms between /status polls — wait_until_ready and reload convergence
+let READY_POLL_REQUEST_TIMEOUT_SEC : int = 2         // per-poll http timeout for the readiness probe: fail-fast-and-retry so one slow round-trip on a loaded runner (the host serves /status off the main loop, so a stalled frame delays it) doesn't burn the whole budget on a single 10s DEFAULT_REQUEST_TIMEOUT_SEC block
 let FRAME_POLL_INTERVAL_MS : uint = 100u             // ms between snapshot polls — 10 req/sec; under libhv's Windows
                                                      // event-loop cap (~16 req/sec) that previously stalled the test
                                                      // sweep on heavy imgui_demo harnesses (see tests.yml comment).
@@ -184,7 +185,7 @@ def public wait_until_ready(app : ImguiApp; timeout_sec : float) : bool {
     let start = ref_time_ticks()
     let timeout_usec = int(timeout_sec * 1000000.0f)
     while (get_time_usec(start) < timeout_usec) {
-        if (http_get("{app.base_url}/status").status == int(http_status.OK)) return true
+        if (http_get("{app.base_url}/status", READY_POLL_REQUEST_TIMEOUT_SEC).status == int(http_status.OK)) return true
         sleep(READY_POLL_INTERVAL_MS)
     }
     return false

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -1935,6 +1935,11 @@ def set_item_tooltip(var state : NarrativeState; text : string;
     if (IsItemHovered(flags)) {
         SetTooltip(text)
         narrative_finalize(widget_ident, "set_item_tooltip", state)
+    } else {
+        // Not hovered: the tooltip didn't render, so we skip narrative_finalize (it stays unregistered
+        // in the snapshot). But widget_prelude's PushID(widget_ident) ran unconditionally, so we must
+        // still pop it here or the ID stack leaks — ImGui 1.92 flags this as "Missing PopID()".
+        PopID()
     }
 }
 


### PR DESCRIPTION
Two fixes — the widget bug, plus the CI-harness robustness issue the macOS lane on this PR exposed.

## 1. `set_item_tooltip` must pop its ID on unhovered frames

`set_item_tooltip` is a `[widget]`, so `widget_prelude` does `PushID(widget_ident)` **unconditionally**. The matching `PopID` lives inside `narrative_finalize`, which the body only called on the **hovered** branch (by design — the tooltip registers as "rendered" only on the frames it actually shows). So on every *unhovered* frame the `PushID` leaked.

Pre-1.92 this was invisible. **Dear ImGui 1.92's stricter end-of-window ID-stack check now reports it** as a red `"In window '<name>': Missing PopID()"` overlay for any window containing one or more unhovered tooltips.

Fix: pop the ID on the unhovered path; render/registration stays hover-gated.

```das
if (IsItemHovered(flags)) {
    SetTooltip(text)
    narrative_finalize(widget_ident, "set_item_tooltip", state)
} else {
    PopID()   // tooltip didn't render; just balance widget_prelude's PushID
}
```

Audited all 156 `[widget]`/`[container]`/`[edit_widget]`/`[edit_container]` defs for the same class (a path from `widget_prelude`'s `PushID` to exit that skips the finalizing `PopID`): `set_item_tooltip` was the only instance. No early-return leaks, no missing-finalize leaks.

## 2. Fail-fast playwright readiness poll

The macOS integration lane on this PR went red: `test_active_widget` → `"daslang-live not ready after 90s"` (104s). Diagnosis: `wait_until_ready` polls `GET /status` every 100ms but each `http_get` used the 10s `DEFAULT_REQUEST_TIMEOUT_SEC`. daslang-live serves the live API off the **main loop**, so `/status` only answers as fast as the host renders a frame; on the free 3-vCPU macOS runner a stalled frame pushed `/status` past 10s, so each poll blocked the full 10s and the 90s budget bought only ~9 attempts. The captured child log confirms the host was listening and answering 200s the whole time, just slower than one 10s round-trip.

Fix: give the readiness probe its own short **2s** per-request timeout — a liveness poll should fail-fast-and-retry, not block 10s per attempt. The 90s budget now buys ~40 rapid retries, catching the first responsive frame.

## Verification

- `test_tooltip_flat.das` (regression for the hover-gating) stays green — asserts the tooltip is *registered* but `rendered=false` while unhovered.
- `test_active_widget.das` passes locally with the new fail-fast poll.
- Lint + formatter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)