### PR TITLE
Superbuild: static half only + defer typeFactory&lt;GLFWwindow&gt; to dasGlfw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,17 +144,14 @@ IF(COMMAND ADD_MODULE_CPP)
         ADD_MODULE_DAS(imgui widgets ${_n})
     ENDFOREACH()
 
-    IF(EMSCRIPTEN)
-        ADD_DAS_STATIC_MODULE_LIB(libDasModuleImgui ${DAS_IMGUI_BIND_SRC} ${DAS_IMGUI_SRC})
-        ADD_DAS_STATIC_MODULE_LIB(libImguiApp ${DAS_IMGUI_APP_SRC})
-        ADD_DAS_STATIC_MODULE_LIB(libImguiAppHeadless ${DAS_IMGUI_DIR}/src/module_imgui_app_headless.cpp)
-        SET(_IMGUI_SUPER_TARGETS libDasModuleImgui libImguiApp libImguiAppHeadless)
-    ELSE()
-        ADD_MODULE_LIB(libDasModuleImgui dasModuleImgui ${DAS_IMGUI_BIND_SRC} ${DAS_IMGUI_SRC})
-        ADD_MODULE_LIB(libImguiApp imguiApp ${DAS_IMGUI_APP_SRC})
-        ADD_MODULE_LIB(libImguiAppHeadless imguiAppHeadless ${DAS_IMGUI_DIR}/src/module_imgui_app_headless.cpp)
-        SET(_IMGUI_SUPER_TARGETS libDasModuleImgui dasModuleImgui libImguiApp imguiApp libImguiAppHeadless imguiAppHeadless)
-    ENDIF()
+    # Static halves only — no ADD_MODULE_LIB shared twins. In a superbuild the DLL
+    # flavor comes from this module's own standalone build (daspkg); the twins would
+    # need the whole dllexport/dllimport matrix (IMGUI_API across the pair, glfw
+    # import libs) for nothing an embedded host ever loads.
+    ADD_DAS_STATIC_MODULE_LIB(libDasModuleImgui ${DAS_IMGUI_BIND_SRC} ${DAS_IMGUI_SRC})
+    ADD_DAS_STATIC_MODULE_LIB(libImguiApp ${DAS_IMGUI_APP_SRC})
+    ADD_DAS_STATIC_MODULE_LIB(libImguiAppHeadless ${DAS_IMGUI_DIR}/src/module_imgui_app_headless.cpp)
+    SET(_IMGUI_SUPER_TARGETS libDasModuleImgui libImguiApp libImguiAppHeadless)
 
     MACRO(SETUP_IMGUI imgui_mod_lib)
         TARGET_INCLUDE_DIRECTORIES(${imgui_mod_lib} PRIVATE
@@ -166,22 +163,20 @@ IF(COMMAND ADD_MODULE_CPP)
         )
         TARGET_COMPILE_DEFINITIONS(${imgui_mod_lib} PRIVATE
             IMGUI_DISABLE_OBSOLETE_FUNCTIONS=1
-            IMGUI_IMPL_OPENGL_LOADER_GL3W)
+            IMGUI_IMPL_OPENGL_LOADER_GL3W
+            # dasGlfw's binding TU owns typeFactory<GLFWwindow> in a superbuild link
+            DAS_IMGUI_APP_EXTERN_GLFW_TYPE_FACTORY=1)
         SETUP_CPP11(${imgui_mod_lib})
     ENDMACRO()
     FOREACH(_t ${_IMGUI_SUPER_TARGETS})
         SETUP_IMGUI(${_t})
     ENDFOREACH()
-    # the imgui core symbols live in the dasModuleImgui libs; the app backends use them
-    IF(EMSCRIPTEN)
-        TARGET_LINK_LIBRARIES(libImguiApp PUBLIC libDasModuleImgui)
-        TARGET_LINK_LIBRARIES(libImguiAppHeadless PUBLIC libDasModuleImgui)
-    ELSE()
+    # the imgui core symbols live in libDasModuleImgui; the app backends use them
+    TARGET_LINK_LIBRARIES(libImguiApp PUBLIC libDasModuleImgui)
+    TARGET_LINK_LIBRARIES(libImguiAppHeadless PUBLIC libDasModuleImgui)
+    IF(NOT EMSCRIPTEN)
         FIND_PACKAGE(OpenGL REQUIRED)
-        TARGET_LINK_LIBRARIES(libImguiApp PUBLIC libDasModuleImgui ${OPENGL_LIBRARIES})
-        TARGET_LINK_LIBRARIES(imguiApp PUBLIC dasModuleImgui ${OPENGL_LIBRARIES})
-        TARGET_LINK_LIBRARIES(libImguiAppHeadless PUBLIC libDasModuleImgui)
-        TARGET_LINK_LIBRARIES(imguiAppHeadless PUBLIC dasModuleImgui)
+        TARGET_LINK_LIBRARIES(libImguiApp PUBLIC ${OPENGL_LIBRARIES})
     ENDIF()
 
 ELSEIF(EMSCRIPTEN)

--- a/src/module_imgui_app.cpp
+++ b/src/module_imgui_app.cpp
@@ -14,7 +14,14 @@ using namespace das;
 
 // NOTE: this module requires GLFW module
 #include "need_dasGLFW.h"
+// In a daslang superbuild dasGlfw's own binding TU already provides the strong
+// typeFactory<GLFWwindow>::make definition — implementing it here too is a duplicate
+// symbol in the static link (the web build papers over the same collision with
+// -Wl,--allow-multiple-definition). The superbuild CMake branch sets the guard; the
+// standalone .shared_module build (no dasGlfw objects in its link) keeps its own copy.
+#ifndef DAS_IMGUI_APP_EXTERN_GLFW_TYPE_FACTORY
 IMPLEMENT_EXTERNAL_TYPE_FACTORY(GLFWwindow,GLFWwindow)
+#endif
 
 MAKE_EXTERNAL_TYPE_FACTORY(ImDrawData,ImDrawData);
 


### PR DESCRIPTION
Found by the daslang fat-man gate on its first real (`daslang_static`) link — two fixes to the superbuild branch from #218:

1. **Static half only** — drop the `ADD_MODULE_LIB` shared twins: the imgui-family twins can't link on Windows (no `IMGUI_API` dllexport matrix across the pair, no glfw import lib), and nothing ever loads them — in a superbuild the DLL flavor comes from this module's own standalone build (daspkg). Static halves are what an embedded host and `daslang_static` actually consume.
2. **`typeFactory<GLFWwindow>` dedup** — `module_imgui_app.cpp`'s `IMPLEMENT_EXTERNAL_TYPE_FACTORY(GLFWwindow)` is now guarded by `DAS_IMGUI_APP_EXTERN_GLFW_TYPE_FACTORY` (set by the superbuild branch): dasGlfw's binding TU owns that strong symbol in a superbuild link, and the duplicate is exactly what `web/CMakeLists` papers over with `-Wl,--allow-multiple-definition` (little-wasm-boy can drop that flag once it uses this path). Standalone `.shared_module` builds keep their own copy.

Validated: full fat-man link + smoke on Windows against `daslang_static` (all five externals statically linked, `rc=0`); standalone desktop flow untouched by both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)