### PR TITLE
wasm: cross-compile the harness + build 3 static wasm64 archives + packaging

### DIFF
--- a/.das_package
+++ b/.das_package
@@ -27,8 +27,10 @@ def release() {
     release_wasm_archive("_wasm/liblibImguiApp.a")
     release_wasm_archive("_wasm/liblibImguiAppHeadless.a")
     // Embed the bundled font into MEMFS so load_daslang_font's AddFontFromFileTTF finds
-    // it at run time (mirrors dasStbImage's HUD-font embed).
-    release_embed_file("modules/dasImgui/font/JetBrainsMono-Regular.ttf", "/modules/dasImgui/font/JetBrainsMono-Regular.ttf")
+    // it at run time (mirrors dasStbImage's HUD-font embed). src is module-relative
+    // (resolved against this .das_package's dir), so it works for an external module
+    // installed under <project>/modules/dasImgui too.
+    release_embed_file("font/JetBrainsMono-Regular.ttf", "/modules/dasImgui/font/JetBrainsMono-Regular.ttf")
     // typeFactory<GLFWwindow>::make is emitted by both imguiApp and dasGLFW; statically
     // linking both into one wasm collides without this.
     release_emcc_arg("-Wl,--allow-multiple-definition")

--- a/.das_package
+++ b/.das_package
@@ -15,3 +15,21 @@ def package() {
 def build() {
     cmake_build()
 }
+
+[export]
+def release() {
+    // Web build: the EMSCRIPTEN branch in CMakeLists.txt emits 3 static wasm archives.
+    // daspkg runs this (cwd = module dir) on demand when a released app links dasImgui
+    // and stages the declared archives into the wasm lib dir. get_das_root() resolves
+    // to the SDK root when this .das_package runs.
+    release_wasm_build("emcmake cmake -S . -B _wasm_build -DDASLANG_DIR={get_das_root()} -DCMAKE_BUILD_TYPE=Release -G Ninja && cmake --build _wasm_build --target dasModuleImgui imguiApp imguiAppHeadless")
+    release_wasm_archive("_wasm/liblibDasModuleImgui.a")
+    release_wasm_archive("_wasm/liblibImguiApp.a")
+    release_wasm_archive("_wasm/liblibImguiAppHeadless.a")
+    // Embed the bundled font into MEMFS so load_daslang_font's AddFontFromFileTTF finds
+    // it at run time (mirrors dasStbImage's HUD-font embed).
+    release_embed_file("modules/dasImgui/font/JetBrainsMono-Regular.ttf", "/modules/dasImgui/font/JetBrainsMono-Regular.ttf")
+    // typeFactory<GLFWwindow>::make is emitted by both imguiApp and dasGLFW; statically
+    // linking both into one wasm collides without this.
+    release_emcc_arg("-Wl,--allow-multiple-definition")
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ libhv.*.log
 example/**/_*.png
 example/_aot_generated/
 build_msvc/
+# wasm build artifacts (daspkg release wasm / emscripten CMake branch)
+_wasm/
+_wasm_build/
+_wasm_obj/
+_*.log
 # Visual-aids ad-hoc smoke screenshots dropped at repo root by the screenshot live_command
 screenshot.png
 tour_*.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,12 @@ ENDIF()
 
 SET(imgui_INCLUDE_DIR ${DAS_IMGUI_DIR}/imgui)
 
-# GLFW (from main repo or sibling module)
-if(EXISTS ${DASLANG_DIR}/modules/dasGlfw/glfw)
+# GLFW headers. Desktop: the built GLFW 3.4 include from the sibling dasGlfw module.
+# Web (emscripten): the vendored 3.4 headers in dasGlfw/web_include (no GLFW source
+# build; emcc's -sUSE_GLFW=3 supplies the symbols at the final app link).
+if(EMSCRIPTEN)
+    SET(GLFW_INCLUDE_DIR ${DASLANG_DIR}/modules/dasGlfw/web_include)
+elseif(EXISTS ${DASLANG_DIR}/modules/dasGlfw/glfw)
     SET(GLFW_INCLUDE_DIR ${DASLANG_DIR}/modules/dasGlfw/glfw/$<CONFIG>/include)
 else()
     message(FATAL_ERROR "GLFW not found at ${DASLANG_DIR}/modules/dasGlfw/glfw")
@@ -93,6 +97,59 @@ SET(DAS_IMGUI_APP_SRC
     ${imgui_INCLUDE_DIR}/backends/imgui_impl_glfw.cpp
     ${DAS_IMGUI_DIR}/gl3w/GL/gl3w.cpp
 )
+
+IF(EMSCRIPTEN)
+    # ===== Web (emscripten) =====
+    # dasImgui is an EXTERNAL module: built standalone here, not inside daslang's web
+    # CMake, so the ADD_DAS_STATIC_MODULE_LIB helper is unavailable. Build the same
+    # sources as plain STATIC archives -- the generated dasIMGUI.cpp's REGISTER_MODULE
+    # provides register_Module_dasIMGUI, which a cross-compiled app's ensure_module
+    # links. `daspkg release wasm` drives this through the .das_package
+    # release_wasm_build hook and stages the liblib*.a into the wasm lib dir.
+    #
+    # gl3w is excluded: its desktop GL/glx.h is fatal under emscripten, and GL comes
+    # from -sFULL_ES3 at the app link -- the pure-das opengl_imgui_driver does the GL.
+    MESSAGE(STATUS "dasImgui: emscripten/web build (3 static wasm archives)")
+
+    SET(IMGUI_WASM_FLAGS
+        -fno-rtti -sMEMORY64=1
+        -msimd128 -msse2 -mnontrapping-fptoint
+        -fwasm-exceptions -sWASM_LEGACY_EXCEPTIONS=0)
+    SET(IMGUI_WASM_DEFS
+        IMGUI_DISABLE_OBSOLETE_FUNCTIONS=1
+        DAS_NO_ASSERTIONS DAS_ENABLE_EXCEPTIONS _EMSCRIPTEN_VER)
+    SET(IMGUI_WASM_INC
+        ${DASLANG_DIR}/include
+        ${imgui_INCLUDE_DIR}
+        ${DAS_IMGUI_DIR}/src
+        ${DAS_IMGUI_DIR}/gl3w
+        ${GLFW_INCLUDE_DIR}
+        ${DASLANG_DIR}/modules/dasGlfw/src)
+
+    # Stage archives at <module>/_wasm, named liblib<CppModule>.a to match daspkg's
+    # wasm_archive_name() convention (the name the in-tree web build emits), so
+    # release_wasm_archive() declarations resolve at the link step.
+    MACRO(ADD_IMGUI_WASM_ARCHIVE tgt out)
+        target_compile_features(${tgt} PRIVATE cxx_std_17)
+        target_compile_options(${tgt} PRIVATE ${IMGUI_WASM_FLAGS})
+        target_compile_definitions(${tgt} PRIVATE ${IMGUI_WASM_DEFS})
+        target_include_directories(${tgt} PRIVATE ${IMGUI_WASM_INC})
+        set_target_properties(${tgt} PROPERTIES
+            PREFIX "" OUTPUT_NAME "${out}" SUFFIX ".a"
+            ARCHIVE_OUTPUT_DIRECTORY "${DAS_IMGUI_DIR}/_wasm")
+    ENDMACRO()
+
+    add_library(dasModuleImgui STATIC ${DAS_IMGUI_BIND_SRC} ${DAS_IMGUI_SRC})
+    ADD_IMGUI_WASM_ARCHIVE(dasModuleImgui liblibDasModuleImgui)
+
+    add_library(imguiApp STATIC
+        ${DAS_IMGUI_DIR}/src/module_imgui_app.cpp
+        ${imgui_INCLUDE_DIR}/backends/imgui_impl_glfw.cpp)
+    ADD_IMGUI_WASM_ARCHIVE(imguiApp liblibImguiApp)
+
+    add_library(imguiAppHeadless STATIC ${DAS_IMGUI_DIR}/src/module_imgui_app_headless.cpp)
+    ADD_IMGUI_WASM_ARCHIVE(imguiAppHeadless liblibImguiAppHeadless)
+ELSE() # ===== Desktop =====
 
 IF(WIN32)
     SET(IMGUI_PUBLIC_ATTR "__declspec\(dllexport\)")
@@ -287,3 +344,5 @@ set_target_properties(imguiAppHeadless PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${DAS_IMGUI_DIR}"
 )
 target_link_libraries(imguiAppHeadless PRIVATE dasModuleImgui)
+
+ENDIF() # IF(EMSCRIPTEN) ... ELSE() [desktop]

--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -44,7 +44,11 @@ require live/glfw_live
 require live/opengl_live // nolint:STYLE030 — loads the APNG recorder (record_* live commands + the [before_update] record_tick) by side effect; no direct symbol use
 
 // Live-host + boost-runtime stack — re-exported public.
-require live/live_api public
+// ?dashv: live_api is the HTTP live-reload server (pulls dashv/libhv, which is not
+// emscripten-portable). Guard it so the harness cross-compiles to wasm — the web
+// build has no dashv, so live_api is skipped (no hot-reload server, which a shipped
+// web demo doesn't need); native builds with dashv present are unchanged.
+require ?dashv live/live_api public
 require live/live_commands public
 require live/live_vars public
 require live_host public
@@ -140,7 +144,14 @@ def public harness_init(title : string; width : int = 800; height : int = 600) {
     // requested size by the monitor scale (no-op on macOS/Linux, where
     // the windowing system already handles it). live_imgui_init then
     // reads glfwGetWindowContentScale and applies it to fonts + theme.
-    glfwWindowHint(int(GLFW_SCALE_TO_MONITOR), 1)
+    // Skip on web: this is a desktop-only DPI hint, and emscripten's GLFW.hints
+    // is null until glfwInit (which live_create_window does), so setting a
+    // pre-init hint there crashes -- and there is nothing to scale to anyway.
+    // get_running_platform_name() (not get_platform_name(), which const-folds to the
+    // compile HOST) so a cross-compiled in-browser exe also skips it.
+    if (get_running_platform_name() != "emscripten") {
+        glfwWindowHint(int(GLFW_SCALE_TO_MONITOR), 1)
+    }
     live_create_window(title, width, height)
     live_imgui_init(live_window)
     // --no-imgui-ini (with_imgui_app passes it for every test spawn): null the

--- a/widgets/imgui_theme_daslang.das
+++ b/widgets/imgui_theme_daslang.das
@@ -160,6 +160,13 @@ def public daslang_font_ttf_path() : string {
     //! so daspkg-release standalone bundles pick up the relocated path.
     //! Read directly if you want to feed your own ``AddFontFromFileTTF``
     //! call (custom size / config / glyph ranges).
+    // On web the TTF is not on a real filesystem: `daspkg release wasm` embeds it into
+    // MEMFS at the fixed path declared by this module's .das_package release_embed_file.
+    // get_running_platform_name() (not get_platform_name, which const-folds to the
+    // compile host) so a cross-compiled in-browser exe resolves it too.
+    if (get_running_platform_name() == "emscripten") {
+        return "/modules/dasImgui/font/JetBrainsMono-Regular.ttf"
+    }
     return path_join(dir_name(get_this_module_dir()), "font/JetBrainsMono-Regular.ttf")
 }
 


### PR DESCRIPTION
Makes dasImgui cross-compile to wasm64 and ship its wasm archives + font through `daspkg release wasm`, so an external app (e.g. the furier OpenGL+ImGui example) can be released to the browser with Dear ImGui working over the 100%-das GL driver.

### Changes
- **`imgui_harness.das`** — cross-compiles to wasm/web:
  - `require ?dashv live/live_api public` (was unconditional) — `live_api` pulls `dashv`/libhv, which isn't emscripten-portable; the harness only re-exports it, so `?dashv` cleanly drops it on wasm.
  - `glfwWindowHint(GLFW_SCALE_TO_MONITOR, …)` guarded on `get_running_platform_name() != "emscripten"` — it runs *before* `glfwInit` (desktop tolerates pre-init hints; emscripten's `GLFW.hints` is null until init → crash). Desktop-only DPI hint, no-op on web.
- **`CMakeLists.txt`** — an `if(EMSCRIPTEN)` branch builds 3 static wasm64 archives (`dasModuleImgui` core / `imguiApp` / `imguiAppHeadless`) with the daScript SIMD/no-rtti/exception flags + `-sMEMORY64=1`. GLFW headers come from dasGlfw's `web_include/`; `gl3w.cpp` is excluded (desktop GL only). Desktop branch unchanged.
- **`.das_package`** — `release()` declares `release_wasm_build` (on-demand emcmake build of the 3 archives), `release_wasm_archive` ×3, a module-relative `release_embed_file` for the bundled JetBrainsMono font, and `-Wl,--allow-multiple-definition` (the `typeFactory<GLFWwindow>::make` dup between imguiApp and dasGLFW when statically linked).
- **`imgui_theme_daslang.das`** — `daslang_font_ttf_path()` returns the embed dst on web (`get_running_platform_name()=="emscripten"`), module-relative on desktop.

### Dependency / merge order
Depends on the daslang side: **GaijinEntertainment/daScript#3294** (`get_running_platform_name()` builtin) and the daspkg external-module wasm wiring PR (`release_wasm_build`/`release_wasm_archive`). CI here stays red until those land in the daslang SDK this repo builds against — that's the merge order, not a defect. Verified locally against a daslang build that has both.