### PR TITLE
adopt addr<T?> sugar (daslang #3464)

### DIFF
--- a/daslib/imgui_boost.das
+++ b/daslib/imgui_boost.das
@@ -363,9 +363,7 @@ def Combo(name : string; var ent : auto(EnumT)&; max_height_in_items : int = -1)
         for (ef in *ti.enumType) {
             names |> push(ef.name)
         }
-        unsafe {
-            return Combo(name, reinterpret<int?>(addr(ent)), names, max_height_in_items)
-        }
+        return Combo(name, unsafe(addr<int?>(ent)), names, max_height_in_items)
     }
     return false
 }
@@ -378,9 +376,7 @@ def ListBox(name : string; var ent : auto(EnumT)&; max_height_in_items : int = -
         for (ef in *ti.enumType) {
             names |> push(ef.name)
         }
-        unsafe {
-            return ListBox(name, reinterpret<int?>(addr(ent)), names, max_height_in_items)
-        }
+        return ListBox(name, unsafe(addr<int?>(ent)), names, max_height_in_items)
     }
     return false
 }

--- a/widgets/imgui_widgets_builtin.das
+++ b/widgets/imgui_widgets_builtin.das
@@ -2518,8 +2518,8 @@ def edit_drag_scalar(var ptr : auto(T)? implicit;
     let has_clamp = (v_min != v_max) || (v_min != default<T>)
     var p : T? = ptr
     unsafe {
-        let lo_ptr = has_clamp ? reinterpret<void? const>(addr(lo)) : null
-        let hi_ptr = has_clamp ? reinterpret<void? const>(addr(hi)) : null
+        let lo_ptr = has_clamp ? addr<void? const>(lo) : null
+        let hi_ptr = has_clamp ? addr<void? const>(hi) : null
         let data_ptr = reinterpret<void?>(p)
         let changed = DragScalar(lbl, scalar_data_type(type<T>),
                                  data_ptr, speed, lo_ptr, hi_ptr, fmt, flags)
@@ -2544,8 +2544,8 @@ def edit_slider_scalar(var ptr : auto(T)? implicit;
     var hi = v_max
     var p : T? = ptr
     unsafe {
-        let lo_ptr = reinterpret<void? const>(addr(lo))
-        let hi_ptr = reinterpret<void? const>(addr(hi))
+        let lo_ptr = addr<void? const>(lo)
+        let hi_ptr = addr<void? const>(hi)
         let data_ptr = reinterpret<void?>(p)
         let changed = SliderScalar(lbl, scalar_data_type(type<T>),
                                    data_ptr, lo_ptr, hi_ptr, fmt, flags)
@@ -2570,8 +2570,8 @@ def edit_input_scalar(var ptr : auto(T)? implicit;
     var stp_fast = step_fast
     var p : T? = ptr
     unsafe {
-        let step_ptr = (step != default<T>) ? reinterpret<void? const>(addr(stp)) : null
-        let step_fast_ptr = (step_fast != default<T>) ? reinterpret<void? const>(addr(stp_fast)) : null
+        let step_ptr = (step != default<T>) ? addr<void? const>(stp) : null
+        let step_fast_ptr = (step_fast != default<T>) ? addr<void? const>(stp_fast) : null
         let data_ptr = reinterpret<void?>(p)
         let changed = InputScalar(lbl, scalar_data_type(type<T>),
                                   data_ptr, step_ptr, step_fast_ptr, fmt, flags)


### PR DESCRIPTION
Index-wide follow-up to GaijinEntertainment/daScript#3464: `reinterpret<T?>(addr(x))` → `addr<T?>(x)` (one unsafe gate; STYLE034 now lints the long form). Eight sites: enum Combo/ListBox in `imgui_boost.das` (single-statement unsafe blocks narrowed to expression form) and six `void? const` scalar-widget pointers in `imgui_widgets_builtin.das`. The three `reinterpret<string>(addr(...))` sites stay — string is not a pointer target, no sugar spelling exists. Mechanical; parse-verified against daslang master locally, CI is the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)