### PR TITLE
harness: fit web imgui window to the on-page canvas box

### DIFF
--- a/widgets/imgui_harness.das
+++ b/widgets/imgui_harness.das
@@ -140,19 +140,36 @@ def public harness_init(title : string; width : int = 800; height : int = 600) {
         }
         return
     }
-    // Opt into per-monitor DPI on Windows so glfwCreateWindow scales the
-    // requested size by the monitor scale (no-op on macOS/Linux, where
-    // the windowing system already handles it). live_imgui_init then
-    // reads glfwGetWindowContentScale and applies it to fonts + theme.
-    // Skip on web: this is a desktop-only DPI hint, and emscripten's GLFW.hints
-    // is null until glfwInit (which live_create_window does), so setting a
-    // pre-init hint there crashes -- and there is nothing to scale to anyway.
-    // get_running_platform_name() (not get_platform_name(), which const-folds to the
-    // compile HOST) so a cross-compiled in-browser exe also skips it.
-    if (get_running_platform_name() != "emscripten") {
+    // Per-monitor DPI (GLFW_SCALE_TO_MONITOR): on desktop glfwCreateWindow scales the requested size by
+    // the monitor scale, and live_imgui_init reads glfwGetWindowContentScale for fonts + theme. On web
+    // emscripten honors it too -- it then renders the backing store at canvas-size x devicePixelRatio, so
+    // the UI is DPR-crisp + native-sized instead of a small fixed backing magnified by CSS. The hint MUST
+    // be set AFTER glfwInit (emscripten's GLFW.hints is null before glfwInit -> crash if set pre-init), so
+    // init here first; glfwInit is idempotent so live_create_window's own glfwInit is a no-op and its
+    // glfwCreateWindow inherits the hint.
+    if (glfwInit() != 0) {
         glfwWindowHint(int(GLFW_SCALE_TO_MONITOR), 1)
     }
-    live_create_window(title, width, height)
+    var w = width
+    var h = height
+    // On web, create the window at the largest card-aspect box that fits the on-page viewport (the
+    // examples iframe) so the UI fills the card box at native scale. Done ONCE, at creation:
+    // glfwCreateWindow sizes the canvas BEFORE the GL context exists, so there is no mid-run canvas
+    // resize -- a runtime resize recreates/invalidates the WebGL context and aborts the wasm. Desktop:
+    // glfw_canvas_css_* return 0, so the requested size is used unchanged.
+    let vw = glfw_canvas_css_width()
+    let vh = glfw_canvas_css_height()
+    if (vw > 0 && vh > 0 && width > 0 && height > 0) {
+        let aspect = float(width) / float(height)
+        if (float(vw) / float(vh) > aspect) {
+            w = int(float(vh) * aspect + 0.5f)
+            h = vh
+        } else {
+            w = vw
+            h = int(float(vw) / aspect + 0.5f)
+        }
+    }
+    live_create_window(title, w, h)
     live_imgui_init(live_window)
     // --no-imgui-ini (with_imgui_app passes it for every test spawn): null the
     // ini AFTER live_imgui_init creates the context, BEFORE the first NewFrame,


### PR DESCRIPTION
## Problem

On web, `harness_init` created the GLFW window at a **fixed backing-store size** (`harness_init(title, 512, 512)` / `1024, 1024`) that the daspkg canvas shell then CSS-magnifies to fill the on-page card box. Everything — including ImGui's fixed-pixel widgets — scaled by that factor, so the UI looked **zoomed/blurry**, and a 1024²-design card **overflowed** a smaller card box.

## Fix (the dasImgui consumer half)

`harness_init` now, on web:

1. **Enables `GLFW_SCALE_TO_MONITOR`** — set *after* `glfwInit()` (emscripten's `GLFW.hints` is null pre-init), so the hint applies on emscripten too. emscripten then renders the backing store at canvas-size × `devicePixelRatio` → **DPR-crisp, native-sized ImGui**. `glfwInit` is idempotent, so `live_create_window`'s own init is a no-op and its `glfwCreateWindow` inherits the hint.
2. **Sizes the window at creation to the on-page box** — reads the viewport via the new daslang `glfw_canvas_css_width()` / `glfw_canvas_css_height()` externs and creates the window at the largest card-aspect box that fits. Done **once, at creation**: a mid-run canvas resize recreates the WebGL context and aborts the wasm, so the fit must happen before the GL context exists.

**Desktop is unchanged** — the externs return `0`, so the fit guard is false and the requested design size is used as-is (verified: `harness_init(…, 1024, 1024)` → a 1024×1024 window, no regression).

## Ordering — depends on daslang#3323 (merged)

Requires the `glfw_canvas_css_width/height` + `glfw_device_pixel_ratio` externs from **GaijinEntertainment/daScript#3323**, which is **already merged to master**. dasImgui CI builds daslang from `master`, so this compiles green.

## Verification

- **"Vectors & Circles"** card (1024² design, the overflow case), wasm64-threaded with the daspkg shell: a 558² examples box → window **558²** (fills the box, no overflow, crisp, native ImGui, no wasm trap); a 1200×800 box aspect-fits to **800²**. Path tracer (512²) fills its box crisp + native.
- **Desktop** — window created at the unchanged design size (fit no-ops).

Fullscreen is a separate follow-up (normal-view fix first).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)