### PR TITLE
superbuild: emscripten-aware app sources (exclude gl3w from the wasm superbuild)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,12 +121,16 @@ SET(DAS_IMGUI_BIND_SRC
     ${DAS_IMGUI_DIR}/src/dasIMGUI.func_34.cpp
 )
 
-# imgui app source files
+# imgui app source files. gl3w is desktop-only: its loader source pulls desktop GL
+# headers that are fatal under emscripten, where GL comes from -sFULL_ES3 at the app
+# link instead (the pure-das opengl_imgui_driver does the GL).
 SET(DAS_IMGUI_APP_SRC
     ${DAS_IMGUI_DIR}/src/module_imgui_app.cpp
     ${imgui_INCLUDE_DIR}/backends/imgui_impl_glfw.cpp
-    ${DAS_IMGUI_DIR}/gl3w/GL/gl3w.cpp
 )
+IF(NOT EMSCRIPTEN)
+    LIST(APPEND DAS_IMGUI_APP_SRC ${DAS_IMGUI_DIR}/gl3w/GL/gl3w.cpp)
+ENDIF()
 
 IF(COMMAND ADD_MODULE_CPP)
     # ===== daslang superbuild: static-embed =====
@@ -250,9 +254,7 @@ ELSEIF(EMSCRIPTEN)
     add_library(dasModuleImgui STATIC ${DAS_IMGUI_BIND_SRC} ${DAS_IMGUI_SRC})
     ADD_IMGUI_WASM_ARCHIVE(dasModuleImgui liblibDasModuleImgui)
 
-    add_library(imguiApp STATIC
-        ${DAS_IMGUI_DIR}/src/module_imgui_app.cpp
-        ${imgui_INCLUDE_DIR}/backends/imgui_impl_glfw.cpp)
+    add_library(imguiApp STATIC ${DAS_IMGUI_APP_SRC})
     ADD_IMGUI_WASM_ARCHIVE(imguiApp liblibImguiApp)
 
     add_library(imguiAppHeadless STATIC ${DAS_IMGUI_DIR}/src/module_imgui_app_headless.cpp)


### PR DESCRIPTION
## What

The superbuild arm (`IF(COMMAND ADD_MODULE_CPP)`) compiled `DAS_IMGUI_APP_SRC` verbatim, which includes `gl3w/GL/gl3w.cpp` — fatal under emscripten (desktop GL headers), where GL comes from `-sFULL_ES3` at the app link instead. The standalone web branch already spelled this exact exclusion inline.

- `DAS_IMGUI_APP_SRC` now appends gl3w only `IF(NOT EMSCRIPTEN)`
- the standalone web branch reuses `DAS_IMGUI_APP_SRC` instead of restating the same two files (one spelling of the invariant)

## Why

Unblocks the daslang **wasm boy** lane (the fat man's web-side sibling): the imgui family cloned into `modules/` of the daslang **web** build, absorbed by the modules glob, and compiled + statically linked from source into the threaded `daslang_static` playground interpreter — replacing the `DAS_WEB_IMGUI_DIR` prebuilt-archive hand-wiring (and its `--allow-multiple-definition`, killed at source by #219's `DAS_IMGUI_APP_EXTERN_GLFW_TYPE_FACTORY` guard, which the superbuild arm already sets).

## Verified

- Windows emsdk superbuild (daslang web build, `-DDAS_WASM_PTHREADS=ON`, this branch junctioned into `modules/`): all three archives compile + link from source, `daslang_static` links **without** `--allow-multiple-definition`, and the imgui-family require-smoke passes under node (exit 0)
- WSL (Ubuntu 24.04, emsdk 5.0.7) verbatim-CI run of the same recipe in flight on the daslang side
- Desktop/standalone arms unchanged: desktop keeps gl3w (same source list as before), standalone-web keeps the same two-file list it always built

🤖 Generated with [Claude Code](https://claude.com/claude-code)