### PR TITLE
Parenthesize cast operands (daslang cast-requires-parens readiness)

### DIFF
--- a/daslib/imgui_boost.das
+++ b/daslib/imgui_boost.das
@@ -29,7 +29,7 @@ def make_input_buffer(var buf : ImGuiInputTextBuffer; txt : string; len : int) {
     buf.buffer |> resize(len)
     let bytes = clamp(length(txt), 0, len - 1)
     unsafe {
-        memcpy(addr(buf.buffer[0]), reinterpret<void?> txt, bytes)
+        memcpy(addr(buf.buffer[0]), reinterpret<void?>(txt), bytes)
     }
 }
 
@@ -49,14 +49,14 @@ def ImGuiInputTextBuffer(txt : string; len : int; var cb : lambda<(var it : ImGu
 def lock(buf : ImGuiInputTextBuffer; blk : block < (st : string#) : void >) {
     unsafe {
         let pbuf = addr(buf.buffer[0])
-        blk |> invoke(reinterpret<string#> pbuf)
+        blk |> invoke(reinterpret<string#>(pbuf))
     }
 }
 
 def to_string(buf : ImGuiInputTextBuffer) {
     unsafe {
         let pbuf = addr(buf.buffer[0])
-        return clone_string(reinterpret<string> pbuf)
+        return clone_string(reinterpret<string>(pbuf))
     }
 }
 
@@ -244,7 +244,7 @@ def PlotHistogram(
 def CheckboxFlags(lab : string; var p_flags : auto(FLAGT)? implicit; flags : FLAGT) {
     unsafe {
         return imgui::CheckboxFlags(lab,
-            reinterpret<int?> p_flags,
+            reinterpret<int?>(p_flags),
             int(flags))
     }
 }
@@ -252,7 +252,7 @@ def CheckboxFlags(lab : string; var p_flags : auto(FLAGT)? implicit; flags : FLA
 def RadioButton(lab : string; var p_flags : auto(FLAGT)? implicit; flags : FLAGT) {
     unsafe {
         return imgui::RadioButton(lab,
-            reinterpret<int?> p_flags,
+            reinterpret<int?>(p_flags),
             int(flags))
     }
 }
@@ -364,7 +364,7 @@ def Combo(name : string; var ent : auto(EnumT)&; max_height_in_items : int = -1)
             names |> push(ef.name)
         }
         unsafe {
-            return Combo(name, reinterpret<int?> addr(ent), names, max_height_in_items)
+            return Combo(name, reinterpret<int?>(addr(ent)), names, max_height_in_items)
         }
     }
     return false
@@ -379,7 +379,7 @@ def ListBox(name : string; var ent : auto(EnumT)&; max_height_in_items : int = -
             names |> push(ef.name)
         }
         unsafe {
-            return ListBox(name, reinterpret<int?> addr(ent), names, max_height_in_items)
+            return ListBox(name, reinterpret<int?>(addr(ent)), names, max_height_in_items)
         }
     }
     return false


### PR DESCRIPTION
daslang gen2 is making the `cast<T>(x)` / `upcast<T>(x)` / `reinterpret<T>(x)` operand parens **mandatory** — the old juxtaposition form `reinterpret<T> x` silently swallowed trailing binary operators into the operand (`reinterpret<uint8?>(p) + 1` parsed as `reinterpret<uint8?>((p) + 1)`, running the arithmetic on the wrong type — stride 0 for `void?`, i.e. dropping the add entirely; that exact shape broke dasVulkan's imgui driver).

This wraps the 7 bare-form sites in `daslib/imgui_boost.das`. The parenthesized spelling parses **identically under both grammars**, so this is safe to land ahead of the daslang change — and required once it merges (CI builds daslang from master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)